### PR TITLE
newt - Only validate package name once

### DIFF
--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -667,6 +667,8 @@ func targetConfigShowCmd(cmd *cobra.Command, args []string) {
 			util.NewNewtError("Must specify target or unittest name"))
 	}
 
+	TryGetProject()
+
 	for _, arg := range args {
 		b, err := TargetBuilderForTargetOrUnittest(arg)
 		if err != nil {
@@ -690,6 +692,8 @@ func targetConfigInitCmd(cmd *cobra.Command, args []string) {
 		b      *builder.TargetBuilder
 		exists bool
 	}
+
+	TryGetProject()
 
 	anyExist := false
 	entries := make([]entry, len(args))
@@ -862,7 +866,6 @@ func AddTargetCommands(cmd *cobra.Command) {
 	}
 	targetCmd.AddCommand(showCmd)
 	AddTabCompleteFn(showCmd, targetList)
-
 
 	cmakeHelpText := "Generate CMakeLists.txt for target specified " +
 		"by <target-name>."

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -294,6 +294,17 @@ func (pkg *LocalPackage) Save() error {
 	return nil
 }
 
+func matchNamePath(name, path string) bool {
+	// assure that name and path use the same path separator...
+	names := filepath.SplitList(name)
+	name = filepath.Join(names...)
+
+	if strings.HasSuffix(path, name) {
+		return true
+	}
+	return false
+}
+
 // Load reads everything that isn't identity specific into the package
 func (pkg *LocalPackage) Load() error {
 	// Load configuration
@@ -314,6 +325,12 @@ func (pkg *LocalPackage) Load() error {
 		return util.FmtNewtError(
 			"Package \"%s\" missing \"pkg.name\" field in its `pkg.yml` file",
 			pkg.basePath)
+	}
+
+	if !matchNamePath(pkg.name, pkg.basePath) {
+		return util.FmtNewtError(
+			"Package \"%s\" has incorrect \"pkg.name\" field in its "+
+				"`pkg.yml` file (pkg.name=%s)", pkg.basePath, pkg.name)
 	}
 
 	typeString := pkg.PkgV.GetString("pkg.type")

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -601,40 +601,18 @@ func (proj *Project) Init(dir string) error {
 	return nil
 }
 
-func matchNamePath(name, path string) bool {
-	// assure that name and path use the same path separator...
-	names := filepath.SplitList(name)
-	name = filepath.Join(names...)
-
-	if strings.HasSuffix(path, name) {
-		return true
-	}
-	return false
-}
-
 func (proj *Project) ResolveDependency(dep interfaces.DependencyInterface) interfaces.PackageInterface {
 	type NamePath struct {
 		name string
 		path string
 	}
 
-	var errorPkgs []NamePath
 	for _, pkgList := range proj.packages {
 		for _, pkg := range *pkgList {
-			name := pkg.Name()
-			path := pkg.BasePath()
-			if !matchNamePath(name, path) {
-				errorPkgs = append(errorPkgs, NamePath{name: name, path: path})
-			}
 			if dep.SatisfiesDependency(pkg) {
 				return pkg
 			}
 		}
-	}
-
-	for _, namepath := range errorPkgs {
-		util.StatusMessage(util.VERBOSITY_VERBOSE,
-			"Package name \"%s\" doesn't match path \"%s\"\n", namepath.name, namepath.path)
 	}
 
 	return nil


### PR DESCRIPTION
Package names were being validated repeatedly.  During dependency resolution, each package was validated during the search.  Also, mismatched names were not displayed to the user.

Now name validation happens once when the package is loaded.