### PR TITLE
newt test - test all descendent packages.

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -88,11 +88,9 @@ func pkgToUnitTests(pack *pkg.LocalPackage) []*pkg.LocalPackage {
 	// Otherwise, return all the package's direct descendants that are unit
 	// test packages.
 	result := []*pkg.LocalPackage{}
-	srcPath := pack.BasePath()
 	for p, _ := range testablePkgs() {
-		dirPath := filepath.ToSlash(filepath.Dir(p.BasePath()))
 		if p.Type() == pkg.PACKAGE_TYPE_UNITTEST &&
-			dirPath == srcPath {
+			strings.HasPrefix(p.FullName(), pack.FullName()) {
 
 			result = append(result, p)
 		}
@@ -382,7 +380,6 @@ func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool, section
 	}
 
 	var sections []string
-
 
 	if ram {
 		sections = append(sections, "RAM")


### PR DESCRIPTION
If the user specifies a non-unittest package as the argument to `newt test <pkg>`, newt attempts to test every unittest package that is a descendant of the specified package (i.e., every test package in a child directory).  This worked only when the unittest packages were *direct* descendants of the specified package.  However, if there were one or more intermediate directories between the specified package and any unittest, newt would fail to detect the unittest.

For example:

```
newt test encoding/json
```

works because `encoding/json/test` is a direct descendant of `encoding/json`.

However, if a set of new packages were created:

* encoding/myproto
* encoding/myproto/misc/test

then, `newt test encoding/myproto` would fail with the following message:

```
Error: Package encoding/myproto contains no unit tests
```

This commit changes newt such that it correctly detects unittest packages that are descendants of the specified package, direct or otherwise.