### PR TITLE
Newt - Generic git repositories

### DIFF
--- a/newt/project/projectstate.go
+++ b/newt/project/projectstate.go
@@ -45,6 +45,10 @@ func (ps *ProjectState) Replace(rname string, rvers *repo.Version) {
 	ps.installedRepos[rname] = rvers
 }
 
+func (ps *ProjectState) Delete(rname string) {
+	delete(ps.installedRepos, rname)
+}
+
 func (ps *ProjectState) StateFile() string {
 	return interfaces.GetProject().Path() + "/" + PROJECT_STATE_FILE
 }
@@ -74,8 +78,8 @@ func (ps *ProjectState) Init() error {
 
 	path := ps.StateFile()
 
-	// Read project state file.  If doesn't exist, it will be empty until somebody
-	// installs a repo
+	// Read project state file.  If doesn't exist, it will be empty until
+	// somebody installs a repo
 	if util.NodeNotExist(path) {
 		return nil
 	}


### PR DESCRIPTION
This commit adds support for a new repository type, as specified in the `project.yml` file: "git".  Here is an example:

```
    repository.apache-mynewt-core:
        type: git
        vers: 0-latest
        url: 'git@github.com:apache/mynewt-core.git'
```

Repositories of this type do not have any fields for credentials; security is handled by the `git` tool, not newt.  The example repo above would authenticate via ssh.

In addition, this commit cleans up some inconsistent and unintuitive behavior in the following newt commands:

* `install`
* `upgrade`
* `sync`

The new behaviors of these commands are described below:

* `install`:
    * For each repo in `project.yml`:
        * If `-f` (force) specified, delete repo's directory.
        * If repo doesn't exist:
            * Clone repo.
            * Checkout appropriate branch.
            * Populate `project.state` file.

* `upgrade`:
    * For each repo in `project.yml`:
        * If repo doesn't exist:
            * Clone repo.
            * Checkout appropriate branch.
            * Populate `project.state` file.
        * Else:
            * If versions in `project.state` and `project.yml` don't match:
                * Prompt user [Y/n]
                * If any local changes:
                    * If !force:
                        * Print error and abort.
                * Upgrade repo to correct branch.  If local changes, attempt merge.
                * Populate `project.state` file.

* `sync`:
    * For each repo in `project.yml`:
        * If repo not installed:
            * Print error message.
        * Else:
            * If remote contains changes not in local branch:
                * If any local changes:
                    * Save `git diff` output to temp file.
                * Replace repo contents with latest from remote.