### PR TITLE
Ensure new `.a` file needed before deleting old

### DIFF
--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -691,7 +691,7 @@ func (c *Compiler) CopyArchive(filename string) error {
 	}
 	if copyRequired {
 		err = util.CopyFile(filename, tgtFile)
-		util.StatusMessage(util.VERBOSITY_DEFAULT, "copying %s\n",
+		util.StatusMessage(util.VERBOSITY_DEFAULT, "Copying %s\n",
 			filepath.ToSlash(tgtFile))
 	}
 

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -1176,11 +1176,8 @@ func (c *Compiler) CompileArchive(archiveFile string) error {
 		return util.NewNewtError(err.Error())
 	}
 
-	// Delete the old archive, if it exists.
-	os.Remove(archiveFile)
-
 	objList := c.getObjFiles([]string{})
-	if objList == nil {
+	if len(objList) == 0 {
 		return nil
 	}
 
@@ -1189,6 +1186,9 @@ func (c *Compiler) CompileArchive(archiveFile string) error {
 			"Not archiving %s; no object files\n", archiveFile)
 		return nil
 	}
+
+	// Delete the old archive, if it exists.
+	os.Remove(archiveFile)
 
 	util.StatusMessage(util.VERBOSITY_DEFAULT, "Archiving %s",
 		path.Base(archiveFile))


### PR DESCRIPTION
When creating a `.a` file for a package, newt first deletes the existing `.a` file from the previous build.  There is one case where this causes problems: the package's source directory contains a `.a` file with the same name that newt plans to use.  In this case, newt confuses the input `.a` file as an artifact from a prior build and deletes it.

The fix is to delay the deletion of the old `.a` file until after ensuring that a new `.a` file will be built.  Newt determines if it will be building a new `.a` file by checking if any `.o` files were produced for the package.  Thus, a package consisting only of `.a` files does not generate
a new `.a` file.