### PR TITLE
MYNEWT-882 Newt - Allow spaces in paths

### DIFF
--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -347,7 +347,8 @@ func (c *Compiler) includesStrings() []string {
 		return nil
 	}
 
-	includes := util.SortFields(c.info.Includes...)
+	includes := util.UniqueStrings(c.info.Includes)
+	sort.Strings(includes)
 
 	tokens := make([]string, len(includes))
 	for i, s := range includes {


### PR DESCRIPTION
Newt was interpreting each include path as a space-delimited list of directories.  If the project directory name contained a space, the path would get split into two separate paths, causing an `#include` directive to fail.

Now, newt treats each entry as a single include path.