### PR TITLE
Makefile for building debian package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+BIN=$(DESTDIR)/usr/bin
+TARGET=newt
+build:
+	./build.sh
+
+install:
+	install -d $(BIN)
+	install $(TARGET)/$(TARGET) $(BIN)
+	rm -f  $(TARGET)/$(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Use for building deb package. Needed by dpkg-buildpackage. 
 BIN=$(DESTDIR)/usr/bin
 TARGET=newt
 build:


### PR DESCRIPTION
So we don't have to create a Makefile each time we build a deb package for newt