### PR TITLE
Selective install

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -625,9 +625,9 @@ func (ld *LocalDownloader) CurrentBranch(path string) (string, error) {
 	return strings.Trim(string(branch), "\r\n"), err
 }
 
-// NOTE: intentionally always error...
 func (ld *LocalDownloader) UpdateRepo(path string, branchName string) error {
-	return util.NewNewtError(fmt.Sprintf("Can't pull from a local repo\n"))
+	// Nothing to update in a local repo.
+	return nil
 }
 
 func (ld *LocalDownloader) CleanupRepo(path string, branchName string) error {

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -206,13 +206,18 @@ func pickVersion(repo *Repo, versions []*Version) ([]*Version, error) {
 	}
 }
 
-func CheckDeps(checkRepos map[string]*Repo) error {
+func CheckDeps(repos []*Repo) error {
+	repoMap := map[string]*Repo{}
+	for _, r := range repos {
+		repoMap[r.Name()] = r
+	}
+
 	// For each dependency, get it's version
 	depArray := map[string][]*Version{}
 
-	for _, checkRepo := range checkRepos {
+	for _, checkRepo := range repoMap {
 		for _, rd := range checkRepo.Deps() {
-			lookupRepo := checkRepos[rd.Name()]
+			lookupRepo := repoMap[rd.Name()]
 
 			_, vers, ok := lookupRepo.rdesc.Match(rd.Storerepo)
 			if !ok {
@@ -242,7 +247,7 @@ func CheckDeps(checkRepos map[string]*Repo) error {
 			}
 		}
 		if pickVer {
-			newArray, err := pickVersion(checkRepos[repoName],
+			newArray, err := pickVersion(repoMap[repoName],
 				depArray[repoName])
 			depArray[repoName] = newArray
 			if err != nil {


### PR DESCRIPTION
Allow install / update / sync of specific repos

This commit allows the user to specify a list of repos with the `install`, `update`, and `sync` commands.  If no repos are specified, newt operates on all repos (as before).