### PR TITLE
    Code for parsing and evaluating syscfg expressions

### DIFF
--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -128,20 +128,17 @@ func (bpkg *BuildPackage) CompilerInfo(
 	}
 
 	ci := toolchain.NewCompilerInfo()
-	features := b.cfg.FeaturesForLpkg(bpkg.rpkg.Lpkg)
+	settings := b.cfg.SettingsForLpkg(bpkg.rpkg.Lpkg)
 
 	// Read each set of flags and expand repo designators ("@<repo-nme>") into
 	// paths.
-	ci.Cflags = newtutil.GetStringSliceFeatures(bpkg.rpkg.Lpkg.PkgV, features,
-		"pkg.cflags")
+	ci.Cflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cflags", settings)
 	expandFlags(ci.Cflags)
 
-	ci.Lflags = newtutil.GetStringSliceFeatures(bpkg.rpkg.Lpkg.PkgV, features,
-		"pkg.lflags")
+	ci.Lflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.lflags", settings)
 	expandFlags(ci.Lflags)
 
-	ci.Aflags = newtutil.GetStringSliceFeatures(bpkg.rpkg.Lpkg.PkgV, features,
-		"pkg.aflags")
+	ci.Aflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.aflags", settings)
 	expandFlags(ci.Aflags)
 
 	// Package-specific injected settings get specified as C flags on the
@@ -151,8 +148,7 @@ func (bpkg *BuildPackage) CompilerInfo(
 	}
 
 	ci.IgnoreFiles = []*regexp.Regexp{}
-	ignPats := newtutil.GetStringSliceFeatures(bpkg.rpkg.Lpkg.PkgV,
-		features, "pkg.ign_files")
+	ignPats := bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.ign_files", settings)
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
 		if err != nil {
@@ -163,8 +159,7 @@ func (bpkg *BuildPackage) CompilerInfo(
 	}
 
 	ci.IgnoreDirs = []*regexp.Regexp{}
-	ignPats = newtutil.GetStringSliceFeatures(bpkg.rpkg.Lpkg.PkgV,
-		features, "pkg.ign_dirs")
+	ignPats = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.ign_dirs", settings)
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
 		if err != nil {
@@ -174,9 +169,8 @@ func (bpkg *BuildPackage) CompilerInfo(
 		ci.IgnoreDirs = append(ci.IgnoreDirs, re)
 	}
 
-	bpkg.SourceDirectories = newtutil.GetStringSliceFeatures(
-		bpkg.rpkg.Lpkg.PkgV,
-		features, "pkg.src_dirs")
+	bpkg.SourceDirectories = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+		"pkg.src_dirs", settings)
 
 	includePaths, err := bpkg.recursiveIncludePaths(b)
 	if err != nil {

--- a/newt/builder/buildutil.go
+++ b/newt/builder/buildutil.go
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"mynewt.apache.org/newt/newt/parse"
 	"mynewt.apache.org/newt/newt/resolve"
 )
 
@@ -36,10 +37,12 @@ func TestTargetName(testPkgName string) string {
 func (b *Builder) FeatureString() string {
 	var buffer bytes.Buffer
 
-	featureMap := b.cfg.Features()
-	featureSlice := make([]string, 0, len(featureMap))
-	for k, _ := range featureMap {
-		featureSlice = append(featureSlice, k)
+	settingMap := b.cfg.SettingValues()
+	featureSlice := make([]string, 0, len(settingMap))
+	for k, v := range settingMap {
+		if parse.ValueIsTrue(v) {
+			featureSlice = append(featureSlice, k)
+		}
 	}
 	sort.Strings(featureSlice)
 

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -41,7 +41,7 @@ func CmakeListsPath() string {
 }
 
 func EscapeName(name string) string {
-	return strings.Replace(name, "/","_", -1)
+	return strings.Replace(name, "/", "_", -1)
 }
 
 func CmakeSourceObjectWrite(w io.Writer, cj toolchain.CompilerJob) {
@@ -200,7 +200,7 @@ func (t *TargetBuilder) CMakeTargetBuilderWrite(w io.Writer, targetCompiler *too
 
 	targetCompiler.LinkerScripts = t.bspPkg.LinkerScripts
 
-	if err := t.bspPkg.Reload(t.AppBuilder.cfg.Features()); err != nil {
+	if err := t.bspPkg.Reload(t.AppBuilder.cfg.SettingValues()); err != nil {
 		return err
 	}
 

--- a/newt/builder/depgraph.go
+++ b/newt/builder/depgraph.go
@@ -22,6 +22,7 @@ package builder
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"mynewt.apache.org/newt/newt/resolve"
 )
@@ -111,8 +112,18 @@ func revdepGraph(rs *resolve.ResolveSet) (DepGraph, error) {
 
 func depString(dep *resolve.ResolveDep) string {
 	s := fmt.Sprintf("%s", dep.Rpkg.Lpkg.FullName())
+
+	var reasons []string
 	if dep.Api != "" {
-		s += fmt.Sprintf("(api:%s)", dep.Api)
+		reasons = append(reasons, fmt.Sprintf("api:%s", dep.Api))
+	}
+
+	if dep.Expr != "" {
+		reasons = append(reasons, fmt.Sprintf("syscfg:%s", dep.Expr))
+	}
+
+	if len(reasons) > 0 {
+		s += fmt.Sprintf("(%s)", strings.Join(reasons, " "))
 	}
 
 	return s

--- a/newt/builder/load.go
+++ b/newt/builder/load.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"mynewt.apache.org/newt/newt/parse"
 	"mynewt.apache.org/newt/newt/pkg"
 	"mynewt.apache.org/newt/newt/project"
 	"mynewt.apache.org/newt/util"
@@ -116,10 +117,10 @@ func (b *Builder) Load(imageSlot int, extraJtagCmd string) error {
 	if extraJtagCmd != "" {
 		envSettings["EXTRA_JTAG_CMD"] = extraJtagCmd
 	}
-	features := b.cfg.Features()
+	settings := b.cfg.SettingValues()
 
 	var flashTargetArea string
-	if _, ok := features["BOOT_LOADER"]; ok {
+	if parse.ValueIsTrue(settings["BOOT_LOADER"]) {
 		envSettings["BOOT_LOADER"] = "1"
 
 		flashTargetArea = "FLASH_AREA_BOOTLOADER"

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -192,9 +192,7 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 
 	warningText := strings.TrimSpace(t.res.WarningText())
 	if warningText != "" {
-		for _, line := range strings.Split(warningText, "\n") {
-			log.Debugf(line)
-		}
+		log.Debug(warningText)
 	}
 
 	if err := syscfg.EnsureWritten(t.res.Cfg,
@@ -312,7 +310,7 @@ func (t *TargetBuilder) buildLoader() error {
 	/* rebuild the loader */
 	project.ResetDeps(t.LoaderList)
 
-	if err := t.bspPkg.Reload(t.LoaderBuilder.cfg.Features()); err != nil {
+	if err := t.bspPkg.Reload(t.LoaderBuilder.cfg.SettingValues()); err != nil {
 		return err
 	}
 
@@ -357,7 +355,7 @@ func (t *TargetBuilder) Build() error {
 	/* Build the Apps */
 	project.ResetDeps(t.AppList)
 
-	if err := t.bspPkg.Reload(t.AppBuilder.cfg.Features()); err != nil {
+	if err := t.bspPkg.Reload(t.AppBuilder.cfg.SettingValues()); err != nil {
 		return err
 	}
 
@@ -572,7 +570,8 @@ func (t *TargetBuilder) createManifest() error {
 	for _, k := range keys {
 		manifest.TgtVars = append(manifest.TgtVars, k+"="+vars[k])
 	}
-	syscfgKV := t.GetTarget().Package().SyscfgV.GetStringMapString("syscfg.vals")
+	syscfgKV := t.GetTarget().Package().SyscfgY.GetValStringMapString(
+		"syscfg.vals", nil)
 	if len(syscfgKV) > 0 {
 		tgtSyscfg := fmt.Sprintf("target.syscfg=%s",
 			syscfg.KeyValueToStr(syscfgKV))
@@ -793,7 +792,7 @@ func (t *TargetBuilder) CreateImages(version string,
 			t.LoaderBuilder.AppHexPath(),
 			tgtArea.Offset)
 		err = c.ConvertBinToHex(t.LoaderBuilder.AppImgPath(),
-				t.LoaderBuilder.AppHexPath(), tgtArea.Offset)
+			t.LoaderBuilder.AppHexPath(), tgtArea.Offset)
 		if err != nil {
 			log.Errorf("Can't convert to hexfile %s\n", err.Error())
 		}
@@ -807,7 +806,7 @@ func (t *TargetBuilder) CreateImages(version string,
 	flashTargetArea := ""
 	if t.LoaderBuilder == nil {
 		flashTargetArea = flash.FLASH_AREA_NAME_IMAGE_0
-	} else  {
+	} else {
 		flashTargetArea = flash.FLASH_AREA_NAME_IMAGE_1
 	}
 	tgtArea := t.bspPkg.FlashMap.Areas[flashTargetArea]
@@ -817,7 +816,7 @@ func (t *TargetBuilder) CreateImages(version string,
 			t.AppBuilder.AppHexPath(),
 			tgtArea.Offset)
 		err = c.ConvertBinToHex(t.AppBuilder.AppImgPath(),
-				t.AppBuilder.AppHexPath(), tgtArea.Offset)
+			t.AppBuilder.AppHexPath(), tgtArea.Offset)
 		if err != nil {
 			log.Errorf("Can't convert to hexfile %s\n", err.Error())
 		}

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -25,6 +25,7 @@ import (
 
 	"mynewt.apache.org/newt/newt/image"
 	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/parse"
 	"mynewt.apache.org/newt/util"
 )
 
@@ -72,9 +73,11 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 			if err != nil {
 				NewtUsage(nil, err)
 			}
-			features := res.Cfg.Features()
+			settings := res.Cfg.SettingValues()
 
-			if !features["BOOT_LOADER"] && !features["BSP_SIMULATED"] {
+			if !parse.ValueIsTrue(settings["BOOT_LOADER"]) &&
+				!parse.ValueIsTrue(settings["BSP_SIMULATED"]) {
+
 				version = "0"
 				fmt.Println("Enter image version(default 0):")
 				fmt.Scanf("%s\n", &version)

--- a/newt/cli/vars.go
+++ b/newt/cli/vars.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"mynewt.apache.org/newt/newt/interfaces"
+	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/pkg"
 	"mynewt.apache.org/newt/newt/project"
 	"mynewt.apache.org/newt/util"
@@ -57,7 +58,7 @@ func settingValues(settingName string) ([]string, error) {
 	packs := project.GetProject().PackagesOfType(-1)
 	for _, pack := range packs {
 		settings :=
-			pack.(*pkg.LocalPackage).PkgV.GetStringSlice(settingName)
+			pack.(*pkg.LocalPackage).PkgY.GetValStringSlice(settingName, nil)
 
 		for _, setting := range settings {
 			settingMap[setting] = struct{}{}
@@ -78,7 +79,7 @@ func buildProfileValues() ([]string, error) {
 
 	packs := project.GetProject().PackagesOfType(pkg.PACKAGE_TYPE_COMPILER)
 	for _, pack := range packs {
-		v, err := util.ReadConfig(pack.(*pkg.LocalPackage).BasePath(),
+		v, err := newtutil.ReadConfig(pack.(*pkg.LocalPackage).BasePath(),
 			"compiler")
 		if err != nil {
 			return nil, err

--- a/newt/compat/compat.go
+++ b/newt/compat/compat.go
@@ -27,8 +27,8 @@ import (
 	"github.com/spf13/cast"
 
 	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
-	"mynewt.apache.org/newt/viper"
 )
 
 type NewtCompatCode int
@@ -104,9 +104,9 @@ func ParseNcTable(strMap map[string]string) (NewtCompatTable, error) {
 	return tbl, nil
 }
 
-func ReadNcMap(v *viper.Viper) (NewtCompatMap, error) {
+func ReadNcMap(yc ycfg.YCfg) (NewtCompatMap, error) {
 	mp := NewtCompatMap{}
-	ncMap := v.GetStringMap("repo.newt_compatibility")
+	ncMap := yc.GetValStringMap("repo.newt_compatibility", nil)
 
 	for k, v := range ncMap {
 		repoVer, err := newtutil.ParseVersion(k)

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -695,8 +695,8 @@ func LoadDownloader(repoName string, repoVars map[string]string) (
 
 		// Alternatively, the user can put security material in
 		// $HOME/.newt/repos.yml.
-		newtrc := newtutil.Newtrc()
-		privRepo := newtrc.GetStringMapString("repository." + repoName)
+		newtrc := settings.Newtrc()
+		privRepo := newtrc.GetValStringMapString("repository."+repoName, nil)
 		if privRepo != nil {
 			if gd.Login == "" {
 				gd.Login = privRepo["login"]

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/settings"
 	"mynewt.apache.org/newt/util"
 )
 

--- a/newt/mfg/load.go
+++ b/newt/mfg/load.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/spf13/cast"
 
+	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/pkg"
 	"mynewt.apache.org/newt/newt/project"
 	"mynewt.apache.org/newt/newt/target"
@@ -220,7 +221,7 @@ func (mi *MfgImage) detectOverlaps() error {
 }
 
 func Load(basePkg *pkg.LocalPackage) (*MfgImage, error) {
-	v, err := util.ReadConfig(basePkg.BasePath(),
+	v, err := newtutil.ReadConfig(basePkg.BasePath(),
 		strings.TrimSuffix(MFG_YAML_FILENAME, ".yml"))
 	if err != nil {
 		return nil, err
@@ -230,7 +231,7 @@ func Load(basePkg *pkg.LocalPackage) (*MfgImage, error) {
 		basePkg: basePkg,
 	}
 
-	bootName := v.GetString("mfg.bootloader")
+	bootName := v.GetValString("mfg.bootloader", nil)
 	if bootName == "" {
 		return nil, mi.loadError("mfg.bootloader field required")
 	}
@@ -239,7 +240,7 @@ func Load(basePkg *pkg.LocalPackage) (*MfgImage, error) {
 		return nil, err
 	}
 
-	imgNames := v.GetStringSlice("mfg.images")
+	imgNames := v.GetValStringSlice("mfg.images", nil)
 	if imgNames != nil {
 		for _, imgName := range imgNames {
 			imgTarget, err := mi.loadTarget(imgName)
@@ -256,7 +257,7 @@ func Load(basePkg *pkg.LocalPackage) (*MfgImage, error) {
 			len(mi.images))
 	}
 
-	itf := v.Get("mfg.raw")
+	itf := v.GetFirstVal("mfg.raw", nil)
 	slice := cast.ToSlice(itf)
 	if slice != nil {
 		for i, entryItf := range slice {
@@ -289,7 +290,7 @@ func Load(basePkg *pkg.LocalPackage) (*MfgImage, error) {
 		return nil, mi.loadError(err.Error())
 	}
 	mi.compiler, err = toolchain.NewCompiler(compilerPkg.BasePath(), "",
-							target.DEFAULT_BUILD_PROFILE)
+		target.DEFAULT_BUILD_PROFILE)
 	if err != nil {
 		return nil, mi.loadError(err.Error())
 	}

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -22,8 +22,6 @@ package newtutil
 import (
 	"fmt"
 	"io/ioutil"
-	"os/user"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -40,9 +38,6 @@ var NewtVersionStr string = "Apache Newt version: 1.3.0"
 var NewtBlinkyTag string = "mynewt_1_3_0_tag"
 var NewtNumJobs int
 var NewtForce bool
-
-const NEWTRC_DIR string = ".newt"
-const REPOS_FILENAME string = "repos.yml"
 
 const CORE_REPO_NAME string = "apache-mynewt-core"
 const ARDUINO_ZERO_REPO_NAME string = "mynewt_arduino_zero"
@@ -100,34 +95,6 @@ func VerCmp(v1 Version, v2 Version) int64 {
 	}
 
 	return 0
-}
-
-// Contains general newt settings read from $HOME/.newt
-var newtrc *viper.Viper
-
-func readNewtrc() *viper.Viper {
-	usr, err := user.Current()
-	if err != nil {
-		return viper.New()
-	}
-
-	dir := usr.HomeDir + "/" + NEWTRC_DIR
-	v, err := util.ReadConfig(dir, strings.TrimSuffix(REPOS_FILENAME, ".yml"))
-	if err != nil {
-		log.Debugf("Failed to read %s/%s file", dir, REPOS_FILENAME)
-		return viper.New()
-	}
-
-	return v
-}
-
-func Newtrc() *viper.Viper {
-	if newtrc != nil {
-		return newtrc
-	}
-
-	newtrc = readNewtrc()
-	return newtrc
 }
 
 func GetSliceFeatures(v *viper.Viper, features map[string]bool,

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -22,15 +22,14 @@ package newtutil
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/spf13/cast"
-
 	"mynewt.apache.org/newt/newt/interfaces"
+	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
-	"mynewt.apache.org/newt/viper"
+	"mynewt.apache.org/newt/yaml"
 )
 
 var NewtVersion Version = Version{1, 3, 0}
@@ -95,115 +94,6 @@ func VerCmp(v1 Version, v2 Version) int64 {
 	}
 
 	return 0
-}
-
-func GetSliceFeatures(v *viper.Viper, features map[string]bool,
-	key string) []interface{} {
-
-	val := v.Get(key)
-	vals := []interface{}{val}
-
-	// Process the features in alphabetical order to ensure consistent
-	// results across repeated runs.
-	featureKeys := make([]string, 0, len(features))
-	for feature, _ := range features {
-		featureKeys = append(featureKeys, feature)
-	}
-	sort.Strings(featureKeys)
-
-	for _, feature := range featureKeys {
-		overwriteVal := v.Get(key + "." + feature + ".OVERWRITE")
-		if overwriteVal != nil {
-			return []interface{}{overwriteVal}
-		}
-
-		appendVal := v.Get(key + "." + feature)
-		if appendVal != nil {
-			vals = append(vals, appendVal)
-		}
-	}
-
-	return vals
-}
-
-func GetStringMapFeatures(v *viper.Viper, features map[string]bool,
-	key string) map[string]interface{} {
-
-	result := map[string]interface{}{}
-
-	slice := GetSliceFeatures(v, features, key)
-	for _, itf := range slice {
-		sub := cast.ToStringMap(itf)
-		for k, v := range sub {
-			result[k] = v
-		}
-	}
-
-	return result
-}
-
-func GetStringFeatures(v *viper.Viper, features map[string]bool,
-	key string) string {
-	val := v.GetString(key)
-
-	// Process the features in alphabetical order to ensure consistent
-	// results across repeated runs.
-	var featureKeys []string
-	for feature, _ := range features {
-		featureKeys = append(featureKeys, feature)
-	}
-	sort.Strings(featureKeys)
-
-	for _, feature := range featureKeys {
-		overwriteVal := v.GetString(key + "." + feature + ".OVERWRITE")
-		if overwriteVal != "" {
-			val = strings.Trim(overwriteVal, "\n")
-			break
-		}
-
-		appendVal := v.GetString(key + "." + feature)
-		if appendVal != "" {
-			val += " " + strings.Trim(appendVal, "\n")
-		}
-	}
-	return strings.TrimSpace(val)
-}
-
-func GetBoolFeaturesDflt(v *viper.Viper, features map[string]bool,
-	key string, dflt bool) (bool, error) {
-
-	s := GetStringFeatures(v, features, key)
-	if s == "" {
-		return dflt, nil
-	}
-
-	b, err := strconv.ParseBool(s)
-	if err != nil {
-		return dflt, util.FmtNewtError("invalid bool value for %s: %s",
-			key, s)
-	}
-
-	return b, nil
-}
-
-func GetBoolFeatures(v *viper.Viper, features map[string]bool,
-	key string) (bool, error) {
-
-	return GetBoolFeaturesDflt(v, features, key, false)
-}
-
-func GetStringSliceFeatures(v *viper.Viper, features map[string]bool,
-	key string) []string {
-
-	vals := GetSliceFeatures(v, features, key)
-
-	strVals := []string{}
-	for _, v := range vals {
-		subVals := cast.ToStringSlice(v)
-		strVals = append(strVals, subVals...)
-	}
-
-	return strVals
 }
 
 // Parses a string of the following form:
@@ -283,4 +173,21 @@ func MakeTempRepoDir() (string, error) {
 	}
 
 	return tmpdir, nil
+}
+
+// Read in the configuration file specified by name, in path
+// return a new viper config object if successful, and error if not
+func ReadConfig(path string, name string) (ycfg.YCfg, error) {
+	file, err := ioutil.ReadFile(path + "/" + name + ".yml")
+	if err != nil {
+		return nil, util.NewNewtError(fmt.Sprintf("Error reading %s.yml: %s",
+			filepath.Join(path, name), err.Error()))
+	}
+
+	settings := map[string]interface{}{}
+	if err := yaml.Unmarshal(file, &settings); err != nil {
+		return nil, err
+	}
+
+	return ycfg.NewYCfg(settings)
 }

--- a/newt/parse/lex.go
+++ b/newt/parse/lex.go
@@ -1,0 +1,175 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"mynewt.apache.org/newt/util"
+)
+
+type TokenCode int
+
+const (
+	TOKEN_NOT_EQUALS TokenCode = iota
+	TOKEN_NOT
+	TOKEN_EQUALS
+	TOKEN_AND
+	TOKEN_OR
+	TOKEN_XOR
+	TOKEN_LPAREN
+	TOKEN_RPAREN
+	TOKEN_STRING
+	TOKEN_NUMBER
+	TOKEN_IDENT
+)
+
+type Token struct {
+	Code   TokenCode
+	Text   string
+	Offset int
+}
+
+// Returns length of token on success; 0 if no match.
+type LexFn func(s string) (string, int, error)
+
+const delimChars = "!='\"&|^() \t\n"
+
+func lexString(s string, sought string) (string, int, error) {
+	if strings.HasPrefix(s, sought) {
+		return sought, len(sought), nil
+	}
+
+	return "", 0, nil
+}
+
+func lexStringFn(sought string) LexFn {
+	return func(s string) (string, int, error) { return lexString(s, sought) }
+}
+
+func lexLitNumber(s string) (string, int, error) {
+	var sub string
+	idx := strings.IndexAny(s, delimChars)
+	if idx == -1 {
+		sub = s
+	} else {
+		sub = s[:idx]
+	}
+	if _, ok := util.AtoiNoOctTry(sub); ok {
+		return sub, len(sub), nil
+	}
+
+	return "", 0, nil
+}
+
+func lexLitString(s string) (string, int, error) {
+	if s[0] != '"' {
+		return "", 0, nil
+	}
+
+	quote2 := strings.IndexByte(s[1:], '"')
+	if quote2 == -1 {
+		return "", 0, fmt.Errorf("unterminated quote: %s", s)
+	}
+
+	return s[1 : quote2+1], quote2 + 2, nil
+}
+
+func lexIdent(s string) (string, int, error) {
+	idx := strings.IndexAny(s, delimChars)
+	if idx == -1 {
+		return s, len(s), nil
+	} else {
+		return s[:idx], idx, nil
+	}
+}
+
+type lexEntry struct {
+	code TokenCode
+	fn   LexFn
+}
+
+var lexEntries = []lexEntry{
+	{TOKEN_NOT_EQUALS, lexStringFn("!=")},
+	{TOKEN_NOT, lexStringFn("!")},
+	{TOKEN_EQUALS, lexStringFn("==")},
+	{TOKEN_AND, lexStringFn("&&")},
+	{TOKEN_OR, lexStringFn("||")},
+	{TOKEN_XOR, lexStringFn("^^")},
+	{TOKEN_LPAREN, lexStringFn("(")},
+	{TOKEN_RPAREN, lexStringFn(")")},
+	{TOKEN_STRING, lexLitString},
+	{TOKEN_NUMBER, lexLitNumber},
+	{TOKEN_IDENT, lexIdent},
+}
+
+func lexOneToken(expr string, offset int) (Token, int, error) {
+	var t Token
+
+	subexpr := expr[offset:]
+	for _, e := range lexEntries {
+		text, sz, err := e.fn(subexpr)
+		if err != nil {
+			return t, 0, err
+		}
+
+		if sz != 0 {
+			t.Code = e.code
+			t.Text = text
+			t.Offset = offset
+			return t, sz, nil
+		}
+	}
+
+	return t, 0, nil
+}
+
+func skipSpaceLeft(s string, offset int) int {
+	sub := s[offset:]
+	newSub := strings.TrimLeft(sub, " \t\n'")
+	return len(sub) - len(newSub)
+}
+
+// Tokenizes a string.
+func Lex(expr string) ([]Token, error) {
+	tokens := []Token{}
+	off := 0
+
+	off += skipSpaceLeft(expr, off)
+	for off < len(expr) {
+		t, skip, err := lexOneToken(expr, off)
+		if err != nil {
+			return nil, err
+		}
+
+		if skip == 0 {
+			return nil, fmt.Errorf("Invalid token starting with: %s", expr)
+		}
+
+		tokens = append(tokens, t)
+
+		off += skip
+		off += skipSpaceLeft(expr, off)
+	}
+
+	return tokens, nil
+}
+
+// Produces a string representation of a token sequence.
+func SprintfTokens(tokens []Token) string {
+	s := ""
+
+	for _, t := range tokens {
+		switch t.Code {
+		case TOKEN_NUMBER:
+			s += fmt.Sprintf("#[%s] ", t.Text)
+		case TOKEN_IDENT:
+			s += fmt.Sprintf("i[%s] ", t.Text)
+		case TOKEN_STRING:
+			s += fmt.Sprintf("\"%s\" ", t.Text)
+		default:
+			s += fmt.Sprintf("%s ", t.Text)
+		}
+	}
+
+	return s
+}

--- a/newt/parse/parse.go
+++ b/newt/parse/parse.go
@@ -1,0 +1,467 @@
+package parse
+
+import (
+	"fmt"
+
+	"mynewt.apache.org/newt/util"
+)
+
+// expr     ::= <unary><expr> | "("<expr>")"
+//              <expr><binary><expr> | <ident> | <literal>
+// ident    ::= <printable-char> { <printable-char> }
+// literal  ::= """ <printable-char> { <printable-char> } """
+// unary    ::= "!"
+// binary   ::= "=" | "!=" | "&" | "|" | "^"
+
+type ParseCode int
+
+const (
+	PARSE_NOT_EQUALS ParseCode = iota
+	PARSE_NOT
+	PARSE_EQUALS
+	PARSE_AND
+	PARSE_OR
+	PARSE_XOR
+	PARSE_NUMBER
+	PARSE_STRING
+	PARSE_IDENT
+)
+
+type Node struct {
+	Code ParseCode
+	Data string
+
+	Left  *Node
+	Right *Node
+}
+
+func (n *Node) String() string {
+	s := fmt.Sprintf("<%s>", n.Data)
+	if n.Left != nil {
+		s += " " + n.Left.String()
+	}
+	if n.Right != nil {
+		s += " " + n.Right.String()
+	}
+
+	return s
+}
+
+// Searches a tokenized expression.  The location of the first token that
+// matches a member of the supplied token set is returned.  This function does
+// not descend into parenthesized expressions.
+func findAnyToken(tokens []Token, any []TokenCode) (int, error) {
+	pcount := 0
+
+	for _, a := range any {
+		for i, t := range tokens {
+			if t.Code == TOKEN_LPAREN {
+				pcount++
+			} else if t.Code == TOKEN_RPAREN {
+				pcount--
+				if pcount < 0 {
+					return -1, fmt.Errorf("imbalanced parenthesis")
+				}
+			} else if pcount == 0 && t.Code == a {
+				return i, nil
+			}
+		}
+
+	}
+	return -1, nil
+}
+
+func binTokenToParse(t TokenCode) ParseCode {
+	return map[TokenCode]ParseCode{
+		TOKEN_NOT_EQUALS: PARSE_NOT_EQUALS,
+		TOKEN_EQUALS:     PARSE_EQUALS,
+		TOKEN_AND:        PARSE_AND,
+		TOKEN_OR:         PARSE_OR,
+		TOKEN_XOR:        PARSE_XOR,
+	}[t]
+}
+
+// Removes the outer layer of parentheses from a tokenized expression.
+func stripParens(tokens []Token) ([]Token, error) {
+	if tokens[0].Code != TOKEN_LPAREN {
+		panic("internal error: stripParens() received unparenthesized string")
+	}
+
+	pcount := 1
+	for i := 1; i < len(tokens); i++ {
+		switch tokens[i].Code {
+		case TOKEN_LPAREN:
+			pcount++
+
+		case TOKEN_RPAREN:
+			pcount--
+			if pcount == 0 {
+				return tokens[1:i], nil
+			}
+
+		default:
+		}
+	}
+
+	return nil, fmt.Errorf("unterminated parenthesis")
+}
+
+var binaryTokens = []TokenCode{
+	TOKEN_EQUALS,
+	TOKEN_NOT_EQUALS,
+	TOKEN_OR,
+	TOKEN_XOR,
+	TOKEN_AND,
+}
+
+func FindBinaryToken(tokens []Token) int {
+	binIdx, err := findAnyToken(tokens, binaryTokens)
+	if err != nil {
+		return -1
+	}
+	return binIdx
+}
+
+// Recursively parses a tokenized expression.
+//
+// @param tokens                The sequence of tokens representing the
+//                                  expression to parse.  This is acquired by a
+//                                  call to `Lex()`.
+//
+// @return *Node                The expression parse tree.
+func Parse(tokens []Token) (*Node, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	////// Terminal symbols.
+
+	if len(tokens) == 1 {
+		switch tokens[0].Code {
+		case TOKEN_NUMBER:
+			return &Node{
+				Code: PARSE_NUMBER,
+				Data: tokens[0].Text,
+			}, nil
+
+		case TOKEN_STRING:
+			return &Node{
+				Code: PARSE_STRING,
+				Data: tokens[0].Text,
+			}, nil
+
+		case TOKEN_IDENT:
+			return &Node{
+				Code: PARSE_IDENT,
+				Data: tokens[0].Text,
+			}, nil
+
+		default:
+			return nil, fmt.Errorf("invalid expression: %s", tokens[0].Text)
+		}
+	}
+
+	////// Nonterminal symbols.
+
+	// <expr><binary><expr>
+	binIdx, err := findAnyToken(tokens, binaryTokens)
+	if err != nil {
+		return nil, err
+	}
+	if binIdx == 0 || binIdx == len(tokens)-1 {
+		return nil, fmt.Errorf("binary operator %s at start or end",
+			tokens[binIdx].Text)
+	}
+	if binIdx != -1 {
+		n := &Node{
+			Code: binTokenToParse(tokens[binIdx].Code),
+			Data: tokens[binIdx].Text,
+		}
+
+		l, err := Parse(tokens[0:binIdx])
+		if err != nil {
+			return nil, err
+		}
+
+		r, err := Parse(tokens[binIdx+1 : len(tokens)])
+		if err != nil {
+			return nil, err
+		}
+
+		n.Left = l
+		n.Right = r
+
+		return n, nil
+	}
+
+	// <unary><expr>
+	if tokens[0].Code == TOKEN_NOT {
+		n := &Node{
+			Code: PARSE_NOT,
+			Data: tokens[0].Text,
+		}
+		r, err := Parse(tokens[1:])
+		if err != nil {
+			return nil, err
+		}
+		n.Right = r
+		return n, nil
+	}
+
+	// "("<expr>")"
+	if tokens[0].Code == TOKEN_LPAREN {
+		stripped, err := stripParens(tokens)
+		if err != nil {
+			return nil, err
+		}
+
+		return Parse(stripped)
+	}
+
+	return nil, fmt.Errorf("invalid expression")
+}
+
+// Evaluates two expressions into boolean values.
+func evalTwo(expr1 *Node, expr2 *Node,
+	settings map[string]string) (bool, bool, error) {
+
+	v1, err := Eval(expr1, settings)
+	if err != nil {
+		return false, false, err
+	}
+	v2, err := Eval(expr2, settings)
+	if err != nil {
+		return false, false, err
+	}
+
+	return v1, v2, nil
+}
+
+type equalsFn func(left *Node, right *Node, settings map[string]string) bool
+type equalsEntry struct {
+	LeftCode  ParseCode
+	RightCode ParseCode
+	Fn        equalsFn
+}
+
+var equalsDispatch = []equalsEntry{
+	// <ident1> == <ident2>
+	// True if both syscfg settings have identical text values.
+	equalsEntry{
+		LeftCode:  PARSE_IDENT,
+		RightCode: PARSE_IDENT,
+		Fn: func(left *Node, right *Node, settings map[string]string) bool {
+			return settings[left.Data] == settings[right.Data]
+		},
+	},
+
+	// <ident> == <number>
+	// True if the syscfg setting's value is a valid representation of the
+	// number on the right.
+	equalsEntry{
+		LeftCode:  PARSE_IDENT,
+		RightCode: PARSE_NUMBER,
+		Fn: func(left *Node, right *Node, settings map[string]string) bool {
+			lnum, ok := util.AtoiNoOctTry(settings[left.Data])
+			if !ok {
+				return false
+			}
+			rnum, ok := util.AtoiNoOctTry(right.Data)
+			if !ok {
+				return false
+			}
+			return lnum == rnum
+		},
+	},
+
+	// <ident> == <string>
+	// True if the syscfg setting's text value is identical to the string on
+	// the right.
+	equalsEntry{
+		LeftCode:  PARSE_IDENT,
+		RightCode: PARSE_STRING,
+		Fn: func(left *Node, right *Node, settings map[string]string) bool {
+			return settings[left.Data] == right.Data
+		},
+	},
+
+	// <number1> == <number2>
+	// True if both numbers have the same value.
+	equalsEntry{
+		LeftCode:  PARSE_NUMBER,
+		RightCode: PARSE_NUMBER,
+		Fn: func(left *Node, right *Node, settings map[string]string) bool {
+			lnum, ok := util.AtoiNoOctTry(left.Data)
+			if !ok {
+				return false
+			}
+			rnum, ok := util.AtoiNoOctTry(right.Data)
+			if !ok {
+				return false
+			}
+			return lnum == rnum
+		},
+	},
+
+	// <number> == <string>
+	// True if the string is a valid representation of the number.
+	equalsEntry{
+		LeftCode:  PARSE_NUMBER,
+		RightCode: PARSE_STRING,
+		Fn: func(left *Node, right *Node, settings map[string]string) bool {
+			return left.Data == right.Data
+		},
+	},
+
+	// <string1> == <string2>
+	// True if both strings are identical (case-sensitive).
+	equalsEntry{
+		LeftCode:  PARSE_STRING,
+		RightCode: PARSE_STRING,
+		Fn: func(left *Node, right *Node, settings map[string]string) bool {
+			return left.Data == right.Data
+		},
+	},
+}
+
+func evalEqualsOnce(
+	left *Node, right *Node, settings map[string]string) (bool, bool) {
+
+	for _, entry := range equalsDispatch {
+		if entry.LeftCode == left.Code && entry.RightCode == right.Code {
+			return entry.Fn(left, right, settings), true
+		}
+	}
+
+	return false, false
+}
+
+// Evaluates an equals expression (`x == y`)
+//
+// @param left                  The fully-parsed left operand.
+// @param left                  The fully-parsed right operand.
+// @param settings              The map of syscfg settings.
+//
+// @return bool                 Whether the expression evaluates to true.
+func evalEquals(
+	left *Node, right *Node, settings map[string]string) (bool, error) {
+
+	// The equals operator has special semantics.  Rather than evaluating both
+	// operands as booleans and then comparing, the behavior of this operator
+	// varies based on the types of operands.  Perform a table lookup using the
+	// operand types, and call the appropriate comparison function if a match
+	// is found.
+	val, ok := evalEqualsOnce(left, right, settings)
+	if ok {
+		return val, nil
+	}
+	val, ok = evalEqualsOnce(right, left, settings)
+	if ok {
+		return val, nil
+	}
+
+	// No special procedure identified.  Fallback to evaluating both operands
+	// as booleans and comparing the results.
+	booll, boolr, err := evalTwo(left, right, settings)
+	if err != nil {
+		return false, err
+	}
+	return booll == boolr, nil
+}
+
+// Evaluates a fully-parsed expression.
+//
+// @param node                  The root of the expression to evaluate.
+// @param settings              The map of syscfg settings.
+//
+// @return bool                 Whether the expression evaluates to true.
+func Eval(expr *Node, settings map[string]string) (bool, error) {
+	switch expr.Code {
+	case PARSE_NOT:
+		r, err := Eval(expr.Right, settings)
+		if err != nil {
+			return false, err
+		}
+		return !r, nil
+
+	case PARSE_EQUALS:
+		return evalEquals(expr.Left, expr.Right, settings)
+
+	case PARSE_NOT_EQUALS:
+		v, err := evalEquals(expr.Left, expr.Right, settings)
+		if err != nil {
+			return false, err
+		}
+		return !v, nil
+
+	case PARSE_AND:
+		l, r, err := evalTwo(expr.Left, expr.Right, settings)
+		if err != nil {
+			return false, err
+		}
+		return l && r, nil
+
+	case PARSE_OR:
+		l, r, err := evalTwo(expr.Left, expr.Right, settings)
+		if err != nil {
+			return false, err
+		}
+		return l || r, nil
+
+	case PARSE_XOR:
+		l, r, err := evalTwo(expr.Left, expr.Right, settings)
+		if err != nil {
+			return false, err
+		}
+		return (l && !r) || (!l && r), nil
+
+	case PARSE_NUMBER:
+		num, ok := util.AtoiNoOctTry(expr.Data)
+		return ok && num != 0, nil
+
+	case PARSE_STRING:
+		return ValueIsTrue(expr.Data), nil
+
+	case PARSE_IDENT:
+		val := settings[expr.Data]
+		return ValueIsTrue(val), nil
+
+	default:
+		return false, fmt.Errorf("invalid parse code: %d", expr.Code)
+	}
+}
+
+// Parses and evaluates string containing a syscfg expression.
+//
+// @param expr                  The expression to parse.
+// @param settings              The map of syscfg settings.
+//
+// @return bool                 Whether the expression evaluates to true.
+func ParseAndEval(expr string, settings map[string]string) (bool, error) {
+	tokens, err := Lex(expr)
+	if err != nil {
+		return false, err
+	}
+
+	n, err := Parse(tokens)
+	if err != nil {
+		return false, fmt.Errorf("error parsing [%s]: %s\n", expr, err.Error())
+	}
+
+	v, err := Eval(n, settings)
+	return v, err
+}
+
+// Evaluates the truthfulness of a text expression.
+func ValueIsTrue(val string) bool {
+	if val == "" {
+		return false
+	}
+
+	i, ok := util.AtoiNoOctTry(val)
+	if ok && i == 0 {
+		return false
+	}
+
+	return true
+}

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -79,7 +79,9 @@ func (bsp *BspPackage) resolveLinkerScriptSetting(
 			return nil, err
 		}
 
-		paths = append(paths, path)
+		if path != "" {
+			paths = append(paths, path)
+		}
 	} else {
 		proj := interfaces.GetProject()
 
@@ -92,7 +94,9 @@ func (bsp *BspPackage) resolveLinkerScriptSetting(
 					bsp.Name(), key)
 			}
 
-			paths = append(paths, path)
+			if path != "" {
+				paths = append(paths, path)
+			}
 		}
 	}
 

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -26,8 +26,8 @@ import (
 	"mynewt.apache.org/newt/newt/flash"
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
-	"mynewt.apache.org/newt/viper"
 )
 
 const BSP_YAML_FILENAME = "bsp.yml"
@@ -41,15 +41,15 @@ type BspPackage struct {
 	DownloadScript     string
 	DebugScript        string
 	FlashMap           flash.FlashMap
-	BspV               *viper.Viper
+	BspV               ycfg.YCfg
 }
 
 func (bsp *BspPackage) resolvePathSetting(
-	features map[string]bool, key string) (string, error) {
+	settings map[string]string, key string) (string, error) {
 
 	proj := interfaces.GetProject()
 
-	val := newtutil.GetStringFeatures(bsp.BspV, features, key)
+	val := bsp.BspV.GetValString(key, settings)
 	if val == "" {
 		return "", nil
 	}
@@ -65,16 +65,16 @@ func (bsp *BspPackage) resolvePathSetting(
 // Interprets a setting as either a single linker script or a list of linker
 // scripts.
 func (bsp *BspPackage) resolveLinkerScriptSetting(
-	features map[string]bool, key string) ([]string, error) {
+	settings map[string]string, key string) ([]string, error) {
 
 	paths := []string{}
 
 	// Assume config file specifies a list of scripts.
-	vals := newtutil.GetStringSliceFeatures(bsp.BspV, features, key)
+	vals := bsp.BspV.GetValStringSlice(key, settings)
 	if vals == nil {
 		// Couldn't read a list of scripts; try to interpret setting as a
 		// single script.
-		path, err := bsp.resolvePathSetting(features, key)
+		path, err := bsp.resolvePathSetting(settings, key)
 		if err != nil {
 			return nil, err
 		}
@@ -99,48 +99,43 @@ func (bsp *BspPackage) resolveLinkerScriptSetting(
 	return paths, nil
 }
 
-func (bsp *BspPackage) Reload(features map[string]bool) error {
+func (bsp *BspPackage) Reload(settings map[string]string) error {
 	var err error
 
-	if features == nil {
-		features = map[string]bool{
-			strings.ToUpper(runtime.GOOS): true,
-		}
-	} else {
-		features[strings.ToUpper(runtime.GOOS)] = true
+	if settings == nil {
+		settings = map[string]string{}
 	}
-	bsp.BspV, err = util.ReadConfig(bsp.BasePath(),
+	settings[strings.ToUpper(runtime.GOOS)] = "1"
+
+	bsp.BspV, err = newtutil.ReadConfig(bsp.BasePath(),
 		strings.TrimSuffix(BSP_YAML_FILENAME, ".yml"))
 	if err != nil {
 		return err
 	}
 	bsp.AddCfgFilename(bsp.BasePath() + BSP_YAML_FILENAME)
 
-	bsp.CompilerName = newtutil.GetStringFeatures(bsp.BspV,
-		features, "bsp.compiler")
-
-	bsp.Arch = newtutil.GetStringFeatures(bsp.BspV,
-		features, "bsp.arch")
+	bsp.CompilerName = bsp.BspV.GetValString("bsp.compiler", settings)
+	bsp.Arch = bsp.BspV.GetValString("bsp.arch", settings)
 
 	bsp.LinkerScripts, err = bsp.resolveLinkerScriptSetting(
-		features, "bsp.linkerscript")
+		settings, "bsp.linkerscript")
 	if err != nil {
 		return err
 	}
 
 	bsp.Part2LinkerScripts, err = bsp.resolveLinkerScriptSetting(
-		features, "bsp.part2linkerscript")
+		settings, "bsp.part2linkerscript")
 	if err != nil {
 		return err
 	}
 
 	bsp.DownloadScript, err = bsp.resolvePathSetting(
-		features, "bsp.downloadscript")
+		settings, "bsp.downloadscript")
 	if err != nil {
 		return err
 	}
 	bsp.DebugScript, err = bsp.resolvePathSetting(
-		features, "bsp.debugscript")
+		settings, "bsp.debugscript")
 	if err != nil {
 		return err
 	}
@@ -154,8 +149,7 @@ func (bsp *BspPackage) Reload(features map[string]bool) error {
 			"(bsp.arch)")
 	}
 
-	ymlFlashMap := newtutil.GetStringMapFeatures(bsp.BspV, features,
-		"bsp.flash_map")
+	ymlFlashMap := bsp.BspV.GetValStringMap("bsp.flash_map", settings)
 	if ymlFlashMap == nil {
 		return util.NewNewtError("BSP does not specify a flash map " +
 			"(bsp.flash_map)")
@@ -173,7 +167,7 @@ func NewBspPackage(lpkg *LocalPackage) (*BspPackage, error) {
 		CompilerName:   "",
 		DownloadScript: "",
 		DebugScript:    "",
-		BspV:           viper.New(),
+		BspV:           ycfg.YCfg{},
 	}
 	lpkg.Load()
 	bsp.LocalPackage = lpkg

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package settings
+
+import (
+	"os/user"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/ycfg"
+)
+
+const NEWTRC_DIR string = ".newt"
+const REPOS_FILENAME string = "repos.yml"
+
+// Contains general newt settings read from $HOME/.newt
+var newtrc ycfg.YCfg
+
+func readNewtrc() ycfg.YCfg {
+	usr, err := user.Current()
+	if err != nil {
+		return ycfg.YCfg{}
+	}
+
+	dir := usr.HomeDir + "/" + NEWTRC_DIR
+	yc, err := newtutil.ReadConfig(dir,
+		strings.TrimSuffix(REPOS_FILENAME, ".yml"))
+	if err != nil {
+		log.Debugf("Failed to read %s/%s file", dir, REPOS_FILENAME)
+		return ycfg.YCfg{}
+	}
+
+	return yc
+}
+
+func Newtrc() ycfg.YCfg {
+	if newtrc != nil {
+		return newtrc
+	}
+
+	newtrc = readNewtrc()
+	return newtrc
+}

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/pkg"
 	"mynewt.apache.org/newt/newt/project"
 	"mynewt.apache.org/newt/newt/repo"
@@ -73,7 +74,7 @@ func (target *Target) Init(basePkg *pkg.LocalPackage) {
 }
 
 func (target *Target) Load(basePkg *pkg.LocalPackage) error {
-	v, err := util.ReadConfig(basePkg.BasePath(),
+	yc, err := newtutil.ReadConfig(basePkg.BasePath(),
 		strings.TrimSuffix(TARGET_FILENAME, ".yml"))
 	if err != nil {
 		return err
@@ -81,8 +82,7 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 
 	target.Vars = map[string]string{}
 
-	settings := v.AllSettings()
-	for k, v := range settings {
+	for k, v := range yc.AllSettings() {
 		target.Vars[k] = fmt.Sprintf("%v", v)
 	}
 

--- a/newt/vendor/mynewt.apache.org/newt/util/util.go
+++ b/newt/vendor/mynewt.apache.org/newt/util/util.go
@@ -37,8 +37,6 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-
-	"mynewt.apache.org/newt/viper"
 )
 
 var Verbosity int
@@ -253,23 +251,6 @@ func Init(logLevel log.Level, logFile string, verbosity int) error {
 	ExecuteShell = false
 
 	return nil
-}
-
-// Read in the configuration file specified by name, in path
-// return a new viper config object if successful, and error if not
-func ReadConfig(path string, name string) (*viper.Viper, error) {
-	v := viper.New()
-	v.SetConfigType("yaml")
-	v.SetConfigName(name)
-	v.AddConfigPath(path)
-
-	err := v.ReadInConfig()
-	if err != nil {
-		return nil, NewNewtError(fmt.Sprintf("Error reading %s.yml: %s",
-			filepath.Join(path, name), err.Error()))
-	} else {
-		return v, nil
-	}
 }
 
 func LogShellCmd(cmdStrs []string, env []string) {

--- a/newt/ycfg/ycfg.go
+++ b/newt/ycfg/ycfg.go
@@ -1,0 +1,424 @@
+package ycfg
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cast"
+
+	"mynewt.apache.org/newt/newt/parse"
+)
+
+// YAML configuration object.  This is a substitute for a viper configuration
+// object, with the following newt-specific advantages:
+// 1. Case sensitive.
+// 2. Efficient conditionals based on syscfg values.
+//
+// A single YCfg setting is implemented as a tree of nodes.  Each word in the
+// setting name represents a node; each "." in the name is a link in the tree.
+// For example, the following syscfg lines:
+//
+// OS_MAIN_STACK_SIZE: 100
+// OS_MAIN_STACK_SIZE.BLE_DEVICE: 200
+// OS_MAIN_STACK_SIZE.SHELL_TASK: 300
+//
+// Is represented as the following tree:
+//
+//                      [OS_MAIN_STACK_SIZE (100)]
+//                     /                          \
+//            [BLE_DEVICE (200)]           [SHELL_TASK (300)]
+//
+// This allows us to quickly determine the value of OS_MAIN_STACK_SIZE.  After
+// finding the OS_MAIN_STACK_SIZE node, the logic is something like this:
+//
+// Is BLE_DEVICE true? --> 200
+// Is SHELL_TASK true? --> 300
+// Else: --> 100
+//
+// The tree structure also allows for arbitrary expressions as conditionals, as
+// opposed to simple setting names.  For example:
+//
+// OS_MAIN_STACK_SIZE: 100
+// OS_MAIN_STACK_SIZE.'(BLE_DEVICE && !SHELL_TASK): 200
+// OS_MAIN_STACK_SIZE.'(SHELL_TASK && !BLE_DEVICE): 300
+// OS_MAIN_STACK_SIZE.'(SHELL_TASK && BLE_DEVICE):  400
+//
+// Since each expression is a child node of the setting in question, they are
+// all known at the time of the lookup.  To determine the value of the setting,
+// each expression is parsed, and only the one evaluating to true is selected.
+type YCfg map[string]*YCfgNode
+
+type YCfgEntry struct {
+	Value interface{}
+	Expr  string
+}
+
+type YCfgNode struct {
+	Overwrite bool
+	Name      string
+	Value     interface{}
+	Children  YCfg
+	Parent    *YCfgNode
+}
+
+func (node *YCfgNode) addChild(name string) (*YCfgNode, error) {
+	if node.Children == nil {
+		node.Children = YCfg{}
+	}
+
+	if node.Children[name] != nil {
+		return nil, fmt.Errorf("Duplicate YCfgNode: %s", name)
+	}
+
+	child := &YCfgNode{
+		Name:   name,
+		Parent: node,
+	}
+	node.Children[name] = child
+
+	return child, nil
+}
+
+func (yc YCfg) Replace(key string, val interface{}) error {
+	elems := strings.Split(key, ".")
+	if len(elems) == 0 {
+		return fmt.Errorf("Invalid ycfg key: \"\"")
+	}
+
+	var overwrite bool
+	if elems[len(elems)-1] == "OVERWRITE" {
+		overwrite = true
+		elems = elems[:len(elems)-1]
+	}
+
+	var parent *YCfgNode
+	for i, e := range elems {
+		var parentChildren YCfg
+		if parent == nil {
+			parentChildren = yc
+		} else {
+			if parent.Children == nil {
+				parent.Children = YCfg{}
+			}
+			parentChildren = parent.Children
+		}
+		child := parentChildren[e]
+		if child == nil {
+			var err error
+			if parent != nil {
+				child, err = parent.addChild(e)
+				if err != nil {
+					return err
+				}
+			} else {
+				child = &YCfgNode{Name: e}
+				parentChildren[e] = child
+			}
+		}
+
+		if i == len(elems)-1 {
+			child.Overwrite = overwrite
+			child.Value = val
+		}
+
+		parent = child
+	}
+
+	return nil
+}
+
+func NewYCfg(kv map[string]interface{}) (YCfg, error) {
+	yc := YCfg{}
+
+	for k, v := range kv {
+		if err := yc.Replace(k, v); err != nil {
+			return nil, err
+		}
+	}
+
+	return yc, nil
+}
+
+func (yc YCfg) find(key string) *YCfgNode {
+	elems := strings.Split(key, ".")
+	if len(elems) == 0 {
+		return nil
+	}
+
+	cur := &YCfgNode{
+		Children: yc,
+	}
+	for _, e := range elems {
+		if cur.Children == nil {
+			return nil
+		}
+
+		cur = cur.Children[e]
+		if cur == nil {
+			return nil
+		}
+	}
+
+	return cur
+}
+
+func (yc YCfg) Get(key string, settings map[string]string) []YCfgEntry {
+	node := yc.find(key)
+	if node == nil {
+		return nil
+	}
+
+	entries := []YCfgEntry{}
+
+	if node.Value != nil {
+		entry := YCfgEntry{Value: node.Value}
+		entries = append(entries, entry)
+	}
+
+	for _, child := range node.Children {
+		val, err := parse.ParseAndEval(child.Name, settings)
+		if err != nil {
+			log.Error(err.Error())
+		} else if val {
+			entry := YCfgEntry{
+				Value: child.Value,
+				Expr:  child.Name,
+			}
+			if child.Overwrite {
+				return []YCfgEntry{entry}
+			}
+
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}
+
+func (yc YCfg) GetSlice(key string, settings map[string]string) []YCfgEntry {
+	sliceEntries := yc.Get(key, settings)
+	if len(sliceEntries) == 0 {
+		return nil
+	}
+
+	result := []YCfgEntry{}
+	for _, sliceEntry := range sliceEntries {
+		if sliceEntry.Value != nil {
+			slice, err := cast.ToSliceE(sliceEntry.Value)
+			if err != nil {
+				// Not a slice.  Put the single value in a new slice.
+				slice = []interface{}{sliceEntry.Value}
+			}
+			for _, v := range slice {
+				entry := YCfgEntry{
+					Value: v,
+					Expr:  sliceEntry.Expr,
+				}
+				result = append(result, entry)
+			}
+		}
+	}
+
+	return result
+}
+
+func (yc YCfg) GetStringMap(
+	key string, settings map[string]string) map[string]YCfgEntry {
+
+	mapEntries := yc.Get(key, settings)
+	if len(mapEntries) == 0 {
+		return nil
+	}
+
+	result := map[string]YCfgEntry{}
+
+	for _, mapEntry := range mapEntries {
+		for k, v := range cast.ToStringMap(mapEntry.Value) {
+			entry := YCfgEntry{
+				Value: v,
+				Expr:  mapEntry.Expr,
+			}
+
+			// XXX: Report collisions?
+			result[k] = entry
+		}
+	}
+
+	return result
+}
+
+func (yc YCfg) GetValStringMap(
+	key string, settings map[string]string) map[string]interface{} {
+
+	entryMap := yc.GetStringMap(key, settings)
+
+	smap := make(map[string]interface{}, len(entryMap))
+	for k, v := range entryMap {
+		if v.Value != nil {
+			smap[k] = v.Value
+		}
+	}
+
+	return smap
+}
+
+func (yc YCfg) GetFirst(key string, settings map[string]string) (YCfgEntry, bool) {
+	entries := yc.Get(key, settings)
+	if len(entries) == 0 {
+		return YCfgEntry{}, false
+	}
+
+	return entries[0], true
+}
+
+func (yc YCfg) GetFirstVal(key string, settings map[string]string) interface{} {
+	entry, ok := yc.GetFirst(key, settings)
+	if !ok {
+		return nil
+	}
+
+	return entry.Value
+}
+
+func (yc YCfg) GetValString(key string, settings map[string]string) string {
+	entry, ok := yc.GetFirst(key, settings)
+	if !ok {
+		return ""
+	} else {
+		return cast.ToString(entry.Value)
+	}
+}
+
+func (yc YCfg) GetValInt(key string, settings map[string]string) int {
+	entry, ok := yc.GetFirst(key, settings)
+	if !ok {
+		return 0
+	} else {
+		return cast.ToInt(entry.Value)
+	}
+}
+
+func (yc YCfg) GetValBoolDflt(key string, settings map[string]string,
+	dflt bool) bool {
+
+	entry, ok := yc.GetFirst(key, settings)
+	if !ok {
+		return dflt
+	} else {
+		return cast.ToBool(entry.Value)
+	}
+}
+
+func (yc YCfg) GetValBool(key string, settings map[string]string) bool {
+	return yc.GetValBoolDflt(key, settings, false)
+}
+
+func (yc YCfg) GetValStringSlice(
+	key string, settings map[string]string) []string {
+
+	entries := yc.GetSlice(key, settings)
+	if len(entries) == 0 {
+		return nil
+	}
+
+	vals := make([]string, len(entries))
+	for i, e := range entries {
+		if e.Value != nil {
+			vals[i] = cast.ToString(e.Value)
+		}
+	}
+
+	return vals
+}
+
+func (yc YCfg) GetValStringSliceNonempty(
+	key string, settings map[string]string) []string {
+
+	strs := yc.GetValStringSlice(key, settings)
+	filtered := make([]string, 0, len(strs))
+	for _, s := range strs {
+		if s != "" {
+			filtered = append(filtered, s)
+		}
+	}
+
+	return filtered
+}
+
+func (yc YCfg) GetValStringMapString(key string,
+	settings map[string]string) map[string]string {
+
+	entryMap := yc.GetStringMap(key, settings)
+
+	valMap := make(map[string]string, len(entryMap))
+	for k, v := range entryMap {
+		if v.Value != nil {
+			valMap[k] = cast.ToString(v.Value)
+		}
+	}
+
+	return valMap
+}
+
+func (node *YCfgNode) FullName() string {
+	tokens := []string{}
+
+	for n := node; n != nil; n = n.Parent {
+		tokens = append(tokens, n.Name)
+	}
+
+	last := len(tokens) - 1
+	for i := 0; i < len(tokens)/2; i++ {
+		tokens[i], tokens[last-i] = tokens[last-i], tokens[i]
+	}
+
+	return strings.Join(tokens, ".")
+}
+
+func (yc YCfg) Traverse(cb func(node *YCfgNode, depth int)) {
+	var traverseLevel func(
+		node *YCfgNode,
+		cb func(node *YCfgNode, depth int),
+		depth int)
+
+	traverseLevel = func(
+		node *YCfgNode,
+		cb func(node *YCfgNode, depth int),
+		depth int) {
+
+		cb(node, depth)
+		for _, child := range node.Children {
+			traverseLevel(child, cb, depth+1)
+		}
+	}
+
+	for _, n := range yc {
+		traverseLevel(n, cb, 0)
+	}
+}
+
+func (yc YCfg) AllSettings() map[string]interface{} {
+	settings := map[string]interface{}{}
+
+	yc.Traverse(func(node *YCfgNode, depth int) {
+		if node.Value != nil {
+			settings[node.FullName()] = node.Value
+		}
+	})
+
+	return settings
+}
+
+func (yc YCfg) String() string {
+	lines := make([]string, 0, len(yc))
+	yc.Traverse(func(node *YCfgNode, depth int) {
+		line := strings.Repeat(" ", depth*4) + node.Name
+		if node.Value != nil {
+			line += fmt.Sprintf(": %+v", node.Value)
+		}
+		lines = append(lines, line)
+	})
+
+	return strings.Join(lines, "\n")
+}

--- a/util/util.go
+++ b/util/util.go
@@ -37,8 +37,6 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-
-	"mynewt.apache.org/newt/viper"
 )
 
 var Verbosity int
@@ -253,23 +251,6 @@ func Init(logLevel log.Level, logFile string, verbosity int) error {
 	ExecuteShell = false
 
 	return nil
-}
-
-// Read in the configuration file specified by name, in path
-// return a new viper config object if successful, and error if not
-func ReadConfig(path string, name string) (*viper.Viper, error) {
-	v := viper.New()
-	v.SetConfigType("yaml")
-	v.SetConfigName(name)
-	v.AddConfigPath(path)
-
-	err := v.ReadInConfig()
-	if err != nil {
-		return nil, NewNewtError(fmt.Sprintf("Error reading %s.yml: %s",
-			filepath.Join(path, name), err.Error()))
-	} else {
-		return v, nil
-	}
 }
 
 func LogShellCmd(cmdStrs []string, env []string) {


### PR DESCRIPTION
This is a big PR that adds the following functionality:

* Syscfg expressions

Allow syscfg values to be conditional on arbitrary expressions, rather than just the enabled state of a single syscfg value.

For example:

    OS_MAIN_STACK_SIZE.'LOG_LEVEL >= 1 && !SHELL_TASK': 200
    OS_MAIN_STACK_SIZE: 300

BNF:
```
    expr     ::= <unary><expr> | "("<expr>")"
                <expr><binary><expr> | <ident> | <literal>
    ident    ::= <printable-char> { <printable-char> }
    literal  ::= """ <printable-char> { <printable-char> } """
    unary    ::= "!"
    binary   ::= "=" | "!=" | "&" | "|" | "^"
```

* `newt target [rev]dep` now indicates when a dependency is pulled in due to an enabled syscfg setting.  For example:
```
    sys/stats/stub <-- [net/nimble/host(api:stats) net/nimble/host/test(syscfg:SELFTEST)]
```

* Improved performance.  `target config show` for targets using nimble is about 30% faster than before.  Sorry, no measurements available on this machine, but I can add (and probably will) them soon.