### PR TITLE
newt - Don't corrupt project on failed install.

### DIFF
--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -424,13 +424,15 @@ func (proj *Project) loadRepo(rname string, v *viper.Viper) error {
 	r.ReadDesc()
 
 	rvers := proj.projState.GetInstalledVersion(rname)
-	code, msg := r.CheckNewtCompatibility(rvers, newtutil.NewtVersion)
-	switch code {
-	case compat.NEWT_COMPAT_GOOD:
-	case compat.NEWT_COMPAT_WARN:
-		util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s.\n", msg)
-	case compat.NEWT_COMPAT_ERROR:
-		return util.NewNewtError(msg)
+	if rvers != nil {
+		code, msg := r.CheckNewtCompatibility(rvers, newtutil.NewtVersion)
+		switch code {
+		case compat.NEWT_COMPAT_GOOD:
+		case compat.NEWT_COMPAT_WARN:
+			util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s.\n", msg)
+		case compat.NEWT_COMPAT_ERROR:
+			return util.NewNewtError(msg)
+		}
 	}
 
 	log.Debugf("Loaded repository %s (type: %s, user: %s, repo: %s)", rname,

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -143,7 +143,7 @@ func (r *Resolver) resolveDep(dep *pkg.Dependency, depender string) (*pkg.LocalP
 	return lpkg, nil
 }
 
-// @return                      true if rhe package's dependency list was
+// @return                      true if the package's dependency list was
 //                                  modified.
 func (rpkg *ResolvePackage) AddDep(apiPkg *ResolvePackage, api string) bool {
 	if dep := rpkg.Deps[apiPkg]; dep != nil {


### PR DESCRIPTION
-Prior to this commit-

If a repo install fails (e.g., due to an incorrect password), newt
creates an empty directory: `repos/.configs/<repo-name>`.  The newt
project is now unusable until the empty directory is deleted.  All newt
actions crash when newt assumes the empty directory contains a
`repository.yml` file.

-After commit-

This commit consists of two changes:

1. If newt fails to retrieve a repo's `repository.yml` file, it removes
the empty directory it just created.

2. If a repo's `.configs` directory is empty, newt skips the
compatibility check instead of crashing.