### PR TITLE
unixchild - fix race condition

### DIFF
--- a/util/unixchild/unixchild.go
+++ b/util/unixchild/unixchild.go
@@ -91,7 +91,7 @@ func New(conf Config) *Client {
 		childArgs:     conf.ChildArgs,
 		maxMsgSz:      conf.MaxMsgSz,
 		FromChild:     make(chan []byte, conf.Depth),
-		ErrChild:      make(chan error),
+		ErrChild:      make(chan error, 1),
 		toChild:       make(chan []byte, conf.Depth),
 		acceptTimeout: conf.AcceptTimeout,
 		stop:          make(chan bool),


### PR DESCRIPTION
This commit gives the unixchild ErrChan a depth of 1 (was 0).  Prior to this change, there was a race condition when the child process terminated at the same time that the calling code stopped the unixchild library.

A depth of 1 is sufficient because there will never be more than one error.  When the first error is encountered, the library terminates.