### PR TITLE
Create compile_commands.json file on build

### DIFF
--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -188,3 +188,7 @@ func (b *Builder) AppBinBasePath() string {
 	return b.PkgBinDir(b.appPkg) + "/" +
 		filepath.Base(b.appPkg.rpkg.Lpkg.Name())
 }
+
+func (b *Builder) CompileCmdsPath() string {
+	return filepath.Dir(b.AppElfPath()) + "/compile_commands.json"
+}


### PR DESCRIPTION
Can be useful for clang tools, rtags, etc.

For example:
To perform static analysis on a source code:

```
clang-check -analyze -p path/to/compile_commands.json path/to/source/file
```

or

```
find path/to/sources/ -name '*.c'|xargs clang-check -analyze -p path/to/compile_commands.json
```