### PR TITLE
MYNEWT-851  newt - Private repo password displayed by `git remote -v`

### DIFF
--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -464,7 +464,7 @@ func (c *Compiler) GenDepsForFile(file string) error {
 	cmd = append(cmd, c.includesStrings()...)
 	cmd = append(cmd, []string{"-MM", "-MG", srcPath}...)
 
-	o, err := util.ShellCommandLimitDbgOutput(cmd, nil, 0)
+	o, err := util.ShellCommandLimitDbgOutput(cmd, nil, true, 0)
 	if err != nil {
 		return err
 	}
@@ -972,7 +972,7 @@ func (c *Compiler) generateExtras(elfFilename string,
 			"-wxdS",
 			elfFilename,
 		}
-		o, err := util.ShellCommandLimitDbgOutput(cmd, nil, 0)
+		o, err := util.ShellCommandLimitDbgOutput(cmd, nil, true, 0)
 		if err != nil {
 			// XXX: gobjdump appears to always crash.  Until we get that sorted
 			// out, don't fail the link process if lst generation fails.
@@ -992,7 +992,7 @@ func (c *Compiler) generateExtras(elfFilename string,
 				sect,
 				elfFilename,
 			}
-			o, err := util.ShellCommandLimitDbgOutput(cmd, nil, 0)
+			o, err := util.ShellCommandLimitDbgOutput(cmd, nil, true, 0)
 			if err != nil {
 				if _, err := f.Write(o); err != nil {
 					return util.NewNewtError(err.Error())
@@ -1004,7 +1004,7 @@ func (c *Compiler) generateExtras(elfFilename string,
 			c.osPath,
 			elfFilename,
 		}
-		o, err = util.ShellCommandLimitDbgOutput(cmd, nil, 0)
+		o, err = util.ShellCommandLimitDbgOutput(cmd, nil, true, 0)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
(Jira: https://issues.apache.org/jira/browse/MYNEWT-851)

#### Prior to commit

For private repos, the user's login and password are part of the repo URL. E.g.,

```
    wes@~/dev/work/repos/private-repo$ git remote -v
    origin    https://wes3:[password-redacted]@github.com/PrivateRepo/private-repo.git (fetch)
    origin    https://wes3:[password-redacted]@github.com/PrivateRepo/private-repo.git (push)
```

#### After commit

Newt wraps all git commands that require remote access as follows:

1. Replace remote URL with the authentication-decorated version.
2. Perform git operation.
3. Replace remote URL with unauthenticated version.