### PR TITLE
newt - Fix error message for priority conflict.

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -802,9 +802,9 @@ func calcPriorities(cfg Cfg, settingType CfgSettingType, max int,
 						return util.FmtNewtError(
 							"duplicate priority value: setting1=%s "+
 								"setting2=%s pkg1=%s pkg2=%s value=%s",
-							oldEntry.Name, entry.Name, entry.Value,
+							oldEntry.Name, entry.Name,
 							oldEntry.History[0].Name(),
-							entry.History[0].Name())
+							entry.History[0].Name(), entry.Value)
 					}
 				}
 


### PR DESCRIPTION
The fields in the error message were misordered.

Example:

OLD:
```
Error: duplicate priority value: setting1=BLE_LL_PRIO setting2=MCU_UART_POLLER_PRIO pkg1=0 pkg2=net/nimble/controller value=hw/mcu/native
```

NEW:
```
Error: duplicate priority value: setting1=BLE_LL_PRIO setting2=MCU_UART_POLLER_PRIO pkg1=net/nimble/controller pkg2=hw/mcu/native value=0
```