### PR TITLE
newt - Don't trace stack during syscfg access

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -128,17 +128,15 @@ func NewCfg() Cfg {
 	}
 }
 
+// Determines if a syscfg value is "true".  Only "" and a string representing 0
+// are considered false; everything else is true.
 func ValueIsTrue(val string) bool {
 	if val == "" {
 		return false
 	}
 
-	i, err := util.AtoiNoOct(val)
-	if err == nil && i == 0 {
-		return false
-	}
-
-	return true
+	i, success := util.AtoiNoOctTry(val)
+	return !success || i != 0
 }
 
 func (cfg *Cfg) Features() map[string]bool {

--- a/newt/vendor/mynewt.apache.org/newt/util/util.go
+++ b/newt/vendor/mynewt.apache.org/newt/util/util.go
@@ -560,7 +560,13 @@ func SortFields(wsSepStrings ...string) []string {
 	return slice
 }
 
-func AtoiNoOct(s string) (int, error) {
+// Converts the specified string to an integer.  The string can be in base-10
+// or base-16.  This is equivalent to the "0" base used in the standard
+// conversion functions, except octal is not supported (a leading zero implies
+// decimal).
+//
+// The second return value is true on success.
+func AtoiNoOctTry(s string) (int, bool) {
 	var runLen int
 	for runLen = 0; runLen < len(s)-1; runLen++ {
 		if s[runLen] != '0' || s[runLen+1] == 'x' {
@@ -574,10 +580,23 @@ func AtoiNoOct(s string) (int, error) {
 
 	i, err := strconv.ParseInt(s, 0, 0)
 	if err != nil {
-		return 0, NewNewtError(err.Error())
+		return 0, false
 	}
 
-	return int(i), nil
+	return int(i), true
+}
+
+// Converts the specified string to an integer.  The string can be in base-10
+// or base-16.  This is equivalent to the "0" base used in the standard
+// conversion functions, except octal is not supported (a leading zero implies
+// decimal).
+func AtoiNoOct(s string) (int, error) {
+	val, success := AtoiNoOctTry(s)
+	if !success {
+		return 0, FmtNewtError("Invalid number: \"%s\"", s)
+	}
+
+	return val, nil
 }
 
 func IsNotExist(err error) bool {

--- a/util/util.go
+++ b/util/util.go
@@ -560,7 +560,13 @@ func SortFields(wsSepStrings ...string) []string {
 	return slice
 }
 
-func AtoiNoOct(s string) (int, error) {
+// Converts the specified string to an integer.  The string can be in base-10
+// or base-16.  This is equivalent to the "0" base used in the standard
+// conversion functions, except octal is not supported (a leading zero implies
+// decimal).
+//
+// The second return value is true on success.
+func AtoiNoOctTry(s string) (int, bool) {
 	var runLen int
 	for runLen = 0; runLen < len(s)-1; runLen++ {
 		if s[runLen] != '0' || s[runLen+1] == 'x' {
@@ -574,10 +580,23 @@ func AtoiNoOct(s string) (int, error) {
 
 	i, err := strconv.ParseInt(s, 0, 0)
 	if err != nil {
-		return 0, NewNewtError(err.Error())
+		return 0, false
 	}
 
-	return int(i), nil
+	return int(i), true
+}
+
+// Converts the specified string to an integer.  The string can be in base-10
+// or base-16.  This is equivalent to the "0" base used in the standard
+// conversion functions, except octal is not supported (a leading zero implies
+// decimal).
+func AtoiNoOct(s string) (int, error) {
+	val, success := AtoiNoOctTry(s)
+	if !success {
+		return 0, FmtNewtError("Invalid number: \"%s\"", s)
+	}
+
+	return val, nil
 }
 
 func IsNotExist(err error) bool {


### PR DESCRIPTION
The purpose of this commit is to speed up newt.  During dependency resolution of a target with a lot of syscfg settings (e.g., anything using nimble), newt spent the majority of its time creating stack traces.  These stack traces were created each time newt determined if a syscfg setting was enabled.

The culprit was the `util.AtoiNoOct()` function.  This function attempts to convert a string to an integer, allowing base-10 and base-16 representations.  If the string cannot be converted, a new `NewtError` is returned.  Each time a `NewtError` is created, the current stack trace is requested and placed in the error object.

The `AtoiNoOct()` function was being called repeatedly, as a syscfg value must be compared to "0" to determine if it is enabled or not.

The fix is to introduce a new function: `AtoiNoOctTry()`.  This function is similar to `AtoiNoOct()`, except it returns a bool indicating success / failure rather than a `NewtError`.

#### Example timings:

##### Before fix
```
[ccollins@ccollins-mac:~/repos/mynewt/core]$ time newt -lfatal -s target config
show bleprph-nrf52dk

real    0m1.052s
user    0m2.022s
sys     0m0.197s
```

##### After fix
```
[ccollins@ccollins-mac:~/repos/mynewt/core]$ time newt -lfatal -s target config
show bleprph-nrf52dk

real    0m0.301s
user    0m0.356s
sys     0m0.037s
```