### PR TITLE
Add option to launch build command using /bin/sh

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -216,10 +216,12 @@ func pkgnames(pkgs []*pkg.LocalPackage) string {
 	return s
 }
 
-func testRunCmd(cmd *cobra.Command, args []string, exclude string) {
+func testRunCmd(cmd *cobra.Command, args []string, exclude string, executeShell bool) {
 	if len(args) < 1 {
 		NewtUsage(cmd, nil)
 	}
+
+	util.ExecuteShell = executeShell
 
 	proj := TryGetProject()
 
@@ -430,10 +432,12 @@ func AddBuildCommands(cmd *cobra.Command) {
 		Use:   "test <package-name> [package-names...] | all",
 		Short: "Executes unit tests for one or more packages",
 		Run: func(cmd *cobra.Command, args []string) {
-			testRunCmd(cmd, args, exclude)
+			testRunCmd(cmd, args, exclude, executeShell)
 		},
 	}
 	testCmd.Flags().StringVarP(&exclude, "exclude", "e", "", "Comma separated list of packages to exclude")
+	testCmd.Flags().BoolVar(&executeShell, "executeShell", false,
+		"Execute build command using /bin/sh (Linux and MacOS only)")
 	cmd.AddCommand(testCmd)
 	AddTabCompleteFn(testCmd, func() []string {
 		return append(testablePkgList(), "all", "allexcept")

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -104,12 +104,13 @@ func pkgToUnitTests(pack *pkg.LocalPackage) []*pkg.LocalPackage {
 var extraJtagCmd string
 var noGDB_flag bool
 
-func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool) {
+func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, executeShell bool) {
 	if len(args) < 1 {
 		NewtUsage(cmd, nil)
 	}
 
 	util.PrintShellCmds = printShellCmds
+	util.ExecuteShell = executeShell
 
 	TryGetProject()
 
@@ -392,17 +393,21 @@ func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool) {
 
 func AddBuildCommands(cmd *cobra.Command) {
 	var printShellCmds bool
+	var executeShell bool
 
 	buildCmd := &cobra.Command{
 		Use:   "build <target-name> [target-names...]",
 		Short: "Build one or more targets",
 		Run: func(cmd *cobra.Command, args []string) {
-			buildRunCmd(cmd, args, printShellCmds)
+			buildRunCmd(cmd, args, printShellCmds, executeShell)
 		},
 	}
 
 	buildCmd.Flags().BoolVarP(&printShellCmds, "printCmds", "p", false,
 		"Print executed build commands")
+
+	buildCmd.Flags().BoolVar(&executeShell, "executeShell", false,
+		"Execute build command using /bin/sh (Linux and MacOS only)")
 
 	cmd.AddCommand(buildCmd)
 	AddTabCompleteFn(buildCmd, func() []string {


### PR DESCRIPTION
This adds "--executeShell" option to "newt build" which will run build
commands using "/bin/sh -c" instead of directly running the compiler.

This is useful e.g. for Coverity which does not recognize compiler
properly when launched from newt (could be due to clone() instead of
fork(), but not really sure). When running using shell, compiler is
properly forked and recognized.

This is applicable only for Linux and MacOS platforms.