### PR TITLE
Avoid useless warning when username isn't available

### DIFF
--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -107,7 +107,6 @@ var newtrc *viper.Viper
 func readNewtrc() *viper.Viper {
 	usr, err := user.Current()
 	if err != nil {
-		log.Warn("Failed to obtain user name")
 		return viper.New()
 	}
 


### PR DESCRIPTION
The username often isn't available when running newt in a container.
This resulted in log lines like:

2017/10/26 20:17:04.580 [WARNING] Failed to obtain user name

This change removes the log line.