### PR TITLE
Add support for configuring the image header size

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -721,6 +721,7 @@ func (b *Builder) CreateImage(version string,
 		}
 	}
 
+	img.HeaderSize = uint(b.targetBuilder.target.HeaderSize)
 	err = img.Generate(loaderImg)
 	if err != nil {
 		return nil, err

--- a/newt/image/image.go
+++ b/newt/image/image.go
@@ -561,7 +561,7 @@ func (image *Image) Generate(loader *Image) error {
 			}
 		}
 		if nonZero {
-			log.Warnf("Skip requested of iamge %s, but image not preceeded by %d bytes of all zeros",
+			log.Warnf("Skip requested of image %s, but image not preceeded by %d bytes of all zeros",
 				image.SourceBin, image.SrcSkip)
 		}
 	}


### PR DESCRIPTION
Some architectures require the image to be flashed at a specific
location, for example, k64f needs vectors to be at a multiple of 0x200
which makes it confusing to define partitions because it requires to
subtract the header size.

This patch makes it possible to configure the header size in target.yml
using the key "target.header_size" which will then, surprise!, write a header
with the requested size allowing the binary firmware to be located at a
well-known address.

Signed-off-by: Fabio Utzig <utzig@apache.org>