### PR TITLE
newt - Include orphans in `newt target revdep`

### DIFF
--- a/newt/builder/depgraph.go
+++ b/newt/builder/depgraph.go
@@ -26,9 +26,16 @@ import (
 	"mynewt.apache.org/newt/newt/resolve"
 )
 
+// Records presence of each dependency.
 type rmap map[*resolve.ResolveDep]struct{}
-type DepGraph map[*resolve.ResolvePackage][]*resolve.ResolveDep
+
+// Type used internally while building a proper dependency graph.
 type graphMap map[*resolve.ResolvePackage]rmap
+
+// Key=parent, Value=slice of children
+// For normal dependency graph:  parent=depender, children=dependees.
+// For reverse dependency graph: parent=dependee, children=dependers.
+type DepGraph map[*resolve.ResolvePackage][]*resolve.ResolveDep
 
 func graphMapEnsure(gm graphMap, p *resolve.ResolvePackage) rmap {
 	if gm[p] == nil {


### PR DESCRIPTION
The `newt target revdep` command prints a target's reverse dependency graph.  Prior to this commit, orphans (packages that no one depended on) were excluded from the output.  I believe it is misleading for packages to be missing from the graph.

For example, the following target:

```
[ccollins@ccollins-mac:~/repos/mynewt/core]$ newt target show blehci-nrf52dk
targets/blehci-nrf52dk
    app=apps/blehci
    bsp=hw/bsp/nrf52dk
    build_profile=debug
    syscfg=BLE_ACL_BUF_SIZE=128:BLE_HCI_UART_BAUD=115200:BLE_HCI_UART_FLOW_CTRL=HAL_UART_FLOW_CTL_NONE:BLE_MAX_CONNECTIONS=4
```

Generates the following reverse dependency graph:

```
[ccollins@ccollins-mac:~/repos/mynewt/core]$ newt target revdep blehci-nrf52dk
Reverse dependency graph (dependee <-- [dependers]):
    * hw/cmsis-core <-- [hw/mcu/nordic hw/mcu/nordic/nrf52xxx]
    * hw/drivers/nimble/nrf52 <-- [hw/bsp/nrf52dk net/nimble/controller(api:ble_driver)]
    * hw/drivers/uart <-- [hw/drivers/uart/uart_hal]
    * hw/drivers/uart/uart_hal <-- [hw/bsp/nrf52dk]
    * hw/hal <-- [hw/drivers/uart/uart_hal hw/mcu/nordic hw/mcu/nordic/nrf52xxx net/nimble/transport/uart]
    * hw/mcu/nordic <-- [hw/mcu/nordic/nrf52xxx]
    * hw/mcu/nordic/nrf52xxx <-- [hw/bsp/nrf52dk]
    * kernel/os <-- [apps/blehci hw/hal libc/baselibc net/nimble net/nimble/controller net/nimble/transport/uart sys/mfg sys/stats/full sys/sysinit util/mem]
    * libc/baselibc <-- [hw/bsp/nrf52dk]
    * net/nimble <-- [hw/drivers/nimble/nrf52 net/nimble/controller net/nimble/transport/uart]
    * net/nimble/controller <-- [apps/blehci hw/drivers/nimble/nrf52]
    * net/nimble/transport/uart <-- [apps/blehci net/nimble/controller(api:ble_transport)]
    * sys/console/stub <-- [apps/blehci kernel/os(api:console) libc/baselibc(api:console)]
    * sys/defs <-- [sys/flash_map]
    * sys/flash_map <-- [sys/mfg sys/sysinit]
    * sys/mfg <-- [sys/flash_map]
    * sys/stats/full <-- [apps/blehci net/nimble/controller(api:stats)]
    * sys/sysinit <-- [kernel/os]
    * util/mem <-- [kernel/os net/nimble/transport/uart]
```

Four packages are missing from the above list: `apps/blehci`, `compiler/arm-none-eabi-m4`, `hw/bsp/nrf52dk`, and `targets/blehci-nrf52dk`.  These are the four packages in the project that nothing else depends on.

After this commit, these packages are included in the graph with an empty reverse dependency list:

```
[ccollins@ccollins-mac:~/repos/mynewt/core]$ newt target revdep blehci-nrf52dk
Reverse dependency graph (dependee <-- [dependers]):
    * apps/blehci <-- []
    * compiler/arm-none-eabi-m4 <-- []
    * hw/bsp/nrf52dk <-- []
    * hw/cmsis-core <-- [hw/mcu/nordic hw/mcu/nordic/nrf52xxx]
    * hw/drivers/nimble/nrf52 <-- [hw/bsp/nrf52dk net/nimble/controller(api:ble_driver)]
    * hw/drivers/uart <-- [hw/drivers/uart/uart_hal]
    * hw/drivers/uart/uart_hal <-- [hw/bsp/nrf52dk]
    * hw/hal <-- [hw/drivers/uart/uart_hal hw/mcu/nordic hw/mcu/nordic/nrf52xxx net/nimble/transport/uart]
    * hw/mcu/nordic <-- [hw/mcu/nordic/nrf52xxx]
    * hw/mcu/nordic/nrf52xxx <-- [hw/bsp/nrf52dk]
    * kernel/os <-- [apps/blehci hw/hal libc/baselibc net/nimble net/nimble/controller net/nimble/transport/uart sys/mfg sys/stats/full sys/sysinit util/mem]
    * libc/baselibc <-- [hw/bsp/nrf52dk]
    * net/nimble <-- [hw/drivers/nimble/nrf52 net/nimble/controller net/nimble/transport/uart]
    * net/nimble/controller <-- [apps/blehci hw/drivers/nimble/nrf52]
    * net/nimble/transport/uart <-- [apps/blehci net/nimble/controller(api:ble_transport)]
    * sys/console/stub <-- [apps/blehci kernel/os(api:console) libc/baselibc(api:console)]
    * sys/defs <-- [sys/flash_map]
    * sys/flash_map <-- [sys/mfg sys/sysinit]
    * sys/mfg <-- [sys/flash_map]
    * sys/stats/full <-- [apps/blehci net/nimble/controller(api:stats)]
    * sys/sysinit <-- [kernel/os]
    * targets/blehci-nrf52dk <-- []
    * util/mem <-- [kernel/os net/nimble/transport/uart]
```
