### PR TITLE
Newt - Don't display warning on initial install.

### DIFF
--- a/newt/interfaces/interfaces.go
+++ b/newt/interfaces/interfaces.go
@@ -66,6 +66,7 @@ type ProjectInterface interface {
 	ResolvePath(basePath string, name string) (string, error)
 	PackageList() PackageList
 	FindRepoPath(rname string) string
+	RepoIsInstalled(rname string) bool
 }
 
 var globalProject ProjectInterface

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -185,6 +185,11 @@ func (proj *Project) FindRepoPath(rname string) string {
 	return r.Path()
 }
 
+// Indicates whether the specified repo is present in the `project.state` file.
+func (proj *Project) RepoIsInstalled(rname string) bool {
+	return proj.projState.GetInstalledVersion(rname) != nil
+}
+
 func (proj *Project) LocalRepo() *repo.Repo {
 	return proj.localRepo
 }

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -117,8 +117,15 @@ func (repo *Repo) FilteredSearchList(
 	path := filepath.Join(repo.Path(), curPath)
 	dirList, err := ioutil.ReadDir(path)
 	if err != nil {
-		return list, util.FmtNewtError("failed to read repo \"%s\": %s",
-			repo.Name(), err.Error())
+		// The repo could not be found in the `repos` directory.  Display a
+		// warning if the `project.state` file indicates that the repo has been
+		// installed.
+		var warning error
+		if interfaces.GetProject().RepoIsInstalled(repo.Name()) {
+			warning = util.FmtNewtError("failed to read repo \"%s\": %s",
+				repo.Name(), err.Error())
+		}
+		return list, warning
 	}
 
 	for _, dirEnt := range dirList {

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -464,7 +464,7 @@ func (r *Repo) updateRepo(branchName string) error {
 	dl := r.downloader
 	err := dl.UpdateRepo(r.Path(), branchName)
 	if err != nil {
-		return util.NewNewtError("Error updating\n")
+		return util.FmtNewtError("Error updating: %s", err.Error())
 	}
 	return nil
 }
@@ -473,7 +473,7 @@ func (r *Repo) cleanupRepo(branchName string) error {
 	dl := r.downloader
 	err := dl.CleanupRepo(r.Path(), branchName)
 	if err != nil {
-		return util.NewNewtError("Error cleaning and updating\n")
+		return util.FmtNewtError("Error cleaning and updating: %s", err.Error())
 	}
 	return nil
 }
@@ -493,14 +493,14 @@ func (r *Repo) saveLocalDiff() (string, error) {
 	f, err := os.Create(filename)
 	if err != nil {
 		return "",
-			util.FmtNewtError("Error creating repo diff file \"%s\"", filename)
+			util.FmtNewtError("Error creating repo diff file \"%s\": %s", filename, err.Error())
 	}
 	defer f.Close()
 
 	_, err = f.Write(diff)
 	if err != nil {
 		return "",
-			util.FmtNewtError("Error writing repo diff file \"%s\"", filename)
+			util.FmtNewtError("Error writing repo diff file \"%s\": %s", filename, err.Error())
 	}
 
 	return filename, nil
@@ -567,8 +567,8 @@ func (r *Repo) Sync(vers *Version, force bool) (bool, error) {
 
 	branchName, _, found := r.rdesc.MatchVersion(vers)
 	if found == false {
-		return false, util.NewNewtError(fmt.Sprintf(
-			"Branch description for %s not found", r.Name()))
+		return false, util.FmtNewtError(
+			"Branch description for %s not found", r.Name())
 	}
 
 	// Here assuming that if the branch was changed by the user,
@@ -642,7 +642,6 @@ func (r *Repo) UpdateDesc() ([]*Repo, bool, error) {
 
 	_, repos, err := r.ReadDesc()
 	if err != nil {
-		fmt.Printf("ReadDesc: %v\n", err)
 		return nil, false, err
 	}
 
@@ -717,8 +716,8 @@ func (r *Repo) readDepRepos(yc ycfg.YCfg) ([]*Repo, error) {
 	branch, _, ok := rdesc.Match(r)
 	if !ok {
 		// No matching branch, barf!
-		return nil, util.NewNewtError(fmt.Sprintf("No "+
-			"matching branch for %s repo", r.Name()))
+		return nil, util.FmtNewtError("No "+
+			"matching branch for %s repo", r.Name())
 	}
 
 	repoTag := fmt.Sprintf("%s.repositories", branch)


### PR DESCRIPTION
`newt new proj && cd proj && newt install` produced the following warning:

```
* Warning: failed to read repo "apache-mynewt-core": open /Users/ccollins/proj/repos/apache-mynewt-core: no such file or directory
```

It isn't surprising that newt failed to read the repo; it hadn't been installed yet!

Now newt only reports a failure to read a repo if the repo has been installed, i.e., if the repo is present in the `project.state` file.