### PR TITLE
Fix infinite loop

### DIFF
--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -61,7 +61,7 @@ func (bpkg *BuildPackage) collectDepsAux(b *Builder,
 		dbpkg := b.PkgMap[dep.Rpkg]
 		if dbpkg == nil {
 			return util.FmtNewtError("Package not found %s; required by %s",
-				dbpkg.rpkg.Lpkg.Name(), bpkg.rpkg.Lpkg.Name())
+				dep.Rpkg.Lpkg.Name(), bpkg.rpkg.Lpkg.Name())
 		}
 
 		if err := dbpkg.collectDepsAux(b, set); err != nil {

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -368,10 +368,10 @@ func (r *Resolver) loadDepsForPkg(rpkg *ResolvePackage) (bool, error) {
 		}
 	}
 
-	for rpkg, _ := range rpkg.Deps {
-		if _, ok := seen[rpkg]; !ok {
-			delete(rpkg.Deps, rpkg)
-			rpkg.refCount--
+	for rdep, _ := range rpkg.Deps {
+		if _, ok := seen[rdep]; !ok {
+			delete(rpkg.Deps, rdep)
+			rdep.refCount--
 			changed = true
 		}
 	}


### PR DESCRIPTION
A loop-local variable (`rpkg`) was shadowing a variable with greater scope.  This caused the code to delete entries from the wrong map.  The result was an infinite loop when a package used the .OVERWRITE flag on its `pkg.deps` field.