### PR TITLE
[RFC] Add option to generate CMakeLists.txt file for a target

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -447,8 +447,8 @@ func (b *Builder) PrepBuild() error {
 	baseCi.AddCompilerInfo(bspCi)
 
 	// All packages have access to the generated code header directory.
-	baseCi.Cflags = append(baseCi.Cflags,
-		"-I"+GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.Name()))
+	baseCi.Includes = append(baseCi.Includes,
+		GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.Name()))
 
 	// Note: Compiler flags get added at the end, after the flags for library
 	// package being built are calculated.

--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -311,6 +311,11 @@ func (b *Builder) collectCompileEntriesBpkg(bpkg *BuildPackage) (
 	return entries, nil
 }
 
+func (b *Builder) CollectCompileEntriesBpkg(bpkg *BuildPackage) (
+	[]toolchain.CompilerJob, error) {
+	return b.collectCompileEntriesBpkg(bpkg)
+}
+
 func (b *Builder) createArchive(c *toolchain.Compiler,
 	bpkg *BuildPackage) error {
 

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -20,23 +20,27 @@
 package builder
 
 import (
-	"mynewt.apache.org/newt/newt/project"
-	"mynewt.apache.org/newt/newt/toolchain"
-	"fmt"
-	"os"
 	"bufio"
-	"io"
 	"bytes"
+	"fmt"
+	"io"
+	"os"
 	"strings"
+
+	"mynewt.apache.org/newt/newt/project"
+	"mynewt.apache.org/newt/newt/target"
+	"mynewt.apache.org/newt/newt/toolchain"
+	"mynewt.apache.org/newt/util"
+	"path/filepath"
 )
 
 const CMAKELISTS_FILENAME string = "CMakeLists.txt"
 
-func (t *TargetBuilder) CmakeListsPath() string {
-	return TargetBinDir(t.target.Name()) + "/" + CMAKELISTS_FILENAME
+func CmakeListsPath() string {
+	return project.GetProject().BasePath + "/" + CMAKELISTS_FILENAME
 }
 
-func (b *Builder) Generate(w io.Writer) error {
+func (b *Builder) Generate(w io.Writer, name string) error {
 	//b.CleanArtifacts()
 
 	// Build the packages alphabetically to ensure a consistent order.
@@ -45,7 +49,7 @@ func (b *Builder) Generate(w io.Writer) error {
 	// Calculate the list of jobs.  Each record represents a single file that
 	// needs to be compiled.
 	entries := []toolchain.CompilerJob{}
-	bpkgCompilerMap := map[*BuildPackage]*toolchain.Compiler{}
+	builtPackages := []*BuildPackage{}
 	for _, bpkg := range bpkgs {
 		subEntries, err := b.collectCompileEntriesBpkg(bpkg)
 		if err != nil {
@@ -58,35 +62,54 @@ func (b *Builder) Generate(w io.Writer) error {
 
 		entries = append(entries, subEntries...)
 		files := []string{}
-		bpkgCompilerMap[bpkg] = subEntries[0].Compiler
 		for _, s := range subEntries {
 			files = append(files, s.Filename)
 		}
 		c := subEntries[0].Compiler
 
-		fmt.Fprintf(w, "# Generating code for %s\n\n", bpkg.rpkg.Lpkg.Name())
-		CmakeCompilerWrite(w, c)
+		builtPackages = append(builtPackages, bpkg)
 
-		fmt.Fprintf(w, "add_library(%s %s)\n\n", bpkg.rpkg.Lpkg.EscapedName(),
+		fmt.Fprintf(w, "# Generating code for %s\n\n", bpkg.rpkg.Lpkg.Name())
+
+		fmt.Fprintf(w, "add_library(%s_%s OBJECT %s)\n\n",
+			name, bpkg.rpkg.Lpkg.EscapedName(),
 			strings.Join(files, " "))
-		CmakeCompilerInfoWrite(w, bpkg, c)
+
+		CmakeCompilerInfoWrite(w, name, bpkg, c)
 
 		fmt.Printf("%s\n", bpkg.rpkg.Lpkg.BasePath())
-
-		for _, entry := range subEntries {
-			fmt.Printf("    %s\n", entry.Filename)
-		}
 	}
+
+	fmt.Fprintf(w, "# Generating code for %s\n\n", name)
+
+	var targetObjectsBuffer bytes.Buffer
+
+	for _, bpkg := range builtPackages {
+		targetObjectsBuffer.WriteString(fmt.Sprintf("$<TARGET_OBJECTS:%s_%s> ",
+			name, bpkg.rpkg.Lpkg.EscapedName()))
+	}
+	fmt.Fprintf(w, "add_library(%s %s)\n\n", name, targetObjectsBuffer.String())
+	fmt.Fprintf(w, ` set_target_properties(%s
+									PROPERTIES ARCHIVE_OUTPUT_DIRECTORY %s
+									LIBRARY_OUTPUT_DIRECTORY %s
+									RUNTIME_OUTPUT_DIRECTORY %s
+									)`,
+		name,
+		filepath.Dir(b.AppElfPath()),
+		filepath.Dir(b.AppElfPath()),
+		filepath.Dir(b.AppElfPath()))
+
+
 	return nil
 }
-func CmakeCompilerInfoWrite(w io.Writer, bpkg *BuildPackage, c *toolchain.Compiler) {
-	fmt.Fprintf(w, "target_include_directories(%s PUBLIC %s %s)\n\n",
-		bpkg.rpkg.Lpkg.EscapedName(), strings.Join(c.GetCompilerInfo().Includes, " "),
+func CmakeCompilerInfoWrite(w io.Writer, target_name string, bpkg *BuildPackage, c *toolchain.Compiler) {
+	fmt.Fprintf(w, "target_include_directories(%s_%s PUBLIC %s %s)\n\n",
+		target_name, bpkg.rpkg.Lpkg.EscapedName(), strings.Join(c.GetCompilerInfo().Includes, " "),
 		strings.Join(c.GetLocalCompilerInfo().Includes, " "))
-	fmt.Fprintf(w, "SET(CMAKE_C_FLAGS  \"${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
+	fmt.Fprintf(w, "set(CMAKE_C_FLAGS  \"${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
 		strings.Join(c.GetCompilerInfo().Cflags, " "),
 		strings.Join(c.GetLocalCompilerInfo().Cflags, " "))
-	fmt.Fprintf(w, "SET(CMAKE_ASM_FLAGS  \"${CMAKE_ASM_FLAGS_BACKUP} %s %s ${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
+	fmt.Fprintf(w, "set(CMAKE_ASM_FLAGS  \"${CMAKE_ASM_FLAGS_BACKUP} %s %s ${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
 		strings.Join(c.GetCompilerInfo().Aflags, " "),
 		strings.Join(c.GetLocalCompilerInfo().Aflags, " "),
 		strings.Join(c.GetCompilerInfo().Cflags, " "),
@@ -96,15 +119,26 @@ func CmakeCompilerInfoWrite(w io.Writer, bpkg *BuildPackage, c *toolchain.Compil
 func CmakeCompilerWrite(w io.Writer, c *toolchain.Compiler) {
 	/* Since CMake 3 it is required to set a full path to the compiler */
 	/* TODO: get rid of the prefix to /usr/bin */
+	fmt.Fprintln(w, "set(CMAKE_SYSTEM_NAME Generic)")
+	fmt.Fprintln(w, "set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)")
 	fmt.Fprintf(w, "set(CMAKE_C_COMPILER %s)\n", "/usr/bin/"+c.GetCcPath())
 	fmt.Fprintf(w, "set(CMAKE_CXX_COMPILER %s)\n", "/usr/bin/"+c.GetCppPath())
 	fmt.Fprintf(w, "set(CMAKE_ASM_COMPILER %s)\n", "/usr/bin/"+c.GetAsPath())
 	fmt.Fprintf(w, "set(CMAKE_AR %s)\n", "/usr/bin/"+c.GetArPath())
-	fmt.Fprintln(w, "enable_language(C CXX ASM)")
 	fmt.Fprintln(w)
 }
 
-func (t *TargetBuilder) Generate() error {
+func CmakeHeaderWrite(w io.Writer, c *toolchain.Compiler) {
+	fmt.Fprintln(w, "cmake_minimum_required(VERSION 3.7)\n")
+	CmakeCompilerWrite(w, c)
+	fmt.Fprintln(w, "project(Mynewt VERSION 0.0.0 LANGUAGES C ASM)\n")
+	fmt.Fprintln(w, "SET(CMAKE_C_FLAGS_BACKUP  \"${CMAKE_C_FLAGS}\")")
+	fmt.Fprintln(w, "SET(CMAKE_CXX_FLAGS_BACKUP  \"${CMAKE_CXX_FLAGS}\")")
+	fmt.Fprintln(w, "SET(CMAKE_ASM_FLAGS_BACKUP  \"${CMAKE_ASM_FLAGS}\")")
+	fmt.Fprintln(w)
+}
+
+func (t *TargetBuilder) CMakeGenerateTarget(w io.Writer) error {
 	if err := t.PrepBuild(); err != nil {
 		return err
 	}
@@ -116,39 +150,38 @@ func (t *TargetBuilder) Generate() error {
 		return err
 	}
 
-	fmt.Println(t.CmakeListsPath())
-	CmakeFileHandle, _ := os.Create(t.CmakeListsPath())
-	var b = bytes.Buffer{}
-	writer := bufio.NewWriter(&b)
-	defer CmakeFileHandle.Close()
-
-	fmt.Fprintln(writer, "cmake_minimum_required(VERSION 3.7)\n")
-	fmt.Fprintln(writer, "SET(CMAKE_C_FLAGS_BACKUP  \"${CMAKE_C_FLAGS}\")")
-	fmt.Fprintln(writer, "SET(CMAKE_CXX_FLAGS_BACKUP  \"${CMAKE_CXX_FLAGS}\")")
-	fmt.Fprintln(writer, "SET(CMAKE_ASM_FLAGS_BACKUP  \"${CMAKE_ASM_FLAGS}\")")
-	fmt.Fprintln(writer)
-
-	if err := t.AppBuilder.Generate(writer); err != nil {
+	if err := t.AppBuilder.Generate(w, t.target.ShortName()); err != nil {
 		return err
 	}
 
-	writer.Flush()
-	CmakeFileHandle.Write(b.Bytes())
-
-	//var linkerScripts []string
-	//if t.LoaderBuilder == nil {
-	//	linkerScripts = t.bspPkg.LinkerScripts
-	//} else {
-	//	if err := t.buildLoader(); err != nil {
-	//		return err
-	//	}
-	//	linkerScripts = t.bspPkg.Part2LinkerScripts
-	//}
-	//
-	///* Link the app. */
-	//if err := t.AppBuilder.Link(linkerScripts); err != nil {
-	//	return err
-	//}
-
 	return nil
+}
+
+func CMakeGenerate(target *target.Target) error {
+	CmakeFileHandle, _ := os.Create(CmakeListsPath())
+	var b = bytes.Buffer{}
+	w := bufio.NewWriter(&b)
+	defer CmakeFileHandle.Close()
+
+
+	targetBuilder, err := NewTargetBuilder(target)
+	if err != nil {
+		return util.NewNewtError(err.Error())
+	}
+
+	c, err := targetBuilder.NewCompiler("")
+	if  err != nil {
+		return err
+	}
+
+	CmakeHeaderWrite(w, c)
+
+	if err := targetBuilder.CMakeGenerateTarget(w); err != nil {
+		return util.NewNewtError(err.Error())
+	}
+
+	w.Flush()
+
+	CmakeFileHandle.Write(b.Bytes())
+	return  nil
 }

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package builder
+
+import (
+	"mynewt.apache.org/newt/newt/project"
+	"mynewt.apache.org/newt/newt/toolchain"
+	"fmt"
+	"os"
+	"bufio"
+	"io"
+	"bytes"
+	"strings"
+)
+
+const CMAKELISTS_FILENAME string = "CMakeLists.txt"
+
+func (t *TargetBuilder) CmakeListsPath() string {
+	return TargetBinDir(t.target.Name()) + "/" + CMAKELISTS_FILENAME
+}
+
+func (b *Builder) Generate(w io.Writer) error {
+	//b.CleanArtifacts()
+
+	// Build the packages alphabetically to ensure a consistent order.
+	bpkgs := b.sortedBuildPackages()
+
+	// Calculate the list of jobs.  Each record represents a single file that
+	// needs to be compiled.
+	entries := []toolchain.CompilerJob{}
+	bpkgCompilerMap := map[*BuildPackage]*toolchain.Compiler{}
+	for _, bpkg := range bpkgs {
+		subEntries, err := b.collectCompileEntriesBpkg(bpkg)
+		if err != nil {
+			return err
+		}
+
+		if len(subEntries) <= 0 {
+			continue
+		}
+
+		entries = append(entries, subEntries...)
+		files := []string{}
+		bpkgCompilerMap[bpkg] = subEntries[0].Compiler
+		for _, s := range subEntries {
+			files = append(files, s.Filename)
+		}
+		c := subEntries[0].Compiler
+
+		fmt.Fprintf(w, "# Generating code for %s\n\n", bpkg.rpkg.Lpkg.Name())
+		CmakeCompilerWrite(w, c)
+
+		fmt.Fprintf(w, "add_library(%s %s)\n\n", bpkg.rpkg.Lpkg.EscapedName(),
+			strings.Join(files, " "))
+		CmakeCompilerInfoWrite(w, bpkg, c)
+
+		fmt.Printf("%s\n", bpkg.rpkg.Lpkg.BasePath())
+
+		for _, entry := range subEntries {
+			fmt.Printf("    %s\n", entry.Filename)
+		}
+	}
+	return nil
+}
+func CmakeCompilerInfoWrite(w io.Writer, bpkg *BuildPackage, c *toolchain.Compiler) {
+	fmt.Fprintf(w, "target_include_directories(%s PUBLIC %s %s)\n\n",
+		bpkg.rpkg.Lpkg.EscapedName(), strings.Join(c.GetCompilerInfo().Includes, " "),
+		strings.Join(c.GetLocalCompilerInfo().Includes, " "))
+	fmt.Fprintf(w, "SET(CMAKE_C_FLAGS  \"${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
+		strings.Join(c.GetCompilerInfo().Cflags, " "),
+		strings.Join(c.GetLocalCompilerInfo().Cflags, " "))
+	fmt.Fprintf(w, "SET(CMAKE_ASM_FLAGS  \"${CMAKE_ASM_FLAGS_BACKUP} %s %s ${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
+		strings.Join(c.GetCompilerInfo().Aflags, " "),
+		strings.Join(c.GetLocalCompilerInfo().Aflags, " "),
+		strings.Join(c.GetCompilerInfo().Cflags, " "),
+		strings.Join(c.GetLocalCompilerInfo().Cflags, " "))
+}
+
+func CmakeCompilerWrite(w io.Writer, c *toolchain.Compiler) {
+	/* Since CMake 3 it is required to set a full path to the compiler */
+	/* TODO: get rid of the prefix to /usr/bin */
+	fmt.Fprintf(w, "set(CMAKE_C_COMPILER %s)\n", "/usr/bin/"+c.GetCcPath())
+	fmt.Fprintf(w, "set(CMAKE_CXX_COMPILER %s)\n", "/usr/bin/"+c.GetCppPath())
+	fmt.Fprintf(w, "set(CMAKE_ASM_COMPILER %s)\n", "/usr/bin/"+c.GetAsPath())
+	fmt.Fprintf(w, "set(CMAKE_AR %s)\n", "/usr/bin/"+c.GetArPath())
+	fmt.Fprintln(w, "enable_language(C CXX ASM)")
+	fmt.Fprintln(w)
+}
+
+func (t *TargetBuilder) Generate() error {
+	if err := t.PrepBuild(); err != nil {
+		return err
+	}
+
+	/* Build the Apps */
+	project.ResetDeps(t.AppList)
+
+	if err := t.bspPkg.Reload(t.AppBuilder.cfg.Features()); err != nil {
+		return err
+	}
+
+	fmt.Println(t.CmakeListsPath())
+	CmakeFileHandle, _ := os.Create(t.CmakeListsPath())
+	var b = bytes.Buffer{}
+	writer := bufio.NewWriter(&b)
+	defer CmakeFileHandle.Close()
+
+	fmt.Fprintln(writer, "cmake_minimum_required(VERSION 3.7)\n")
+	fmt.Fprintln(writer, "SET(CMAKE_C_FLAGS_BACKUP  \"${CMAKE_C_FLAGS}\")")
+	fmt.Fprintln(writer, "SET(CMAKE_CXX_FLAGS_BACKUP  \"${CMAKE_CXX_FLAGS}\")")
+	fmt.Fprintln(writer, "SET(CMAKE_ASM_FLAGS_BACKUP  \"${CMAKE_ASM_FLAGS}\")")
+	fmt.Fprintln(writer)
+
+	if err := t.AppBuilder.Generate(writer); err != nil {
+		return err
+	}
+
+	writer.Flush()
+	CmakeFileHandle.Write(b.Bytes())
+
+	//var linkerScripts []string
+	//if t.LoaderBuilder == nil {
+	//	linkerScripts = t.bspPkg.LinkerScripts
+	//} else {
+	//	if err := t.buildLoader(); err != nil {
+	//		return err
+	//	}
+	//	linkerScripts = t.bspPkg.Part2LinkerScripts
+	//}
+	//
+	///* Link the app. */
+	//if err := t.AppBuilder.Link(linkerScripts); err != nil {
+	//	return err
+	//}
+
+	return nil
+}

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -36,11 +36,17 @@ import (
 
 const CMAKELISTS_FILENAME string = "CMakeLists.txt"
 
+const (
+	COMPILER_TYPE_C       = 0
+	COMPILER_TYPE_ASM     = 1
+	COMPILER_TYPE_CPP     = 2
+)
+
 func CmakeListsPath() string {
 	return project.GetProject().BasePath + "/" + CMAKELISTS_FILENAME
 }
 
-func (b *Builder) Generate(w io.Writer, name string) error {
+func (b *Builder) Generate(w io.Writer, name string, c *toolchain.Compiler) error {
 	//b.CleanArtifacts()
 
 	// Build the packages alphabetically to ensure a consistent order.
@@ -65,17 +71,16 @@ func (b *Builder) Generate(w io.Writer, name string) error {
 		for _, s := range subEntries {
 			files = append(files, s.Filename)
 		}
-		c := subEntries[0].Compiler
 
 		builtPackages = append(builtPackages, bpkg)
 
 		fmt.Fprintf(w, "# Generating code for %s\n\n", bpkg.rpkg.Lpkg.Name())
 
-		fmt.Fprintf(w, "add_library(%s_%s OBJECT %s)\n\n",
-			name, bpkg.rpkg.Lpkg.EscapedName(),
+		fmt.Fprintf(w, "add_library(%s %s)\n\n",
+			bpkg.rpkg.Lpkg.EscapedName(),
 			strings.Join(files, " "))
 
-		CmakeCompilerInfoWrite(w, name, bpkg, c)
+		CmakeCompilerInfoWrite(w, bpkg, subEntries[0])
 
 		fmt.Printf("%s\n", bpkg.rpkg.Lpkg.BasePath())
 	}
@@ -85,35 +90,97 @@ func (b *Builder) Generate(w io.Writer, name string) error {
 	var targetObjectsBuffer bytes.Buffer
 
 	for _, bpkg := range builtPackages {
-		targetObjectsBuffer.WriteString(fmt.Sprintf("$<TARGET_OBJECTS:%s_%s> ",
-			name, bpkg.rpkg.Lpkg.EscapedName()))
+		targetObjectsBuffer.WriteString(fmt.Sprintf("%s ",
+			bpkg.rpkg.Lpkg.EscapedName()))
+
 	}
-	fmt.Fprintf(w, "add_library(%s %s)\n\n", name, targetObjectsBuffer.String())
-	fmt.Fprintf(w, ` set_target_properties(%s
-									PROPERTIES ARCHIVE_OUTPUT_DIRECTORY %s
-									LIBRARY_OUTPUT_DIRECTORY %s
-									RUNTIME_OUTPUT_DIRECTORY %s
-									)`,
+
+	fmt.Fprintln(w, "file(WRITE null.c \"\")")
+	fmt.Fprintf(w, "add_executable(%s null.c)\n\n", name)
+
+	fmt.Fprintf(w, `
+	target_link_libraries(%s
+							-Wl,--start-group %s -Wl,--end-group)`,
+		name,
+		targetObjectsBuffer.String())
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "set_target_properties(%s PROPERTIES COMPILE_FLAGS %s)\n\n",
+		name,
+		strings.Replace(strings.Join(append(c.GetCompilerInfo().Cflags,
+			c.GetLocalCompilerInfo().Cflags...), ","), " ", ",", -1))
+
+	fmt.Fprintf(w, `
+	set_target_properties(%s
+							PROPERTIES
+							ARCHIVE_OUTPUT_DIRECTORY %s
+							LIBRARY_OUTPUT_DIRECTORY %s
+							RUNTIME_OUTPUT_DIRECTORY %s
+							OUTPUT_DIRECTORY %s
+							LINK_FLAGS %s
+							LINKER_LANGUAGE C)`,
 		name,
 		filepath.Dir(b.AppElfPath()),
 		filepath.Dir(b.AppElfPath()),
-		filepath.Dir(b.AppElfPath()))
+		filepath.Dir(b.AppElfPath()),
+		filepath.Dir(b.AppElfPath()),
+		strings.Join(append(c.GetCompilerInfo().Lflags,
+			c.GetLocalCompilerInfo().Lflags...), ";"))
 
+	fmt.Fprintln(w)
+	for _, ld := range c.LinkerScripts {
+		fmt.Fprintf(w, `
+			set_target_properties(%s
+									PROPERTIES
+									LINK_DEPENDS %s)`,
+			name,
+			ld)
+		fmt.Fprintln(w)
+	}
 
 	return nil
 }
-func CmakeCompilerInfoWrite(w io.Writer, target_name string, bpkg *BuildPackage, c *toolchain.Compiler) {
-	fmt.Fprintf(w, "target_include_directories(%s_%s PUBLIC %s %s)\n\n",
-		target_name, bpkg.rpkg.Lpkg.EscapedName(), strings.Join(c.GetCompilerInfo().Includes, " "),
+func CmakeCompilerInfoWrite(w io.Writer, bpkg *BuildPackage, cj toolchain.CompilerJob) {
+	c := cj.Compiler
+
+	fmt.Fprintf(w, `
+	set_target_properties(%s
+							PROPERTIES
+							ARCHIVE_OUTPUT_DIRECTORY %s
+							LIBRARY_OUTPUT_DIRECTORY %s
+							RUNTIME_OUTPUT_DIRECTORY %s)`,
+		bpkg.rpkg.Lpkg.EscapedName(),
+		bpkg.rpkg.Lpkg.BasePath(),
+		bpkg.rpkg.Lpkg.BasePath(),
+		bpkg.rpkg.Lpkg.BasePath())
+	fmt.Fprintln(w)
+
+	compileFlags := []string{}
+
+	switch cj.CompilerType {
+	case COMPILER_TYPE_C:
+		compileFlags = append(compileFlags, c.GetCompilerInfo().Cflags...)
+		compileFlags = append(compileFlags, c.GetLocalCompilerInfo().Cflags...)
+	case COMPILER_TYPE_ASM:
+		compileFlags = append(compileFlags, c.GetCompilerInfo().Cflags...)
+		compileFlags = append(compileFlags, c.GetLocalCompilerInfo().Cflags...)
+		compileFlags = append(compileFlags, c.GetCompilerInfo().Aflags...)
+		compileFlags = append(compileFlags, c.GetLocalCompilerInfo().Aflags...)
+	case COMPILER_TYPE_CPP:
+		compileFlags = append(compileFlags, c.GetCompilerInfo().Cflags...)
+		compileFlags = append(compileFlags, c.GetLocalCompilerInfo().Cflags...)
+	}
+
+	fmt.Fprintf(w, `set_target_properties(%s
+													PROPERTIES
+													COMPILE_FLAGS %s)`,
+		bpkg.rpkg.Lpkg.EscapedName(),
+		strings.Replace(strings.Join(compileFlags, ","), " ", ",", -1))
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "target_include_directories(%s PUBLIC %s %s)\n\n",
+		bpkg.rpkg.Lpkg.EscapedName(),
+		strings.Join(c.GetCompilerInfo().Includes, " "),
 		strings.Join(c.GetLocalCompilerInfo().Includes, " "))
-	fmt.Fprintf(w, "set(CMAKE_C_FLAGS  \"${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
-		strings.Join(c.GetCompilerInfo().Cflags, " "),
-		strings.Join(c.GetLocalCompilerInfo().Cflags, " "))
-	fmt.Fprintf(w, "set(CMAKE_ASM_FLAGS  \"${CMAKE_ASM_FLAGS_BACKUP} %s %s ${CMAKE_C_FLAGS_BACKUP} %s %s\")\n\n",
-		strings.Join(c.GetCompilerInfo().Aflags, " "),
-		strings.Join(c.GetLocalCompilerInfo().Aflags, " "),
-		strings.Join(c.GetCompilerInfo().Cflags, " "),
-		strings.Join(c.GetLocalCompilerInfo().Cflags, " "))
 }
 
 func CmakeCompilerWrite(w io.Writer, c *toolchain.Compiler) {
@@ -124,7 +191,8 @@ func CmakeCompilerWrite(w io.Writer, c *toolchain.Compiler) {
 	fmt.Fprintf(w, "set(CMAKE_C_COMPILER %s)\n", "/usr/bin/"+c.GetCcPath())
 	fmt.Fprintf(w, "set(CMAKE_CXX_COMPILER %s)\n", "/usr/bin/"+c.GetCppPath())
 	fmt.Fprintf(w, "set(CMAKE_ASM_COMPILER %s)\n", "/usr/bin/"+c.GetAsPath())
-	fmt.Fprintf(w, "set(CMAKE_AR %s)\n", "/usr/bin/"+c.GetArPath())
+	/* TODO: cmake returns error on link */
+	//fmt.Fprintf(w, "set(CMAKE_AR %s)\n", "/usr/bin/"+c.GetArPath())
 	fmt.Fprintln(w)
 }
 
@@ -138,7 +206,7 @@ func CmakeHeaderWrite(w io.Writer, c *toolchain.Compiler) {
 	fmt.Fprintln(w)
 }
 
-func (t *TargetBuilder) CMakeGenerateTarget(w io.Writer) error {
+func (t *TargetBuilder) CMakeGenerateTarget(w io.Writer, c *toolchain.Compiler) error {
 	if err := t.PrepBuild(); err != nil {
 		return err
 	}
@@ -146,11 +214,13 @@ func (t *TargetBuilder) CMakeGenerateTarget(w io.Writer) error {
 	/* Build the Apps */
 	project.ResetDeps(t.AppList)
 
+	c.LinkerScripts = t.bspPkg.LinkerScripts
+
 	if err := t.bspPkg.Reload(t.AppBuilder.cfg.Features()); err != nil {
 		return err
 	}
 
-	if err := t.AppBuilder.Generate(w, t.target.ShortName()); err != nil {
+	if err := t.AppBuilder.Generate(w, t.target.ShortName(), c); err != nil {
 		return err
 	}
 
@@ -163,25 +233,24 @@ func CMakeGenerate(target *target.Target) error {
 	w := bufio.NewWriter(&b)
 	defer CmakeFileHandle.Close()
 
-
 	targetBuilder, err := NewTargetBuilder(target)
 	if err != nil {
 		return util.NewNewtError(err.Error())
 	}
 
 	c, err := targetBuilder.NewCompiler("")
-	if  err != nil {
+	if err != nil {
 		return err
 	}
 
 	CmakeHeaderWrite(w, c)
 
-	if err := targetBuilder.CMakeGenerateTarget(w); err != nil {
+	if err := targetBuilder.CMakeGenerateTarget(w, c); err != nil {
 		return util.NewNewtError(err.Error())
 	}
 
 	w.Flush()
 
 	CmakeFileHandle.Write(b.Bytes())
-	return  nil
+	return nil
 }

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -74,7 +74,7 @@ func CmakeSourceObjectWrite(w io.Writer, cj toolchain.CompilerJob) {
 														COMPILE_FLAGS
 														"%s")`,
 		cj.Filename,
-		strings.Replace(strings.Join(compileFlags, " "), "\"", "\\\"", -1))
+		strings.Replace(strings.Join(compileFlags, " "), "\"", "\\\\\\\"", -1))
 	fmt.Fprintln(w)
 }
 
@@ -148,7 +148,7 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 														"%s")`,
 		elfName,
 		strings.Replace(strings.Join(append(c.GetCompilerInfo().Cflags,
-			c.GetLocalCompilerInfo().Cflags...), " "), "\"", "\\\"", -1))
+			c.GetLocalCompilerInfo().Cflags...), " "), "\"", "\\\\\\\"", -1))
 	fmt.Fprintln(w)
 
 	lFlags := append(c.GetCompilerInfo().Lflags, c.GetLocalCompilerInfo().Lflags...)

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -241,7 +241,7 @@ func targetCmakeCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	builder.CMakeGenerate(targets[0])
+	builder.CMakeTargetGenerate(targets[0])
 }
 
 func targetSetCmd(cmd *cobra.Command, args []string) {

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -226,6 +226,61 @@ func targetShowCmd(cmd *cobra.Command, args []string) {
 	}
 }
 
+func targetCmakeCmd(cmd *cobra.Command, args []string) {
+	TryGetProject()
+
+	// Verify and resolve each specified package.
+	targets, all, err := ResolveTargetsOrAll(args...)
+	if err != nil {
+		NewtUsage(cmd, err)
+	}
+
+	if all {
+		// Collect all targets that specify an app package.
+		targets = []*target.Target{}
+		for _, name := range targetList() {
+			t := ResolveTarget(name)
+			if t != nil && t.AppName != "" {
+				targets = append(targets, t)
+			}
+		}
+	}
+
+	for i, _ := range targets {
+		// Reset the global state for the next build.
+		// XXX: It is not good that this is necessary.  This is certainly going
+		// to bite us...
+		if i > 0 {
+			if err := ResetGlobalState(); err != nil {
+				NewtUsage(nil, err)
+			}
+		}
+
+		// Look up the target by name.  This has to be done a second time here
+		// now that the project has been reset.
+		t := ResolveTarget(targets[i].FullName())
+		if t == nil {
+			NewtUsage(nil, util.NewNewtError("Failed to resolve target: "+
+				targets[i].Name()))
+		}
+
+		util.StatusMessage(util.VERBOSITY_DEFAULT, "Building target %s\n",
+			t.FullName())
+
+		builder, err := builder.NewTargetBuilder(t)
+		if err != nil {
+			NewtUsage(nil, err)
+		}
+
+		if err := builder.Generate(); err != nil {
+			NewtUsage(nil, err)
+		}
+
+		util.StatusMessage(util.VERBOSITY_DEFAULT,
+			"Target successfully built: %s\n", t.Name())
+	}
+}
+
 func targetSetCmd(cmd *cobra.Command, args []string) {
 	if len(args) < 2 {
 		NewtUsage(cmd,
@@ -844,6 +899,22 @@ func AddTargetCommands(cmd *cobra.Command) {
 	}
 	targetCmd.AddCommand(showCmd)
 	AddTabCompleteFn(showCmd, targetList)
+
+
+	cmakeHelpText := "Cmake all the variables for the target specified " +
+		"by <target-name>."
+	cmakeHelpEx := "  newt target cmake <target-name>\n"
+	cmakeHelpEx += "  newt target cmake my_target1"
+
+	cmakeCmd := &cobra.Command{
+		Use:     "cmake",
+		Short:   "View target configuration variables",
+		Long:    cmakeHelpText,
+		Example: cmakeHelpEx,
+		Run:     targetCmakeCmd,
+	}
+	targetCmd.AddCommand(cmakeCmd)
+	AddTabCompleteFn(cmakeCmd, targetList)
 
 	setHelpText := "Set a target variable (<var-name>) on target "
 	setHelpText += "<target-name> to value <value>.\n"

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -864,7 +864,7 @@ func AddTargetCommands(cmd *cobra.Command) {
 	AddTabCompleteFn(showCmd, targetList)
 
 
-	cmakeHelpText := "Cmake all the variables for the target specified " +
+	cmakeHelpText := "Generate CMakeLists.txt for target specified " +
 		"by <target-name>."
 	cmakeHelpEx := "  newt target cmake <target-name>\n"
 	cmakeHelpEx += "  newt target cmake my_target1"

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -96,10 +96,6 @@ func (pkg *LocalPackage) Name() string {
 	return pkg.name
 }
 
-func (pkg *LocalPackage) EscapedName() string {
-	return strings.Replace(pkg.name, "/","_", -1)
-}
-
 func (pkg *LocalPackage) FullName() string {
 	r := pkg.Repo()
 	if r.IsLocal() {

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -96,6 +96,10 @@ func (pkg *LocalPackage) Name() string {
 	return pkg.name
 }
 
+func (pkg *LocalPackage) EscapedName() string {
+	return strings.Replace(pkg.name, "/","_", -1)
+}
+
 func (pkg *LocalPackage) FullName() string {
 	r := pkg.Repo()
 	if r.IsLocal() {

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -110,6 +110,30 @@ func (c *Compiler) GetCompileCommands() []CompileCommand {
 	return c.compileCommands
 }
 
+func (c *Compiler) GetCcPath() string {
+	return c.ccPath
+}
+
+func (c *Compiler) GetCppPath() string {
+	return c.cppPath
+}
+
+func (c *Compiler) GetAsPath() string {
+	return c.asPath
+}
+
+func (c *Compiler) GetArPath() string {
+	return c.arPath
+}
+
+func (c *Compiler) GetCompilerInfo() CompilerInfo {
+	return c.info
+}
+
+func (c *Compiler) GetLocalCompilerInfo() CompilerInfo {
+	return c.lclInfo
+}
+
 type CompilerJob struct {
 	Filename     string
 	Compiler     *Compiler


### PR DESCRIPTION
This PR adds a command to generate CMakeLists.txt file for a target. The file is placed in project root directory. 

Usage: newt target cmake <target>