### PR TITLE
 Don't require repo TOC in project.yml

### DIFF
--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -558,10 +558,15 @@ func (proj *Project) loadConfig() error {
 		r.AddIgnoreDir(ignDir)
 	}
 
-	rstrs := yc.GetValStringSlice("project.repositories", nil)
-	for _, repoName := range rstrs {
-		if err := proj.loadRepo(repoName, yc); err != nil {
-			return err
+	// Assume every item starting with "repository." is a repository descriptor
+	// and try to load it.
+	for k, _ := range yc.AllSettings() {
+		repoName := strings.TrimPrefix(k, "repository.")
+		if repoName != k {
+			if err := proj.loadRepo(repoName, yc); err != nil {
+				util.StatusMessage(util.VERBOSITY_QUIET,
+					"* Warning: %s\n", err.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
The user's `project.yml` file needed to specify each repo dependency
twice:
* Name in `project.repositories` table of contents
* Definition as separate item (`repository.<...>`)

This made it a bit of a hassle to add a new repo to a project.

This commit eliminates the need for the `project.repositories` table of
contents.  Now newt assumes all top-level items starting with
"repository." describe a repository, and it attempts to load them.