### PR TITLE
make master newt version ahead of releases

### DIFF
--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -35,8 +35,8 @@ import (
 	"mynewt.apache.org/newt/viper"
 )
 
-var NewtVersion Version = Version{1, 2, 0}
-var NewtVersionStr string = "Apache Newt version: 1.2.0-dev"
+var NewtVersion Version = Version{1, 4, 0}
+var NewtVersionStr string = "Apache Newt version: 1.4.0-dev"
 var NewtBlinkyTag string = "master"
 var NewtNumJobs int
 var NewtForce bool


### PR DESCRIPTION
When doing a brew install from --HEAD, resulting newt should not show version older than existing releases and candidates?