### PR TITLE
Fix conditional dependency lists

### DIFF
--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -24,8 +24,6 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
-
 	"mynewt.apache.org/newt/newt/flash"
 	"mynewt.apache.org/newt/newt/pkg"
 	"mynewt.apache.org/newt/newt/project"
@@ -80,9 +78,8 @@ type ResolvePackage struct {
 	// Keeps track of API requirements and whether they are satisfied.
 	reqApiMap map[string]resolveReqApi
 
-	depsResolved  bool
-	apisSatisfied bool
-	refCount      int
+	depsResolved bool
+	refCount     int
 }
 
 type ResolveSet struct {
@@ -180,7 +177,6 @@ func (rpkg *ResolvePackage) AddDep(
 	if dep := rpkg.Deps[apiPkg]; dep != nil {
 		if dep.Api != "" && api == "" {
 			dep.Api = api
-			return true
 		} else {
 			return false
 		}
@@ -190,8 +186,19 @@ func (rpkg *ResolvePackage) AddDep(
 			Api:  api,
 			Expr: expr,
 		}
-		return true
 	}
+
+	// If this dependency came from an API requirement, record that the API
+	// requirement is now satisfied.
+	if api != "" {
+		apiReq := rpkg.reqApiMap[api]
+		apiReq.expr = expr
+		apiReq.satisfied = true
+		rpkg.reqApiMap[api] = apiReq
+	}
+
+	apiPkg.refCount++
+	return true
 }
 
 func (r *Resolver) rpkgSlice() []*ResolvePackage {
@@ -229,108 +236,83 @@ func (r *Resolver) addPkg(lpkg *pkg.LocalPackage) (*ResolvePackage, bool) {
 
 	rpkg := NewResolvePkg(lpkg)
 	r.pkgMap[lpkg] = rpkg
-	rpkg.refCount = 1
 	return rpkg, true
 }
 
-// @return bool                 true if this is a new API.
-func (r *Resolver) addApi(
-	apiString string, rpkg *ResolvePackage, expr string) bool {
+func (r *Resolver) sortedRpkgs() []*ResolvePackage {
+	rpkgs := make([]*ResolvePackage, 0, len(r.pkgMap))
+	for _, rpkg := range r.pkgMap {
+		rpkgs = append(rpkgs, rpkg)
+	}
 
-	api := r.apis[apiString]
-	if api.rpkg == nil {
-		r.apis[apiString] = resolveApi{
-			rpkg: rpkg,
-			expr: expr,
-		}
-		return true
-	} else {
-		if api.rpkg != rpkg {
-			if r.apiConflicts[apiString] == nil {
-				r.apiConflicts[apiString] = map[*ResolvePackage]struct{}{}
+	SortResolvePkgs(rpkgs)
+	return rpkgs
+}
+
+// Selects the final API suppliers among all packages implementing APIs.  The
+// result gets written to the resolver's `apis` map.  If more than one package
+// implements the same API, an API conflict error is recorded.
+func (r *Resolver) selectApiSuppliers() {
+	apiMap := map[string][]resolveApi{}
+
+	for _, rpkg := range r.sortedRpkgs() {
+		settings := r.cfg.SettingsForLpkg(rpkg.Lpkg)
+		apiStrings := rpkg.Lpkg.PkgY.GetSlice("pkg.apis", settings)
+		for _, entry := range apiStrings {
+			apiStr, ok := entry.Value.(string)
+			if ok && apiStr != "" {
+				apiMap[apiStr] = append(apiMap[apiStr], resolveApi{
+					rpkg: rpkg,
+					expr: entry.Expr,
+				})
 			}
-			r.apiConflicts[apiString][api.rpkg] = struct{}{}
-			r.apiConflicts[apiString][rpkg] = struct{}{}
 		}
-		return false
+	}
+
+	apiNames := make([]string, 0, len(apiMap))
+	for name, _ := range apiMap {
+		apiNames = append(apiNames, name)
+	}
+	sort.Strings(apiNames)
+
+	for _, name := range apiNames {
+		apis := apiMap[name]
+		for _, api := range apis {
+			old := r.apis[name]
+			if old.rpkg != nil {
+				if r.apiConflicts[name] == nil {
+					r.apiConflicts[name] = map[*ResolvePackage]struct{}{}
+				}
+				r.apiConflicts[name][api.rpkg] = struct{}{}
+				r.apiConflicts[name][old.rpkg] = struct{}{}
+			} else {
+				r.apis[name] = api
+			}
+		}
 	}
 }
 
-func joinExprs(expr1 string, expr2 string) string {
-	if expr1 == "" {
-		return expr2
-	}
-	if expr2 == "" {
-		return expr1
-	}
-
-	return expr1 + "," + expr2
-}
-
-// Searches for a package which can satisfy bpkg's API requirement.  If such a
-// package is found, bpkg's API requirement is marked as satisfied, and the
-// package is added to bpkg's dependency list.
-//
-// @return bool                 true if the API is now satisfied.
-func (r *Resolver) satisfyApi(
-	rpkg *ResolvePackage, reqApi string, expr string) bool {
-
-	api := r.apis[reqApi]
-	if api.rpkg == nil {
-		// Insert null entry to indicate an unsatisfied API.
-		r.apis[reqApi] = resolveApi{}
-		return false
-	}
-
-	rpkg.reqApiMap[reqApi] = resolveReqApi{
-		satisfied: true,
-		expr:      expr,
-	}
-
-	// This package now has a new unresolved dependency.
-	rpkg.depsResolved = false
-
-	log.Debugf("API requirement satisfied; pkg=%s API=(%s, %s) expr=(%s)",
-		rpkg.Lpkg.Name(), reqApi, api.rpkg.Lpkg.FullName(), expr)
-
-	return true
-}
-
-// @return bool                 true if a new dependency was detected as a
-//                                  result of satisfying an API for this
-//                                  package.
-func (r *Resolver) satisfyApis(rpkg *ResolvePackage) bool {
-	// Assume all this package's APIs are satisfied and that no new
-	// dependencies will be detected.
-	rpkg.apisSatisfied = true
-	newDeps := false
-
+// Populates the specified package's set of API requirements.
+func (r *Resolver) calcApiReqsFor(rpkg *ResolvePackage) {
 	settings := r.cfg.SettingsForLpkg(rpkg.Lpkg)
 
-	// Determine if any of the package's API requirements can now be satisfied.
-	// If so, another full iteration is required.
 	reqApiEntries := rpkg.Lpkg.PkgY.GetSlice("pkg.req_apis", settings)
 	for _, entry := range reqApiEntries {
 		apiStr, ok := entry.Value.(string)
 		if ok && apiStr != "" {
-			if !rpkg.reqApiMap[apiStr].satisfied {
-				apiSatisfied := r.satisfyApi(rpkg, apiStr, entry.Expr)
-				if apiSatisfied {
-					// An API was satisfied; the package now has a new
-					// dependency that needs to be resolved.
-					newDeps = true
-				} else {
-					rpkg.reqApiMap[apiStr] = resolveReqApi{
-						satisfied: false,
-						expr:      "",
-					}
-					rpkg.apisSatisfied = false
-				}
+			rpkg.reqApiMap[apiStr] = resolveReqApi{
+				satisfied: false,
+				expr:      "",
 			}
 		}
 	}
+}
 
-	return newDeps
+// Populates all packages' API requirements sets.
+func (r *Resolver) calcApiReqs() {
+	for _, rpkg := range r.pkgMap {
+		r.calcApiReqsFor(rpkg)
+	}
 }
 
 // @return bool                 True if this this function changed the resolver
@@ -413,13 +395,6 @@ func (r *Resolver) resolvePkg(rpkg *ResolvePackage) (bool, error) {
 		rpkg.depsResolved = !newDeps
 	}
 
-	if !rpkg.apisSatisfied {
-		newApiDep := r.satisfyApis(rpkg)
-		if newApiDep {
-			newDeps = true
-		}
-	}
-
 	return newDeps, nil
 }
 
@@ -477,10 +452,23 @@ func (r *Resolver) resolveDepsOnce() (bool, error) {
 	return newDeps, nil
 }
 
+// Given a fully calculated syscfg and API map, resolves package dependencies
+// by populating the resolver's package map.  This function should only be
+// called if the resolver's syscfg (`cfg`) member is assigned.  This only
+// happens for split images when the individual loader and app components are
+// resolved separately, after the master syscfg and API map have been
+// calculated.
 func (r *Resolver) resolveDeps() ([]*ResolvePackage, error) {
 	if _, err := r.resolveDepsOnce(); err != nil {
 		return nil, err
 	}
+
+	// Now that the final set of packages is known, determine which ones
+	// satisfy each required API.
+	r.selectApiSuppliers()
+
+	// Determine which packages have API requirements.
+	r.calcApiReqs()
 
 	// Satisfy API requirements.
 	if err := r.resolveApiDeps(); err != nil {
@@ -508,7 +496,6 @@ func (r *Resolver) resolveDepsAndCfg() error {
 			// reprocessed.
 			for _, rpkg := range r.pkgMap {
 				rpkg.depsResolved = false
-				rpkg.apisSatisfied = false
 			}
 		}
 
@@ -521,6 +508,13 @@ func (r *Resolver) resolveDepsAndCfg() error {
 			break
 		}
 	}
+
+	// Now that the final set of packages is known, determine which ones
+	// satisfy each required API.
+	r.selectApiSuppliers()
+
+	// Determine which packages have API requirements.
+	r.calcApiReqs()
 
 	// Satisfy API requirements.
 	if err := r.resolveApiDeps(); err != nil {
@@ -540,16 +534,34 @@ func (r *Resolver) resolveDepsAndCfg() error {
 	return nil
 }
 
+func joinExprs(expr1 string, expr2 string) string {
+	if expr1 == "" {
+		return expr2
+	}
+	if expr2 == "" {
+		return expr1
+	}
+
+	return expr1 + "," + expr2
+}
+
 // Transforms each package's required APIs to hard dependencies.  That is, this
 // function determines which package supplies each required API, and adds the
 // corresponding dependecy to each package which requires the API.
 func (r *Resolver) resolveApiDeps() error {
 	for _, rpkg := range r.pkgMap {
 		for apiString, reqApi := range rpkg.reqApiMap {
-			api := r.apis[apiString]
-			if api.rpkg != nil {
+			// Determine which package satisfies this API requirement.
+			api, ok := r.apis[apiString]
+
+			// If there is a package that supports the requested API, add a
+			// hard dependency to the package.  Otherwise, record an
+			// unsatisfied API requirement with an empty API struct.
+			if ok && api.rpkg != nil {
 				rpkg.AddDep(api.rpkg, apiString,
 					joinExprs(api.expr, reqApi.expr))
+			} else if !ok {
+				r.apis[apiString] = resolveApi{}
 			}
 		}
 	}
@@ -608,9 +620,6 @@ func ResolveFull(
 
 	res := newResolution()
 	res.Cfg = r.cfg
-	if err := r.resolveApiDeps(); err != nil {
-		return nil, err
-	}
 
 	// Determine which package satisfies each API and which APIs are
 	// unsatisfied.

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -79,7 +79,10 @@ type ResolvePackage struct {
 	reqApiMap map[string]resolveReqApi
 
 	depsResolved bool
-	refCount     int
+
+	// Tracks this package's number of dependents.  If this number reaches 0,
+	// this package can be deleted from the resolver.
+	refCount int
 }
 
 type ResolveSet struct {
@@ -480,6 +483,10 @@ func (r *Resolver) resolveDeps() ([]*ResolvePackage, error) {
 	return rpkgs, nil
 }
 
+// Performs a set of resolution actions:
+// 1. Calculates the system configuration (syscfg).
+// 2. Determines which packages satisfy which API requirements.
+// 3. Resolves package dependencies by populating the resolver's package map.
 func (r *Resolver) resolveDepsAndCfg() error {
 	if _, err := r.resolveDepsOnce(); err != nil {
 		return err

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -150,7 +150,7 @@ func (cfg *Cfg) SettingsForLpkg(lpkg *pkg.LocalPackage) map[string]string {
 		_, ok := settings[k]
 		if ok {
 			log.Warnf("Attempt to override syscfg setting %s with "+
-				"injected feature from package %s", k, lpkg.Name())
+				"injected feature from package %s", k, lpkg.FullName())
 		} else {
 			settings[k] = v
 		}
@@ -163,7 +163,7 @@ func (point CfgPoint) Name() string {
 	if point.Source == nil {
 		return "newt"
 	} else {
-		return point.Source.Name()
+		return point.Source.FullName()
 	}
 }
 
@@ -256,7 +256,7 @@ func (entry *CfgEntry) ambiguityText() string {
 			str += ", "
 		}
 
-		str += p.Source.Name()
+		str += p.Source.FullName()
 	}
 	str += "]"
 
@@ -715,8 +715,10 @@ func (cfg *Cfg) ErrorText() string {
 			entry := cfg.Settings[priority.SettingName]
 			historyMap[priority.SettingName] = entry.History
 
-			str += fmt.Sprintf("    Package: %s overriding setting: %s defined by %s\n",
-				priority.PackageSrc.Name(), priority.SettingName, priority.PackageDef.Name())
+			str += fmt.Sprintf(
+				"    Package: %s overriding setting: %s defined by %s\n",
+				priority.PackageSrc.FullName(), priority.SettingName,
+				priority.PackageDef.FullName())
 		}
 	}
 
@@ -732,11 +734,9 @@ func (cfg *Cfg) ErrorText() string {
 		}
 	}
 
-	if str == "" {
-		return ""
+	if len(historyMap) > 0 {
+		str += "\n" + historyText(historyMap)
 	}
-
-	str += "\n" + historyText(historyMap)
 
 	return str
 }
@@ -762,11 +762,9 @@ func (cfg *Cfg) WarningText() string {
 		}
 	}
 
-	if str == "" {
-		return ""
+	if len(historyMap) > 0 {
+		str += "\n" + historyText(historyMap)
 	}
-
-	str += "\n" + historyText(historyMap)
 
 	return str
 }

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -561,6 +561,7 @@ func (cfg *Cfg) detectPriorityViolations() {
 	}
 }
 
+// Detects all flash conflict errors in the syscfg and records them internally.
 func (cfg *Cfg) detectFlashConflicts(flashMap flash.FlashMap) {
 	entries := cfg.settingsOfType(CFG_SETTING_TYPE_FLASH_OWNER)
 
@@ -677,6 +678,7 @@ func (cfg *Cfg) ErrorText() string {
 		}
 	}
 
+	// Violation errors.
 	if len(cfg.Violations) > 0 {
 		str += "Syscfg restriction violations detected:\n"
 		for settingName, rslice := range cfg.Violations {
@@ -692,6 +694,7 @@ func (cfg *Cfg) ErrorText() string {
 		}
 	}
 
+	// Ambiguity errors.
 	if len(cfg.Ambiguities) > 0 {
 		str += "Syscfg ambiguities detected:\n"
 
@@ -708,6 +711,7 @@ func (cfg *Cfg) ErrorText() string {
 		}
 	}
 
+	// Priority violation errors.
 	if len(cfg.PriorityViolations) > 0 {
 		str += "Priority violations detected (Packages can only override " +
 			"settings defined by packages of lower priority):\n"


### PR DESCRIPTION
This fixes https://github.com/apache/mynewt-newt/issues/162.  Please see the issue for more information.

This is a rather large PR, but it fixes the issue, and I believe it makes the newt code clearer.  The fix involves these two changes:

1. Delay API requirement resolution until after dependency resolution and syscfg calculation.  This is done to prevent an incorrect package from being selected as an API-supplier before dependency resolution has completed.
2. Allow a package to be deleted from the syscfg state.  When a package is invalidated by a conditional dependency list, all setting definitions and overrides belonging to the package need to be removed from the system.