### PR TITLE
MYNEWT-859 - Newt crashes on bad target setting

### DIFF
--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -20,6 +20,7 @@
 package target
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -82,11 +83,7 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 
 	settings := v.AllSettings()
 	for k, v := range settings {
-		var ok bool
-		target.Vars[k], ok = v.(string)
-		if !ok {
-			target.Vars[k] = strconv.Itoa(v.(int))
-		}
+		target.Vars[k] = fmt.Sprintf("%v", v)
 	}
 
 	target.BspName = target.Vars["target.bsp"]


### PR DESCRIPTION
(Jira ticket: https://issues.apache.org/jira/browse/MYNEWT-859)

If a target's `target.yml` file contains a setting whose value is not a string and not an integer, newt panics with a stack trace like this:

```
    goroutine 1 [running]:
    mynewt.apache.org/newt/newt/target.(*Target).Load(0xc42052c540, 0xc42049c070, 0x3000100, 0x0)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/target/target.go:88 +0x831
    mynewt.apache.org/newt/newt/target.LoadTarget(0xc42049c070, 0x8, 0xc42045a680, 0x6)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/target/target.go:63 +0x5b
    mynewt.apache.org/newt/newt/target.buildTargetMap(0x0, 0x8)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/target/target.go:281 +0xe9
    mynewt.apache.org/newt/newt/target.GetTargets(0x7fff5fbffbfa)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/target/target.go:301 +0x48
    mynewt.apache.org/newt/newt/cli.ResolveTarget(0x7fff5fbffbf3, 0x8, 0x0)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/cli/util.go:86 +0x9d
    mynewt.apache.org/newt/newt/cli.ResolveTargetsOrAll(0xc420041300, 0x1, 0x1, 0x1103d5d, 0xc42007a16c, 0xc42004fbf0, 0x11035c2, 0xc42007a16c, 0x14fb9d8)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/cli/util.go:125 +0xda
    mynewt.apache.org/newt/newt/cli.buildRunCmd(0xc420089440, 0xc420041300, 0x1, 0x1, 0x0)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/cli/build_cmds.go:118 +0x90
    mynewt.apache.org/newt/newt/cli.AddBuildCommands.func1(0xc420089440, 0xc420041300, 0x1, 0x1)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/cli/build_cmds.go:404 +0x5f
    mynewt.apache.org/newt/newt/vendor/github.com/spf13/cobra.(*Command).execute(0xc420089440, 0xc4200412c0, 0x1, 0x1, 0xc420089440, 0xc4200412c0)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/vendor/github.com/spf13/cobra/command.go:636 +0x234
    mynewt.apache.org/newt/newt/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420088fc0, 0x5, 0x25, 0x14ea8fa)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/vendor/github.com/spf13/cobra/command.go:722 +0x2fe
    mynewt.apache.org/newt/newt/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420088fc0, 0x14ea8fa, 0x5)
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/vendor/github.com/spf13/cobra/command.go:681 +0x2b
    main.main()
        /private/tmp/mynewt-newt-20170911-92237-1eg3req/mynewt-newt-mynewt_1_2_0_tag/gopath/src/mynewt.apache.org/newt/newt/newt.go:170 +0x1ac
```

The fix is to coerce all setting values into strings by applying `fmt.Sprintf("%v")` to them.