### PR TITLE
newt: Add option to print size report for any section

### DIFF
--- a/newt/builder/size.go
+++ b/newt/builder/size.go
@@ -510,7 +510,7 @@ func (b *Builder) Size() error {
 	return nil
 }
 
-func (t *TargetBuilder) SizeReport(ram, flash bool) error {
+func (t *TargetBuilder) SizeReport(sectionName string) error {
 
 	err := t.PrepBuild()
 
@@ -519,21 +519,21 @@ func (t *TargetBuilder) SizeReport(ram, flash bool) error {
 	}
 
 	fmt.Printf("Size of Application Image: %s\n", t.AppBuilder.buildName)
-	err = t.AppBuilder.SizeReport(ram, flash)
+	err = t.AppBuilder.SizeReport(sectionName)
 
 	if err == nil {
 		if t.LoaderBuilder != nil {
 			fmt.Printf("Size of Loader Image: %s\n", t.LoaderBuilder.buildName)
-			err = t.LoaderBuilder.SizeReport(ram, flash)
+			err = t.LoaderBuilder.SizeReport(sectionName)
 		}
 	}
 
 	return err
 }
 
-func (b *Builder) SizeReport(ram, flash bool) error {
+func (b *Builder) SizeReport(sectionName string) error {
 	srcBase := b.targetBuilder.GetTarget().App().Repo().Path() + "/"
-	err := SizeReport(b.AppElfPath(), srcBase, ram, flash)
+	err := SizeReport(b.AppElfPath(), srcBase, sectionName)
 	if err != nil {
 		return util.NewNewtError(err.Error())
 	}

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -364,7 +364,7 @@ func debugRunCmd(cmd *cobra.Command, args []string) {
 	}
 }
 
-func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool) {
+func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool, section string) {
 	if len(args) < 1 {
 		NewtUsage(cmd, util.NewNewtError("Must specify target"))
 	}
@@ -381,10 +381,28 @@ func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool) {
 		NewtUsage(nil, err)
 	}
 
-	if ram || flash {
-		if err := b.SizeReport(ram, flash); err != nil {
-			NewtUsage(cmd, err)
+	var sections []string
+
+
+	if ram {
+		sections = append(sections, "RAM")
+	}
+
+	if flash {
+		sections = append(sections, "FLASH")
+	}
+
+	if section != "" {
+		sections = append(sections, section)
+	}
+
+	if len(sections) > 0 {
+		for _, sectionName := range sections {
+			if err := b.SizeReport(sectionName); err != nil {
+				NewtUsage(cmd, err)
+			}
 		}
+
 		return
 	}
 
@@ -479,18 +497,20 @@ func AddBuildCommands(cmd *cobra.Command) {
 		"<target-name>."
 
 	var ram, flash bool
+	var section string
 	sizeCmd := &cobra.Command{
 		Use:   "size <target-name>",
 		Short: "Size of target components",
 		Long:  sizeHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
-			sizeRunCmd(cmd, args, ram, flash)
+			sizeRunCmd(cmd, args, ram, flash, section)
 		},
 	}
 
 	sizeCmd.Flags().BoolVarP(&ram, "ram", "R", false, "Print RAM statistics")
 	sizeCmd.Flags().BoolVarP(&flash, "flash", "F", false,
 		"Print FLASH statistics")
+	sizeCmd.Flags().StringVarP(&section, "section", "S", "", "Print section statistics")
 
 	cmd.AddCommand(sizeCmd)
 	AddTabCompleteFn(sizeCmd, targetList)


### PR DESCRIPTION
This patch adds a new option to the newt size command.
It's possible to specify a custom section name for the size report.
Usage:

newt size --section <section> <target>
newt size -S <section> <target>

RAM (--ram, -R) and FLASH (--flash,-F) options still work,
to ensure backwards compatibility.