### PR TITLE
newt - Warn instead of fail on broken links.

### DIFF
--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -429,7 +429,7 @@ func ReadLocalPackageRecursive(repo *repo.Repo,
 
 	dirList, err := repo.FilteredSearchList(pkgName, searchedMap)
 	if err != nil {
-		return warnings, util.NewNewtError(err.Error())
+		return append(warnings, err.Error()), nil
 	}
 
 	for _, name := range dirList {
@@ -445,9 +445,7 @@ func ReadLocalPackageRecursive(repo *repo.Repo,
 		}
 	}
 
-	if util.NodeNotExist(filepath.Join(basePath, pkgName,
-		PACKAGE_FILE_NAME)) {
-
+	if util.NodeNotExist(filepath.Join(basePath, pkgName, PACKAGE_FILE_NAME)) {
 		return warnings, nil
 	}
 


### PR DESCRIPTION
### Before change

If newt failed to enter a directory while scanning for packages, it aborted the scan with an error.  This could be annoying because one broken link in the project would make newt think no packages are present.

### Now

newt warns about the issue and continues the scan.
