### PR TITLE
Allow package-level syscfg restrictions

### DIFF
--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -128,7 +128,7 @@ func (bpkg *BuildPackage) CompilerInfo(
 	}
 
 	ci := toolchain.NewCompilerInfo()
-	settings := b.cfg.SettingsForLpkg(bpkg.rpkg.Lpkg)
+	settings := b.cfg.AllSettingsForLpkg(bpkg.rpkg.Lpkg)
 
 	// Read each set of flags and expand repo designators ("@<repo-nme>") into
 	// paths.

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -259,7 +259,7 @@ func (r *Resolver) selectApiSuppliers() {
 	apiMap := map[string][]resolveApi{}
 
 	for _, rpkg := range r.sortedRpkgs() {
-		settings := r.cfg.SettingsForLpkg(rpkg.Lpkg)
+		settings := r.cfg.AllSettingsForLpkg(rpkg.Lpkg)
 		apiStrings := rpkg.Lpkg.PkgY.GetSlice("pkg.apis", settings)
 		for _, entry := range apiStrings {
 			apiStr, ok := entry.Value.(string)
@@ -297,7 +297,7 @@ func (r *Resolver) selectApiSuppliers() {
 
 // Populates the specified package's set of API requirements.
 func (r *Resolver) calcApiReqsFor(rpkg *ResolvePackage) {
-	settings := r.cfg.SettingsForLpkg(rpkg.Lpkg)
+	settings := r.cfg.AllSettingsForLpkg(rpkg.Lpkg)
 
 	reqApiEntries := rpkg.Lpkg.PkgY.GetSlice("pkg.req_apis", settings)
 	for _, entry := range reqApiEntries {
@@ -323,7 +323,7 @@ func (r *Resolver) calcApiReqs() {
 //                                  in this case.
 //         error                non-nil on failure.
 func (r *Resolver) loadDepsForPkg(rpkg *ResolvePackage) (bool, error) {
-	settings := r.cfg.SettingsForLpkg(rpkg.Lpkg)
+	settings := r.cfg.AllSettingsForLpkg(rpkg.Lpkg)
 
 	changed := false
 


### PR DESCRIPTION
Currently, syscfg restrictions can only be specified at the setting level.  For example:

```
syscfg.defs:
    LOG_CLI:
        value: 0
        restrictions:
            - SHELL_TASK
```

Sometimes, it is desirable to place restrictions on an entire package.  For example, the `hw/bsp/arduino_zero` package ought to require exactly one of `BSP_ARDUINO_ZERO_PRO` or `BSP_ARDUINO_ZERO` be set.  Currently, this restriction can only be imposed by creating a new setting for the sole purpose of containing this restriction (and hoping no one overrides the setting!), or by "shoehorning" the restriction into an existing setting.  Another example where it would be useful to impose restrictions at the level of the package is for apps.  An app may require some settings to be enabled to function properly.

This PR allows restrictions to be defined at the top-level of a `syscfg.yml` file.  For example:

```
syscfg.defs:
    # ...

syscfg.vals:
    # ...

syscfg.restrictions:
    - 'BSP_ARDUINO_ZERO ^^ BSP_ARDUINO_ZERO_PRO'
    - SHELL_TASK
```
