### PR TITLE
Forced reinstall (`install -f`) was always failing

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -104,7 +104,7 @@ func executeGitCommand(dir string, cmd []string, logCmd bool) ([]byte, error) {
 	}
 
 	if err := os.Chdir(dir); err != nil {
-		return nil, util.NewNewtError(err.Error())
+		return nil, util.ChildNewtError(err)
 	}
 
 	defer os.Chdir(wd)

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -219,12 +219,19 @@ func (r *Repo) checkExists() bool {
 }
 
 func (r *Repo) updateRepo(branchName string) error {
-	dl := r.downloader
-	err := dl.UpdateRepo(r.Path(), branchName)
+	err := r.downloader.UpdateRepo(r.Path(), branchName)
 	if err != nil {
-		return util.FmtNewtError("Error updating \"%s\": %s",
-			r.Name(), err.Error())
+		// If the update failed because the repo directory has been deleted,
+		// clone the repo again.
+		if util.IsNotExist(err) {
+			err = r.downloadRepo(branchName)
+		}
+		if err != nil {
+			return util.FmtNewtError(
+				"Error updating \"%s\": %s", r.Name(), err.Error())
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Forced reinstalls always failed with an error message similar to the following:
```
Error: Error updating "blehostd": chdir /Users/ccollins/tmp/myproj2/repos/blehostd: no such file or directory
```

The problem occurred when newt attempted to fetch the repo after deleting the repo's directory.

The fix is to re-clone the repo rather than fetch it if the directory is missing.