### PR TITLE
MYNEWT-553; add option to print only executed commands during build

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -104,10 +104,12 @@ func pkgToUnitTests(pack *pkg.LocalPackage) []*pkg.LocalPackage {
 var extraJtagCmd string
 var noGDB_flag bool
 
-func buildRunCmd(cmd *cobra.Command, args []string) {
+func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool) {
 	if len(args) < 1 {
 		NewtUsage(cmd, nil)
 	}
+
+	util.PrintShellCmds = printShellCmds
 
 	TryGetProject()
 
@@ -389,11 +391,18 @@ func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool) {
 }
 
 func AddBuildCommands(cmd *cobra.Command) {
+	var printShellCmds bool
+
 	buildCmd := &cobra.Command{
 		Use:   "build <target-name> [target-names...]",
 		Short: "Build one or more targets",
-		Run:   buildRunCmd,
+		Run: func(cmd *cobra.Command, args []string) {
+			buildRunCmd(cmd, args, printShellCmds)
+		},
 	}
+
+	buildCmd.Flags().BoolVarP(&printShellCmds, "printCmds", "p", false,
+		"Print executed build commands")
 
 	cmd.AddCommand(buildCmd)
 	AddTabCompleteFn(buildCmd, func() []string {

--- a/newt/vendor/mynewt.apache.org/newt/util/util.go
+++ b/newt/vendor/mynewt.apache.org/newt/util/util.go
@@ -42,6 +42,7 @@ import (
 )
 
 var Verbosity int
+var PrintShellCmds bool
 var logFile *os.File
 
 func ParseEqualsPair(v string) (string, string, error) {
@@ -247,6 +248,7 @@ func Init(logLevel log.Level, logFile string, verbosity int) error {
 	}
 
 	Verbosity = verbosity
+	PrintShellCmds = false
 
 	return nil
 }
@@ -290,6 +292,10 @@ func ShellCommandLimitDbgOutput(
 		envLogStr = strings.Join(env, " ") + " "
 	}
 	log.Debugf("%s%s", envLogStr, strings.Join(cmdStrs, " "))
+
+	if PrintShellCmds {
+		StatusMessage(VERBOSITY_SILENT, "%s\n", strings.Join(cmdStrs, " "))
+	}
 
 	name := cmdStrs[0]
 	args := cmdStrs[1:]

--- a/util/util.go
+++ b/util/util.go
@@ -42,6 +42,7 @@ import (
 )
 
 var Verbosity int
+var PrintShellCmds bool
 var logFile *os.File
 
 func ParseEqualsPair(v string) (string, string, error) {
@@ -247,6 +248,7 @@ func Init(logLevel log.Level, logFile string, verbosity int) error {
 	}
 
 	Verbosity = verbosity
+	PrintShellCmds = false
 
 	return nil
 }
@@ -290,6 +292,10 @@ func ShellCommandLimitDbgOutput(
 		envLogStr = strings.Join(env, " ") + " "
 	}
 	log.Debugf("%s%s", envLogStr, strings.Join(cmdStrs, " "))
+
+	if PrintShellCmds {
+		StatusMessage(VERBOSITY_SILENT, "%s\n", strings.Join(cmdStrs, " "))
+	}
 
 	name := cmdStrs[0]
 	args := cmdStrs[1:]


### PR DESCRIPTION
To print only executed commands:
newt build --silent --printCmds <target>