### PR TITLE
MYNEWT-858 Collect all package lflags during link.

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -372,6 +372,13 @@ func (b *Builder) link(elfName string, linkerScripts []string,
 			archiveNames[i] = filepath.ToSlash(archiveName)
 		}
 		pkgNames = append(pkgNames, archiveNames...)
+
+		// Collect lflags from all constituent packages.
+		ci, err := bpkg.CompilerInfo(b)
+		if err != nil {
+			return err
+		}
+		c.AddInfo(ci)
 	}
 
 	c.LinkerScripts = linkerScripts


### PR DESCRIPTION
If you add the following to a test package:

```
pkg.lflags:
    - "-foo"
```

and then test the package with `newt test`, the flag does not get passed to gcc during linking.

Newt currently only reads lflags from the following package types:
* target
* app
* bsp
* compiler

Now, all packages' lflags are collected and specified during linking.