### PR TITLE
fixed matchNamePath for windows and added -f flag for rm in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,4 +80,4 @@ ln -s "$installdir" "$repodir"
 )
 
 ### Delete the temporary directory.
-rm -r "$godir"
+rm -rf "$godir"

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -296,8 +296,8 @@ func (pkg *LocalPackage) Save() error {
 
 func matchNamePath(name, path string) bool {
 	// assure that name and path use the same path separator...
-	names := filepath.SplitList(name)
-	name = filepath.Join(names...)
+	names := strings.Split(name, "/")
+	name = strings.Join(names, "/")
 
 	if strings.HasSuffix(path, name) {
 		return true


### PR DESCRIPTION
 fixed matchNamePath for windows  and also added -f to rm /tmp/* in build.sh so
 won't get prompt when removing write protected file. 
