### PR TITLE
newt - Fix crash during `newt test` and `newt run` commands.

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -49,6 +49,7 @@ type Builder struct {
 	bspPkg           *BuildPackage
 	compilerPkg      *BuildPackage
 	targetPkg        *BuildPackage
+	testPkg          *BuildPackage
 	compilerInfo     *toolchain.CompilerInfo
 	targetBuilder    *TargetBuilder
 	cfg              syscfg.Cfg

--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -174,9 +174,9 @@ func (b *Builder) AppPath() string {
 	return b.PkgBinDir(b.appPkg) + "/"
 }
 
-func (b *Builder) TestExePath(bpkg *BuildPackage) string {
+func (b *Builder) TestExePath() string {
 	return TestExePath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
-		bpkg.rpkg.Lpkg.Name(), bpkg.rpkg.Lpkg.Type())
+		b.testPkg.rpkg.Lpkg.Name(), b.testPkg.rpkg.Lpkg.Type())
 }
 
 func (b *Builder) ManifestPath() string {
@@ -190,5 +190,12 @@ func (b *Builder) AppBinBasePath() string {
 }
 
 func (b *Builder) CompileCmdsPath() string {
-	return filepath.Dir(b.AppElfPath()) + "/compile_commands.json"
+	// The path depends on whether we are building an app or running a test.
+	var basePath string
+	if b.appPkg != nil {
+		basePath = filepath.Dir(b.AppElfPath())
+	} else {
+		basePath = filepath.Dir(b.TestExePath())
+	}
+	return basePath + "/compile_commands.json"
 }

--- a/newt/builder/selftest.go
+++ b/newt/builder/selftest.go
@@ -99,6 +99,17 @@ func (t *TargetBuilder) SelfTestDebug() error {
 		return err
 	}
 
+	testRpkg, err := t.getTestRpkg()
+	if err != nil {
+		return err
+	}
+
+	t.AppBuilder.testPkg = t.AppBuilder.PkgMap[testRpkg]
+	if t.AppBuilder.testPkg == nil {
+		return util.FmtNewtError(
+			"builder in invalid state: missing test package")
+	}
+
 	return t.AppBuilder.debugBin(
 		strings.TrimSuffix(t.AppBuilder.TestExePath(), ".elf"),
 		"", false, false)

--- a/newt/builder/selftest.go
+++ b/newt/builder/selftest.go
@@ -31,25 +31,8 @@ import (
 	"mynewt.apache.org/newt/util"
 )
 
-func (b *Builder) getTestBpkg(rpkg *resolve.ResolvePackage) (
-	*BuildPackage, error) {
-
-	testBpkg := b.PkgMap[rpkg]
-	if testBpkg == nil {
-		return nil, util.FmtNewtError("builder missing test package: %s",
-			rpkg.Lpkg.FullName())
-	}
-
-	return testBpkg, nil
-}
-
 func (b *Builder) SelfTestLink(rpkg *resolve.ResolvePackage) error {
-	testBpkg, err := b.getTestBpkg(rpkg)
-	if err != nil {
-		return err
-	}
-
-	testPath := b.TestExePath(testBpkg)
+	testPath := b.TestExePath()
 	if err := b.link(testPath, nil, nil); err != nil {
 		return err
 	}
@@ -72,12 +55,18 @@ func (t *TargetBuilder) SelfTestCreateExe() error {
 		return err
 	}
 
-	if err := t.AppBuilder.Build(); err != nil {
+	testRpkg, err := t.getTestRpkg()
+	if err != nil {
 		return err
 	}
 
-	testRpkg, err := t.getTestRpkg()
-	if err != nil {
+	t.AppBuilder.testPkg = t.AppBuilder.PkgMap[testRpkg]
+	if t.AppBuilder.testPkg == nil {
+		return util.FmtNewtError(
+			"builder in invalid state: missing test package")
+	}
+
+	if err := t.AppBuilder.Build(); err != nil {
 		return err
 	}
 
@@ -110,18 +99,8 @@ func (t *TargetBuilder) SelfTestDebug() error {
 		return err
 	}
 
-	testRpkg, err := t.getTestRpkg()
-	if err != nil {
-		return err
-	}
-
-	testBpkg, err := t.AppBuilder.getTestBpkg(testRpkg)
-	if err != nil {
-		return err
-	}
-
 	return t.AppBuilder.debugBin(
-		strings.TrimSuffix(t.AppBuilder.TestExePath(testBpkg), ".elf"),
+		strings.TrimSuffix(t.AppBuilder.TestExePath(), ".elf"),
 		"", false, false)
 }
 
@@ -151,12 +130,7 @@ func (b *Builder) testOwner(bpkg *BuildPackage) *BuildPackage {
 }
 
 func (b *Builder) SelfTestExecute(testRpkg *resolve.ResolvePackage) error {
-	testBpkg, err := b.getTestBpkg(testRpkg)
-	if err != nil {
-		return err
-	}
-
-	testPath := b.TestExePath(testBpkg)
+	testPath := b.TestExePath()
 	if err := os.Chdir(filepath.Dir(testPath)); err != nil {
 		return err
 	}


### PR DESCRIPTION
The crash would generate a stack dump like this:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7ad094]

goroutine 1 [running]:
mynewt.apache.org/newt/newt/builder.(*Builder).AppElfPath(0xc4204f6b60, 0x0, 0x0)
    /home/jenkins/go/src/mynewt.apache.org/newt/newt/builder/paths.go:151 +0x34
mynewt.apache.org/newt/newt/builder.(*Builder).CompileCmdsPath(0xc4204f6b60, 0xc4201be760, 0x0)
    /home/jenkins/go/src/mynewt.apache.org/newt/newt/builder/paths.go:193 +0x2f
mynewt.apache.org/newt/newt/builder.(*Builder).Build(0xc4204f6b60, 0x0, 0x0)
    /home/jenkins/go/src/mynewt.apache.org/newt/newt/builder/build.go:595 +0xa5a
mynewt.apache.org/newt/newt/builder.(*TargetBuilder).SelfTestCreateExe(0xc420380540, 0xc420135c18, 0x1)
    /home/jenkins/go/src/mynewt.apache.org/newt/newt/builder/selftest.go:75 +0x54
[...]
```

The crash occurs when newt tries to determine the path where the `compile_commands.json` file should get written.  Calculation of the path assumed the presence of an app package in the target.  This is a reasonable assumption in most cases, but one scenario where it causes problems is the `newt test` command.  During self-test, there is no app package.  Instead, there is a "test package."

The fix is to add a `testPkg` field to the Builder struct.  When determining the `compile_commands.json` path, the app package is used if there is one; otherwise, the test package is used.

Prior to this commit, there was a fair amount of code for determining a builder's test package.  Now that the Builder struct has a dedicated field for this information, this code is unnecessary and has been removed.