### PR TITLE
Add new package types to "newt pkg new" command

### DIFF
--- a/newt/cli/pkg_cmds.go
+++ b/newt/cli/pkg_cmds.go
@@ -243,7 +243,7 @@ func AddPackageCommands(cmd *cobra.Command) {
 	}
 
 	newCmd.PersistentFlags().StringVarP(&NewTypeStr, "type", "t",
-		"pkg", "Type of package to create: pkg, bsp, sdk.")
+		"lib", "Type of package to create: app, bsp, lib, sdk.")
 
 	pkgCmd.AddCommand(newCmd)
 

--- a/newt/project/pkgwriter.go
+++ b/newt/project/pkgwriter.go
@@ -31,31 +31,58 @@ import (
 	"mynewt.apache.org/newt/util"
 )
 
+type templateRepo struct {
+	owner  string
+	name   string
+	branch string
+}
+
 type PackageWriter struct {
 	downloader *downloader.GithubDownloader
-	repo       string
+	repo       templateRepo
 	targetPath string
 	template   string
 	fullName   string
 	project    *Project
 }
 
-var TemplateRepoMap = map[string]string{
-	"SDK": "incubator-incubator-mynewt-pkg-sdk",
-	"BSP": "incubator-incubator-mynewt-pkg-bsp",
-	"PKG": "incubator-incubator-mynewt-pkg-pkg",
+var TemplateRepoMap = map[string]templateRepo{
+	"APP": templateRepo{
+		owner:  "runtimeco",
+		name:   "mynewt-pkg-app",
+		branch: "master",
+	},
+	"SDK": templateRepo{
+		owner:  "apache",
+		name:   "incubator-incubator-mynewt-pkg-sdk",
+		branch: "master",
+	},
+	"BSP": templateRepo{
+		owner:  "apache",
+		name:   "incubator-incubator-mynewt-pkg-bsp",
+		branch: "master",
+	},
+	"LIB": templateRepo{
+		owner:  "apache",
+		name:   "incubator-incubator-mynewt-pkg-pkg",
+		branch: "master",
+	},
+
+	// Type=pkg is identical to type=lib for backwards compatibility.
+	"PKG": templateRepo{
+		owner:  "apache",
+		name:   "incubator-incubator-mynewt-pkg-pkg",
+		branch: "master",
+	},
 }
 
-const PACKAGEWRITER_GITHUB_DOWNLOAD_USER = "apache"
-const PACKAGEWRITER_GITHUB_DOWNLOAD_BRANCH = "master"
-
 func (pw *PackageWriter) ConfigurePackage(template string, loc string) error {
-	str, ok := TemplateRepoMap[template]
+	tr, ok := TemplateRepoMap[template]
 	if !ok {
 		return util.NewNewtError(fmt.Sprintf("Cannot find matching "+
 			"repository for template %s", template))
 	}
-	pw.repo = str
+	pw.repo = tr
 
 	pw.fullName = path.Clean(loc)
 	path := pw.project.Path()
@@ -73,17 +100,14 @@ func (pw *PackageWriter) ConfigurePackage(template string, loc string) error {
 }
 
 func (pw *PackageWriter) cleanupPackageFile(pfile string) error {
-	f, err := os.Open(pfile)
+	data, err := ioutil.ReadFile(pfile)
 	if err != nil {
 		return util.ChildNewtError(err)
 	}
-	defer f.Close()
-
-	data, _ := ioutil.ReadAll(f)
 
 	// Search & replace file contents
 	re := regexp.MustCompile("your-pkg-name")
-	res := re.ReplaceAllString(string(data), pw.fullName)
+	res := re.ReplaceAllString(string(data), "\""+pw.fullName+"\"")
 
 	if err := ioutil.WriteFile(pfile, []byte(res), 0666); err != nil {
 		return util.ChildNewtError(err)
@@ -92,28 +116,39 @@ func (pw *PackageWriter) cleanupPackageFile(pfile string) error {
 	return nil
 }
 
-func (pw *PackageWriter) fixupPKG() error {
+func (pw *PackageWriter) fixupPkg() error {
 	pkgBase := path.Base(pw.fullName)
 
 	// Move include file to name after package name
 	if err := util.MoveFile(pw.targetPath+"/include/your-path/your-file.h",
 		pw.targetPath+"/include/your-path/"+pkgBase+".h"); err != nil {
-		return err
+
+		if !util.IsNotExist(err) {
+			return err
+		}
 	}
 
 	// Move source file
 	if err := util.MoveFile(pw.targetPath+"/src/your-source.c",
 		pw.targetPath+"/src/"+pkgBase+".c"); err != nil {
-		return err
+
+		if !util.IsNotExist(err) {
+			return err
+		}
 	}
 
 	if err := util.CopyDir(pw.targetPath+"/include/your-path/",
 		pw.targetPath+"/include/"+pkgBase+"/"); err != nil {
-		return err
+
+		if !util.IsNotExist(err) {
+			return err
+		}
 	}
 
 	if err := os.RemoveAll(pw.targetPath + "/include/your-path/"); err != nil {
-		return util.ChildNewtError(err)
+		if !util.IsNotExist(err) {
+			return util.ChildNewtError(err)
+		}
 	}
 
 	if err := pw.cleanupPackageFile(pw.targetPath + "/pkg.yml"); err != nil {
@@ -126,14 +161,14 @@ func (pw *PackageWriter) fixupPKG() error {
 func (pw *PackageWriter) WritePackage() error {
 	dl := pw.downloader
 
-	dl.User = PACKAGEWRITER_GITHUB_DOWNLOAD_USER
-	dl.Repo = pw.repo
+	dl.User = pw.repo.owner
+	dl.Repo = pw.repo.name
 
 	util.StatusMessage(util.VERBOSITY_DEFAULT,
 		"Download package template for package type %s.\n",
 		strings.ToLower(pw.template))
 
-	tmpdir, err := dl.DownloadRepo(PACKAGEWRITER_GITHUB_DOWNLOAD_BRANCH)
+	tmpdir, err := dl.DownloadRepo(pw.repo.branch)
 	if err != nil {
 		return err
 	}
@@ -146,11 +181,8 @@ func (pw *PackageWriter) WritePackage() error {
 		return err
 	}
 
-	switch pw.template {
-	case "PKG":
-		if err := pw.fixupPKG(); err != nil {
-			return err
-		}
+	if err := pw.fixupPkg(); err != nil {
+		return err
 	}
 
 	util.StatusMessage(util.VERBOSITY_DEFAULT,

--- a/newt/project/pkgwriter.go
+++ b/newt/project/pkgwriter.go
@@ -67,6 +67,11 @@ var TemplateRepoMap = map[string]templateRepo{
 		name:   "incubator-incubator-mynewt-pkg-pkg",
 		branch: "master",
 	},
+	"UNITTEST": templateRepo{
+		owner:  "runtimeco",
+		name:   "mynewt-pkg-unittest",
+		branch: "master",
+	},
 
 	// Type=pkg is identical to type=lib for backwards compatibility.
 	"PKG": templateRepo{

--- a/newt/vendor/mynewt.apache.org/newt/util/util.go
+++ b/newt/vendor/mynewt.apache.org/newt/util/util.go
@@ -300,6 +300,7 @@ func ShellCommandLimitDbgOutput(
 	}
 
 	o, err := cmd.CombinedOutput()
+
 	if maxDbgOutputChrs < 0 || len(o) <= maxDbgOutputChrs {
 		dbgStr := string(o)
 		log.Debugf("o=%s", dbgStr)
@@ -451,7 +452,7 @@ func MoveFile(srcFile string, destFile string) error {
 	}
 
 	if err := os.RemoveAll(srcFile); err != nil {
-		return err
+		return ChildNewtError(err)
 	}
 
 	return nil
@@ -463,7 +464,7 @@ func MoveDir(srcDir string, destDir string) error {
 	}
 
 	if err := os.RemoveAll(srcDir); err != nil {
-		return err
+		return ChildNewtError(err)
 	}
 
 	return nil
@@ -618,4 +619,10 @@ func IntMin(a, b int) int {
 	} else {
 		return b
 	}
+}
+
+func PrintStacks() {
+	buf := make([]byte, 1024*1024)
+	stacklen := runtime.Stack(buf, true)
+	fmt.Printf("*** goroutine dump\n%s\n*** end\n", buf[:stacklen])
 }

--- a/util/util.go
+++ b/util/util.go
@@ -452,7 +452,7 @@ func MoveFile(srcFile string, destFile string) error {
 	}
 
 	if err := os.RemoveAll(srcFile); err != nil {
-		return err
+		return ChildNewtError(err)
 	}
 
 	return nil
@@ -464,7 +464,7 @@ func MoveDir(srcDir string, destDir string) error {
 	}
 
 	if err := os.RemoveAll(srcDir); err != nil {
-		return err
+		return ChildNewtError(err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds the following package types to the "newt pkg new" command:
* app
* unittest

These new types are needed to aid in documentation.  Rather than tell the user which parts of their `pkg.yml` to modify, it is simpler to put the changes in the template.

This PR is a complicated a bit because the new repos are in runtimeco rather than apache.  This repo was chosen to avoid complications when "incubator-" is removed from the current repo names.  After the rename occurs, the new repos could be moved to apache along with the other package templates.