### PR TITLE
newt - Don't abort if setting is redefined.

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -330,12 +330,13 @@ func (cfg *Cfg) readDefsOnce(lpkg *pkg.LocalPackage,
 			}
 
 			if oldEntry, exists := cfg.Settings[k]; exists {
-				// Setting already defined.  Allow this only if the setting is
-				// injected, in which case the injected value takes precedence.
+				// Setting already defined.  Warn the user and keep the
+				// original definition.
 				point := mostRecentPoint(oldEntry)
 				if !point.IsInjected() {
-					// XXX: Better error message.
-					return util.FmtNewtError("setting %s redefined", k)
+					util.StatusMessage(util.VERBOSITY_QUIET,
+						"* Warning: setting %s redefined (pkg1=%s pkg2=%s)\n",
+						k, point.Source.Name(), lpkg.Name())
 				}
 
 				entry.History = append(entry.History, oldEntry.History...)


### PR DESCRIPTION
Syscfg settings must have unique names.  When newt detected two settings
with the same name, it would terminate with this error message:
```
setting <name> redefined
```

This commit changes two things:

1. The error is now just a warning.  Newt warns the user about the
issue, but ignores the second definition and proceeds with its
operation.

Allowing newt to proceed makes it easier to debug the syscfg issue.  Now
the user can use commands like `target revdep` to debug the issue.

2. The message text is now more detailed:
```
* Warning: setting <name> redefined (pkg1=<pkg-name> pkg2=<pkg-name>)
```