### PR TITLE
Always refer to packages by their full name

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -92,11 +92,11 @@ func NewBuilder(
 		bpkg := b.PkgMap[rpkg]
 		if bpkg == nil {
 			for _, rpkg := range b.sortedRpkgs() {
-				log.Debugf("    * %s", rpkg.Lpkg.Name())
+				log.Debugf("    * %s", rpkg.Lpkg.FullName())
 			}
 			return nil, util.FmtNewtError(
 				"Unexpected unsatisfied API: %s; required by: %s", api,
-				rpkg.Lpkg.Name())
+				rpkg.Lpkg.FullName())
 		}
 
 		b.apiMap[api] = bpkg
@@ -152,8 +152,8 @@ func (b *Builder) addPackage(rpkg *resolve.ResolvePackage) (
 func pkgTypeConflictErr(p1 *BuildPackage, p2 *BuildPackage) error {
 	return util.FmtNewtError("Two %s packages in build: %s, %s",
 		pkg.PackageTypeNames[p1.rpkg.Lpkg.Type()],
-		p1.rpkg.Lpkg.Name(),
-		p2.rpkg.Lpkg.Name())
+		p1.rpkg.Lpkg.FullName(),
+		p2.rpkg.Lpkg.FullName())
 }
 
 // Recursively compiles all the .c and .s files in the specified directory.
@@ -333,7 +333,7 @@ func (b *Builder) createArchive(c *toolchain.Compiler,
 func (b *Builder) RemovePackages(cmn map[string]bool) error {
 	for pkgName, _ := range cmn {
 		for lp, bpkg := range b.PkgMap {
-			if bpkg.rpkg.Lpkg.Name() == pkgName {
+			if bpkg.rpkg.Lpkg.FullName() == pkgName {
 				delete(b.PkgMap, lp)
 			}
 		}
@@ -448,12 +448,12 @@ func (b *Builder) PrepBuild() error {
 	bspCi.Cflags = append(bspCi.Cflags, "-DARCH_NAME="+archName+"")
 
 	if b.appPkg != nil {
-		appName := filepath.Base(b.appPkg.rpkg.Lpkg.Name())
+		appName := filepath.Base(b.appPkg.rpkg.Lpkg.FullName())
 		bspCi.Cflags = append(bspCi.Cflags, "-DAPP_"+util.CIdentifier(appName))
 		bspCi.Cflags = append(bspCi.Cflags, "-DAPP_NAME="+appName+"")
 	}
 
-	bspName := filepath.Base(b.bspPkg.rpkg.Lpkg.Name())
+	bspName := filepath.Base(b.bspPkg.rpkg.Lpkg.FullName())
 	bspCi.Cflags = append(bspCi.Cflags, "-DBSP_"+util.CIdentifier(bspName))
 	bspCi.Cflags = append(bspCi.Cflags, "-DBSP_NAME="+bspName+"")
 
@@ -461,7 +461,7 @@ func (b *Builder) PrepBuild() error {
 
 	// All packages have access to the generated code header directory.
 	baseCi.Includes = append(baseCi.Includes,
-		GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.Name()))
+		GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.FullName()))
 
 	// Let multiplatform libraries know that a Mynewt binary is being build.
 	baseCi.Cflags = append(baseCi.Cflags, "-DMYNEWT=1")
@@ -479,7 +479,7 @@ func (b *Builder) AddCompilerInfo(info *toolchain.CompilerInfo) {
 
 func (b *Builder) addSysinitBpkg() (*BuildPackage, error) {
 	lpkg := pkg.NewLocalPackage(b.targetPkg.rpkg.Lpkg.Repo().(*repo.Repo),
-		GeneratedBaseDir(b.targetPkg.rpkg.Lpkg.Name()))
+		GeneratedBaseDir(b.targetPkg.rpkg.Lpkg.FullName()))
 	lpkg.SetName(pkg.ShortName(b.targetPkg.rpkg.Lpkg) + "-sysinit-" +
 		b.buildName)
 	lpkg.SetType(pkg.PACKAGE_TYPE_GENERATED)
@@ -666,7 +666,7 @@ func (b *Builder) FetchSymbolMap() (error, *symbol.SymbolMap) {
 		err, sm := b.ParseObjectLibrary(bpkg)
 		if err == nil {
 			util.StatusMessage(util.VERBOSITY_VERBOSE,
-				"Size of %s Loader Map %d\n", bpkg.rpkg.Lpkg.Name(), len(*sm))
+				"Size of %s Loader Map %d\n", bpkg.rpkg.Lpkg.FullName(), len(*sm))
 			loaderSm, err = loaderSm.Merge(sm)
 			if err != nil {
 				return err, nil

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -61,7 +61,7 @@ func (bpkg *BuildPackage) collectDepsAux(b *Builder,
 		dbpkg := b.PkgMap[dep.Rpkg]
 		if dbpkg == nil {
 			return util.FmtNewtError("Package not found %s; required by %s",
-				dep.Rpkg.Lpkg.Name(), bpkg.rpkg.Lpkg.Name())
+				dep.Rpkg.Lpkg.FullName(), bpkg.rpkg.Lpkg.FullName())
 		}
 
 		if err := dbpkg.collectDepsAux(b, set); err != nil {
@@ -204,7 +204,7 @@ func (bpkg *BuildPackage) findSdkIncludes() []string {
 }
 
 func (bpkg *BuildPackage) publicIncludeDirs(bspPkg *pkg.BspPackage) []string {
-	pkgBase := filepath.Base(bpkg.rpkg.Lpkg.Name())
+	pkgBase := filepath.Base(bpkg.rpkg.Lpkg.FullName())
 	bp := bpkg.rpkg.Lpkg.BasePath()
 
 	incls := []string{

--- a/newt/builder/buildutil.go
+++ b/newt/builder/buildutil.go
@@ -67,7 +67,7 @@ func (b bpkgSorter) Swap(i, j int) {
 	b.bpkgs[i], b.bpkgs[j] = b.bpkgs[j], b.bpkgs[i]
 }
 func (b bpkgSorter) Less(i, j int) bool {
-	return b.bpkgs[i].rpkg.Lpkg.Name() < b.bpkgs[j].rpkg.Lpkg.Name()
+	return b.bpkgs[i].rpkg.Lpkg.FullName() < b.bpkgs[j].rpkg.Lpkg.FullName()
 }
 
 func (b *Builder) sortedBuildPackages() []*BuildPackage {

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -149,7 +149,7 @@ func (b *Builder) CMakeBuildPackageWrite(w io.Writer, bpkg *BuildPackage) (*Buil
 		return nil, nil
 	}
 
-	pkgName := bpkg.rpkg.Lpkg.Name()
+	pkgName := bpkg.rpkg.Lpkg.FullName()
 
 	util.StatusMessage(util.VERBOSITY_DEFAULT, "Generating CMakeLists.txt for %s\n", pkgName)
 	fmt.Fprintf(w, "# Generating CMakeLists.txt for %s\n\n", pkgName)
@@ -188,7 +188,7 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 
 	for _, bpkg := range builtPackages {
 		targetObjectsBuffer.WriteString(fmt.Sprintf("%s ",
-			EscapeName(bpkg.rpkg.Lpkg.Name())))
+			EscapeName(bpkg.rpkg.Lpkg.FullName())))
 	}
 
 	elfOutputDir := trimProjectPath(filepath.Dir(b.AppElfPath()))
@@ -266,14 +266,14 @@ func CmakeCompilerInfoWrite(w io.Writer, archiveFile string, bpkg *BuildPackage,
 							ARCHIVE_OUTPUT_DIRECTORY %s
 							LIBRARY_OUTPUT_DIRECTORY %s
 							RUNTIME_OUTPUT_DIRECTORY %s)`,
-		EscapeName(bpkg.rpkg.Lpkg.Name()),
+		EscapeName(bpkg.rpkg.Lpkg.FullName()),
 		archiveFile,
 		archiveFile,
 		archiveFile,
 	)
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "target_include_directories(%s PUBLIC %s)\n\n",
-		EscapeName(bpkg.rpkg.Lpkg.Name()),
+		EscapeName(bpkg.rpkg.Lpkg.FullName()),
 		strings.Join(includes, " "))
 }
 

--- a/newt/builder/library.go
+++ b/newt/builder/library.go
@@ -162,7 +162,7 @@ func (b *Builder) ParseObjectLibraryFile(bp *BuildPackage,
 
 			/* assign the library */
 			if bp != nil {
-				(*si).Bpkg = bp.rpkg.Lpkg.Name()
+				(*si).Bpkg = bp.rpkg.Lpkg.FullName()
 			} else {
 				(*si).Bpkg = "elf"
 			}

--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -21,6 +21,7 @@ package builder
 
 import (
 	"path/filepath"
+	"strings"
 
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/pkg"
@@ -31,16 +32,28 @@ import (
 const BUILD_NAME_APP = "app"
 const BUILD_NAME_LOADER = "loader"
 
+// Removes odd characters from paths.
+func fixPath(s string) string {
+	s = strings.Replace(s, "@", "", -1)
+	s = strings.Replace(s, " ", "_", -1)
+	s = strings.Replace(s, "\t", "_", -1)
+	s = strings.Replace(s, "\n", "_", -1)
+
+	return s
+}
+
 func BinRoot() string {
 	return project.GetProject().Path() + "/bin"
 }
 
 func TargetBinDir(targetName string) string {
+	targetName = util.FilenameFromPath(targetName)
 	return BinRoot() + "/" + targetName
 }
 
 func GeneratedBaseDir(targetName string) string {
-	return BinRoot() + "/" + targetName + "/generated"
+	targetName = util.FilenameFromPath(targetName)
+	return fixPath(BinRoot() + "/" + targetName + "/generated")
 }
 
 func GeneratedSrcDir(targetName string) string {
@@ -64,11 +77,11 @@ func PkgSyscfgPath(pkgPath string) string {
 }
 
 func BinDir(targetName string, buildName string) string {
-	return BinRoot() + "/" + targetName + "/" + buildName
+	return fixPath(BinRoot() + "/" + targetName + "/" + buildName)
 }
 
 func FileBinDir(targetName string, buildName string, pkgName string) string {
-	return BinDir(targetName, buildName) + "/" + pkgName
+	return fixPath(BinDir(targetName, buildName) + "/" + pkgName)
 }
 
 func PkgBinDir(targetName string, buildName string, pkgName string,
@@ -86,12 +99,12 @@ func ArchivePath(targetName string, buildName string, pkgName string,
 	pkgType interfaces.PackageType) string {
 
 	filename := util.FilenameFromPath(pkgName) + ".a"
-	return PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" + filename
+	return fixPath(PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" + filename)
 }
 
 func AppElfPath(targetName string, buildName string, appName string) string {
-	return FileBinDir(targetName, buildName, appName) + "/" +
-		filepath.Base(appName) + ".elf"
+	return fixPath(FileBinDir(targetName, buildName, appName) + "/" +
+		filepath.Base(appName) + ".elf")
 }
 
 func AppBinPath(targetName string, buildName string, appName string) string {
@@ -101,8 +114,8 @@ func AppBinPath(targetName string, buildName string, appName string) string {
 func TestExePath(targetName string, buildName string, pkgName string,
 	pkgType interfaces.PackageType) string {
 
-	return PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" +
-		TestTargetName(pkgName) + ".elf"
+	return fixPath(PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" +
+		TestTargetName(pkgName) + ".elf")
 }
 
 func ManifestPath(targetName string, buildName string, pkgName string) string {
@@ -110,12 +123,12 @@ func ManifestPath(targetName string, buildName string, pkgName string) string {
 }
 
 func AppImgPath(targetName string, buildName string, appName string) string {
-	return FileBinDir(targetName, buildName, appName) + "/" +
-		filepath.Base(appName) + ".img"
+	return fixPath(FileBinDir(targetName, buildName, appName) + "/" +
+		filepath.Base(appName) + ".img")
 }
 
 func MfgBinDir(mfgPkgName string) string {
-	return BinRoot() + "/" + mfgPkgName
+	return fixPath(BinRoot() + "/" + mfgPkgName)
 }
 
 func MfgBootDir(mfgPkgName string) string {
@@ -123,46 +136,46 @@ func MfgBootDir(mfgPkgName string) string {
 }
 
 func (b *Builder) BinDir() string {
-	return BinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName)
+	return BinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName)
 }
 
 func (b *Builder) FileBinDir(pkgName string) string {
-	return FileBinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, pkgName)
+	return FileBinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName, pkgName)
 }
 
 func (b *Builder) PkgBinDir(bpkg *BuildPackage) string {
-	return PkgBinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, bpkg.rpkg.Lpkg.Name(),
+	return PkgBinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName, bpkg.rpkg.Lpkg.FullName(),
 		bpkg.rpkg.Lpkg.Type())
 }
 
 // Generates the path+filename of the specified package's .a file.
 func (b *Builder) ArchivePath(bpkg *BuildPackage) string {
-	return ArchivePath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, bpkg.rpkg.Lpkg.Name(),
+	return ArchivePath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName, bpkg.rpkg.Lpkg.FullName(),
 		bpkg.rpkg.Lpkg.Type())
 }
 
 func (b *Builder) AppTentativeElfPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
 		"_tmp.elf"
 }
 
 func (b *Builder) AppElfPath() string {
-	return AppElfPath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
-		b.appPkg.rpkg.Lpkg.Name())
+	return AppElfPath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		b.appPkg.rpkg.Lpkg.FullName())
 }
 
 func (b *Builder) AppLinkerElfPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
 		"linker.elf"
 }
 
 func (b *Builder) AppImgPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
 		".img"
 }
 
 func (b *Builder) AppHexPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
 		".hex"
 }
 
@@ -175,18 +188,18 @@ func (b *Builder) AppPath() string {
 }
 
 func (b *Builder) TestExePath() string {
-	return TestExePath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
-		b.testPkg.rpkg.Lpkg.Name(), b.testPkg.rpkg.Lpkg.Type())
+	return TestExePath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		b.testPkg.rpkg.Lpkg.FullName(), b.testPkg.rpkg.Lpkg.Type())
 }
 
 func (b *Builder) ManifestPath() string {
-	return ManifestPath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
-		b.appPkg.rpkg.Lpkg.Name())
+	return ManifestPath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		b.appPkg.rpkg.Lpkg.FullName())
 }
 
 func (b *Builder) AppBinBasePath() string {
 	return b.PkgBinDir(b.appPkg) + "/" +
-		filepath.Base(b.appPkg.rpkg.Lpkg.Name())
+		filepath.Base(b.appPkg.rpkg.Lpkg.FullName())
 }
 
 func (b *Builder) CompileCmdsPath() string {

--- a/newt/builder/selftest.go
+++ b/newt/builder/selftest.go
@@ -117,7 +117,7 @@ func (t *TargetBuilder) SelfTestDebug() error {
 
 func (b *Builder) testOwner(bpkg *BuildPackage) *BuildPackage {
 	if bpkg.rpkg.Lpkg.Type() != pkg.PACKAGE_TYPE_UNITTEST {
-		panic("Expected unittest package; got: " + bpkg.rpkg.Lpkg.Name())
+		panic("Expected unittest package; got: " + bpkg.rpkg.Lpkg.FullName())
 	}
 
 	curPath := bpkg.rpkg.Lpkg.BasePath()
@@ -152,7 +152,7 @@ func (b *Builder) SelfTestExecute(testRpkg *resolve.ResolvePackage) error {
 	if _, err := util.ShellCommand(cmd, nil); err != nil {
 		newtError := err.(*util.NewtError)
 		newtError.Text = fmt.Sprintf("Test failure (%s):\n%s",
-			testRpkg.Lpkg.Name(), newtError.Text)
+			testRpkg.Lpkg.FullName(), newtError.Text)
 		return newtError
 	}
 

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -203,7 +203,7 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 	}
 
 	if err := syscfg.EnsureWritten(t.res.Cfg,
-		GeneratedIncludeDir(t.target.Name())); err != nil {
+		GeneratedIncludeDir(t.target.FullName())); err != nil {
 
 		return err
 	}
@@ -216,7 +216,7 @@ func (t *TargetBuilder) generateSysinit() error {
 		return err
 	}
 
-	srcDir := GeneratedSrcDir(t.target.Name())
+	srcDir := GeneratedSrcDir(t.target.FullName())
 
 	if t.res.LoaderSet != nil {
 		lpkgs := resolve.RpkgSliceToLpkgSlice(t.res.LoaderSet.Rpkgs)
@@ -233,8 +233,8 @@ func (t *TargetBuilder) generateSysinit() error {
 
 func (t *TargetBuilder) generateFlashMap() error {
 	return t.bspPkg.FlashMap.EnsureWritten(
-		GeneratedSrcDir(t.target.Name()),
-		GeneratedIncludeDir(t.target.Name()),
+		GeneratedSrcDir(t.target.FullName()),
+		GeneratedIncludeDir(t.target.FullName()),
 		pkg.ShortName(t.target.Package()))
 }
 
@@ -337,7 +337,7 @@ func (t *TargetBuilder) buildLoader() error {
 	}
 
 	/* The app can ignore these packages next time */
-	delete(commonPkgs, t.bspPkg.Name())
+	delete(commonPkgs, t.bspPkg.FullName())
 	t.AppBuilder.RemovePackages(commonPkgs)
 
 	/* create the special elf to link the app against */
@@ -480,11 +480,11 @@ func (t *TargetBuilder) RelinkLoader() (error, map[string]bool,
 	/* fetch symbols from the elf and from the libraries themselves */
 	log.Debugf("Loader packages:")
 	for _, rpkg := range t.LoaderBuilder.sortedRpkgs() {
-		log.Debugf("    * %s", rpkg.Lpkg.Name())
+		log.Debugf("    * %s", rpkg.Lpkg.FullName())
 	}
 	log.Debugf("App packages:")
 	for _, rpkg := range t.AppBuilder.sortedRpkgs() {
-		log.Debugf("    * %s", rpkg.Lpkg.Name())
+		log.Debugf("    * %s", rpkg.Lpkg.FullName())
 	}
 	err, appLibSym := t.AppBuilder.ExtractSymbolInfo()
 	if err != nil {
@@ -518,14 +518,14 @@ func (t *TargetBuilder) RelinkLoader() (error, map[string]bool,
 	uncommonPkgs := smNomatch.Packages()
 
 	/* ensure that the loader and app packages are never shared */
-	delete(commonPkgs, t.AppBuilder.appPkg.rpkg.Lpkg.Name())
-	uncommonPkgs[t.AppBuilder.appPkg.rpkg.Lpkg.Name()] = true
-	ma := smMatch.FilterPkg(t.AppBuilder.appPkg.rpkg.Lpkg.Name())
+	delete(commonPkgs, t.AppBuilder.appPkg.rpkg.Lpkg.FullName())
+	uncommonPkgs[t.AppBuilder.appPkg.rpkg.Lpkg.FullName()] = true
+	ma := smMatch.FilterPkg(t.AppBuilder.appPkg.rpkg.Lpkg.FullName())
 	smMatch.RemoveMap(ma)
 
-	delete(commonPkgs, t.LoaderBuilder.appPkg.rpkg.Lpkg.Name())
-	uncommonPkgs[t.LoaderBuilder.appPkg.rpkg.Lpkg.Name()] = true
-	ml := smMatch.FilterPkg(t.LoaderBuilder.appPkg.rpkg.Lpkg.Name())
+	delete(commonPkgs, t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName())
+	uncommonPkgs[t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName()] = true
+	ml := smMatch.FilterPkg(t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName())
 	smMatch.RemoveMap(ml)
 
 	util.StatusMessage(util.VERBOSITY_VERBOSE,
@@ -536,9 +536,9 @@ func (t *TargetBuilder) RelinkLoader() (error, map[string]bool,
 	var symbolStr string
 	for v, _ := range uncommonPkgs {
 		if t.AppBuilder.appPkg != nil &&
-			t.AppBuilder.appPkg.rpkg.Lpkg.Name() != v &&
+			t.AppBuilder.appPkg.rpkg.Lpkg.FullName() != v &&
 			t.LoaderBuilder.appPkg != nil &&
-			t.LoaderBuilder.appPkg.rpkg.Lpkg.Name() != v {
+			t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName() != v {
 
 			trouble := smNomatch.FilterPkg(v)
 

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -144,7 +144,7 @@ func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, execute
 		t := ResolveTarget(targets[i].FullName())
 		if t == nil {
 			NewtUsage(nil, util.NewNewtError("Failed to resolve target: "+
-				targets[i].Name()))
+				targets[i].FullName()))
 		}
 
 		util.StatusMessage(util.VERBOSITY_DEFAULT, "Building target %s\n",
@@ -160,7 +160,7 @@ func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, execute
 		}
 
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
-			"Target successfully built: %s\n", t.Name())
+			"Target successfully built: %s\n", t.FullName())
 	}
 }
 
@@ -199,7 +199,7 @@ func cleanRunCmd(cmd *cobra.Command, args []string) {
 		cleanDir(builder.BinRoot())
 	} else {
 		for _, t := range targets {
-			cleanDir(builder.TargetBinDir(t.Name()))
+			cleanDir(builder.TargetBinDir(t.FullName()))
 		}
 	}
 }
@@ -208,7 +208,7 @@ func pkgnames(pkgs []*pkg.LocalPackage) string {
 	s := ""
 
 	for _, p := range pkgs {
-		s += p.Name() + " "
+		s += p.FullName() + " "
 	}
 
 	return s
@@ -263,7 +263,7 @@ func testRunCmd(cmd *cobra.Command, args []string, exclude string, executeShell 
 	packLoop:
 		for _, pack := range orig {
 			for _, excl := range excls {
-				if pack.Name() == excl || strings.HasPrefix(pack.Name(), excl+"/") {
+				if pack.FullName() == excl || strings.HasPrefix(pack.FullName(), excl+"/") {
 					continue packLoop
 				}
 			}
@@ -283,7 +283,7 @@ func testRunCmd(cmd *cobra.Command, args []string, exclude string, executeShell 
 			NewtUsage(nil, err)
 		}
 
-		t, err := ResolveUnittest(pack.Name())
+		t, err := ResolveUnittest(pack.FullName())
 		if err != nil {
 			NewtUsage(nil, err)
 		}

--- a/newt/cli/complete_cmd.go
+++ b/newt/cli/complete_cmd.go
@@ -73,7 +73,7 @@ func pkgNameList(filterCb func(*pkg.LocalPackage) bool) []string {
 func targetList() []string {
 	targetNames := pkgNameList(func(pack *pkg.LocalPackage) bool {
 		return pack.Type() == pkg.PACKAGE_TYPE_TARGET &&
-			!strings.HasSuffix(pack.Name(), "/unittest")
+			!strings.HasSuffix(pack.FullName(), "/unittest")
 	})
 
 	// Remove "targets/" prefix.

--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -161,8 +161,8 @@ func infoRunCmd(cmd *cobra.Command, args []string) {
 				// it.
 				// XXX: This is a hack; come up with a better solution for
 				// unit testing.
-				if !strings.HasSuffix(pack.Name(), "/unittest") {
-					packNames = append(packNames, pack.Name())
+				if !strings.HasSuffix(pack.FullName(), "/unittest") {
+					packNames = append(packNames, pack.FullName())
 				}
 			}
 

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -561,7 +561,7 @@ func printSetting(entry syscfg.CfgEntry) {
 			"    * Overridden: ")
 		for i := 1; i < len(entry.History); i++ {
 			util.StatusMessage(util.VERBOSITY_DEFAULT, "%s, ",
-				entry.History[i].Source.Name())
+				entry.History[i].Source.FullName())
 		}
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			"default=%s\n", entry.History[0].Value)
@@ -674,7 +674,7 @@ func targetConfigShowCmd(cmd *cobra.Command, args []string) {
 		}
 
 		res := targetBuilderConfigResolve(b)
-		printCfg(b.GetTarget().Name(), res.Cfg)
+		printCfg(b.GetTarget().FullName(), res.Cfg)
 	}
 }
 

--- a/newt/cli/util.go
+++ b/newt/cli/util.go
@@ -182,7 +182,7 @@ func PackageNameList(pkgs []*pkg.LocalPackage) string {
 		if i != 0 {
 			buffer.WriteString(" ")
 		}
-		buffer.WriteString(pack.Name())
+		buffer.WriteString(pack.FullName())
 	}
 
 	return buffer.String()
@@ -274,7 +274,7 @@ func ResolveTargetOrUnittest(pkgName string) (
 			pkg.PackageTypeNames[pack.Type()])
 	}
 
-	t, err := ResolveUnittest(pack.Name())
+	t, err := ResolveUnittest(pack.FullName())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/newt/image/image.go
+++ b/newt/image/image.go
@@ -1175,7 +1175,7 @@ func (r *RepoManager) GetImageManifestPkg(
 	lpkg *pkg.LocalPackage) *ImageManifestPkg {
 
 	ip := &ImageManifestPkg{
-		Name: lpkg.Name(),
+		Name: lpkg.FullName(),
 	}
 
 	var path string

--- a/newt/mfg/create.go
+++ b/newt/mfg/create.go
@@ -44,8 +44,8 @@ type mfgManifest struct {
 }
 
 type mfgSection struct {
-	offset     int
-	blob       []byte
+	offset int
+	blob   []byte
 }
 
 type createState struct {
@@ -283,13 +283,13 @@ func areaNameFromImgIdx(imgIdx int) (string, error) {
 func bootLoaderFromPaths(t *target.Target) []string {
 	return []string{
 		/* boot.elf */
-		builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
+		builder.AppElfPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
 
 		/* boot.elf.bin */
-		builder.AppBinPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
+		builder.AppBinPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
 
 		/* manifest.json */
-		builder.ManifestPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
+		builder.ManifestPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
 	}
 }
 
@@ -300,25 +300,25 @@ func loaderFromPaths(t *target.Target) []string {
 
 	return []string{
 		/* <loader>.elf */
-		builder.AppElfPath(t.Name(), builder.BUILD_NAME_LOADER,
-			t.Loader().Name()),
+		builder.AppElfPath(t.FullName(), builder.BUILD_NAME_LOADER,
+			t.Loader().FullName()),
 
 		/* <app>.img */
-		builder.AppImgPath(t.Name(), builder.BUILD_NAME_LOADER,
-			t.Loader().Name()),
+		builder.AppImgPath(t.FullName(), builder.BUILD_NAME_LOADER,
+			t.Loader().FullName()),
 	}
 }
 
 func appFromPaths(t *target.Target) []string {
 	return []string{
 		/* <app>.elf */
-		builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
+		builder.AppElfPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
 
 		/* <app>.img */
-		builder.AppImgPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
+		builder.AppImgPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
 
 		/* manifest.json */
-		builder.ManifestPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
+		builder.ManifestPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
 	}
 }
 
@@ -342,14 +342,14 @@ func (mi *MfgImage) copyBinFile(srcPath string, dstDir string) error {
 }
 
 func (mi *MfgImage) copyBinFiles() error {
-	dstPath := MfgBinDir(mi.basePkg.Name())
+	dstPath := MfgBinDir(mi.basePkg.FullName())
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
 		return util.ChildNewtError(err)
 	}
 
 	bootPaths := bootLoaderFromPaths(mi.boot)
 	for _, path := range bootPaths {
-		dstDir := MfgBootDir(mi.basePkg.Name())
+		dstDir := MfgBootDir(mi.basePkg.FullName())
 		if err := mi.copyBinFile(path, dstDir); err != nil {
 			return err
 		}
@@ -357,7 +357,7 @@ func (mi *MfgImage) copyBinFiles() error {
 
 	for i, imgTarget := range mi.images {
 		imgPaths := imageFromPaths(imgTarget)
-		dstDir := MfgImageBinDir(mi.basePkg.Name(), i)
+		dstDir := MfgImageBinDir(mi.basePkg.FullName(), i)
 		for _, path := range imgPaths {
 			if err := mi.copyBinFile(path, dstDir); err != nil {
 				return err
@@ -374,7 +374,7 @@ func (mi *MfgImage) dstBootBinPath() string {
 	}
 
 	return fmt.Sprintf("%s/%s.elf.bin",
-		MfgBootDir(mi.basePkg.Name()),
+		MfgBootDir(mi.basePkg.FullName()),
 		pkg.ShortName(mi.boot.App()))
 }
 
@@ -413,7 +413,7 @@ func (mi *MfgImage) dstImgPath(slotIdx int) string {
 	}
 
 	return fmt.Sprintf("%s/%s.img",
-		MfgImageBinDir(mi.basePkg.Name(), imgIdx), pkg.ShortName(pack))
+		MfgImageBinDir(mi.basePkg.FullName(), imgIdx), pkg.ShortName(pack))
 }
 
 // Returns a slice containing the path of each file required to build the
@@ -505,18 +505,18 @@ func (mi *MfgImage) CreateMfgImage() ([]string, error) {
 		return nil, err
 	}
 
-	sectionDir := MfgSectionBinDir(mi.basePkg.Name())
+	sectionDir := MfgSectionBinDir(mi.basePkg.FullName())
 	if err := os.MkdirAll(sectionDir, 0755); err != nil {
 		return nil, util.ChildNewtError(err)
 	}
 
 	for device, section := range cs.dsMap {
-		sectionPath := MfgSectionBinPath(mi.basePkg.Name(), device)
+		sectionPath := MfgSectionBinPath(mi.basePkg.FullName(), device)
 		err := ioutil.WriteFile(sectionPath, section.blob[section.offset:], 0644)
 		if err != nil {
 			return nil, util.ChildNewtError(err)
 		}
-		hexPath := MfgSectionHexPath(mi.basePkg.Name(), device)
+		hexPath := MfgSectionHexPath(mi.basePkg.FullName(), device)
 		mi.compiler.ConvertBinToHex(sectionPath, hexPath, section.offset)
 	}
 

--- a/newt/mfg/load.go
+++ b/newt/mfg/load.go
@@ -64,7 +64,7 @@ func sortParts(parts []mfgPart) []mfgPart {
 func (mi *MfgImage) loadError(
 	msg string, args ...interface{}) *util.NewtError {
 
-	return util.FmtNewtError("Error in %s mfg: %s", mi.basePkg.Name(),
+	return util.FmtNewtError("Error in %s mfg: %s", mi.basePkg.FullName(),
 		fmt.Sprintf(msg, args...))
 
 }
@@ -298,14 +298,14 @@ func Load(basePkg *pkg.LocalPackage) (*MfgImage, error) {
 	for _, imgTarget := range mi.images {
 		if len(mi.images) > 1 && imgTarget.LoaderName != "" {
 			return nil, mi.loadError("only one image allowed in "+
-				"split image mode (%s is a split build)", imgTarget.Name())
+				"split image mode (%s is a split build)", imgTarget.FullName())
 		}
 
 		if imgTarget.Bsp() != mi.bsp.LocalPackage {
 			return nil, mi.loadError(
 				"image target \"%s\" specified conflicting BSP; "+
 					"boot loader uses %s, image uses %s",
-				imgTarget.Name(), mi.bsp.Name(), imgTarget.BspName)
+				imgTarget.FullName(), mi.bsp.FullName(), imgTarget.BspName)
 		}
 	}
 

--- a/newt/mfg/paths.go
+++ b/newt/mfg/paths.go
@@ -88,7 +88,7 @@ func MfgManifestPath(mfgPkgName string) string {
 }
 
 func (mi *MfgImage) ManifestPath() string {
-	return MfgManifestPath(mi.basePkg.Name())
+	return MfgManifestPath(mi.basePkg.FullName())
 }
 
 func (mi *MfgImage) BootBinPath() string {
@@ -96,7 +96,7 @@ func (mi *MfgImage) BootBinPath() string {
 		return ""
 	}
 
-	return MfgBootBinPath(mi.basePkg.Name(),
+	return MfgBootBinPath(mi.basePkg.FullName(),
 		pkg.ShortName(mi.boot.App()))
 }
 
@@ -105,7 +105,7 @@ func (mi *MfgImage) BootElfPath() string {
 		return ""
 	}
 
-	return MfgBootElfPath(mi.basePkg.Name(), pkg.ShortName(mi.boot.App()))
+	return MfgBootElfPath(mi.basePkg.FullName(), pkg.ShortName(mi.boot.App()))
 }
 
 func (mi *MfgImage) BootManifestPath() string {
@@ -113,7 +113,7 @@ func (mi *MfgImage) BootManifestPath() string {
 		return ""
 	}
 
-	return MfgBootManifestPath(mi.basePkg.Name(),
+	return MfgBootManifestPath(mi.basePkg.FullName(),
 		pkg.ShortName(mi.boot.App()))
 }
 
@@ -123,7 +123,7 @@ func (mi *MfgImage) AppImgPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageImgPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(app))
+	return MfgImageImgPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(app))
 }
 
 func (mi *MfgImage) AppElfPath(imageIdx int) string {
@@ -132,7 +132,7 @@ func (mi *MfgImage) AppElfPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageElfPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(app))
+	return MfgImageElfPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(app))
 }
 
 func (mi *MfgImage) LoaderImgPath(imageIdx int) string {
@@ -141,7 +141,7 @@ func (mi *MfgImage) LoaderImgPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageImgPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(loader))
+	return MfgImageImgPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(loader))
 }
 
 func (mi *MfgImage) LoaderElfPath(imageIdx int) string {
@@ -150,7 +150,7 @@ func (mi *MfgImage) LoaderElfPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageElfPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(loader))
+	return MfgImageElfPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(loader))
 }
 
 func (mi *MfgImage) ImageManifestPath(imageIdx int) string {
@@ -158,7 +158,7 @@ func (mi *MfgImage) ImageManifestPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageManifestPath(mi.basePkg.Name(), imageIdx)
+	return MfgImageManifestPath(mi.basePkg.FullName(), imageIdx)
 }
 
 func (mi *MfgImage) SectionBinPaths() []string {
@@ -166,7 +166,7 @@ func (mi *MfgImage) SectionBinPaths() []string {
 
 	paths := make([]string, len(sectionIds))
 	for i, sectionId := range sectionIds {
-		paths[i] = MfgSectionBinPath(mi.basePkg.Name(), sectionId)
+		paths[i] = MfgSectionBinPath(mi.basePkg.FullName(), sectionId)
 	}
 	return paths
 }
@@ -176,7 +176,7 @@ func (mi *MfgImage) SectionHexPaths() []string {
 
 	paths := make([]string, len(sectionIds))
 	for i, sectionId := range sectionIds {
-		paths[i] = MfgSectionHexPath(mi.basePkg.Name(), sectionId)
+		paths[i] = MfgSectionHexPath(mi.basePkg.FullName(), sectionId)
 	}
 	return paths
 }

--- a/newt/mfg/read.go
+++ b/newt/mfg/read.go
@@ -28,7 +28,7 @@ import (
 // @return						mfg-image-path, error
 func (mi *MfgImage) Upload() (string, error) {
 	// For now, we always upload section 0 only.
-	section0Path := MfgSectionBinPath(mi.basePkg.Name(), 0)
+	section0Path := MfgSectionBinPath(mi.basePkg.FullName(), 0)
 	baseName := strings.TrimSuffix(section0Path, ".bin")
 
 	envSettings := map[string]string{"MFG_IMAGE": "1"}

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -57,7 +57,7 @@ func (bsp *BspPackage) resolvePathSetting(
 	if err != nil {
 		return "", util.PreNewtError(err,
 			"BSP \"%s\" specifies invalid %s setting",
-			bsp.Name(), key)
+			bsp.FullName(), key)
 	}
 	return path, nil
 }
@@ -91,7 +91,7 @@ func (bsp *BspPackage) resolveLinkerScriptSetting(
 			if err != nil {
 				return nil, util.PreNewtError(err,
 					"BSP \"%s\" specifies invalid %s setting",
-					bsp.Name(), key)
+					bsp.FullName(), key)
 			}
 
 			if path != "" {

--- a/newt/pkg/dependency.go
+++ b/newt/pkg/dependency.go
@@ -35,15 +35,7 @@ func (dep *Dependency) String() string {
 }
 
 func (dep *Dependency) SatisfiesDependency(pkg interfaces.PackageInterface) bool {
-	if dep.Name != pkg.Name() {
-		return false
-	}
-
-	if dep.Repo != pkg.Repo().Name() {
-		return false
-	}
-
-	return true
+	return dep.String() == pkg.FullName()
 }
 
 func (dep *Dependency) setRepoAndName(parentRepo interfaces.RepoInterface, str string) error {

--- a/newt/pkg/dependency.go
+++ b/newt/pkg/dependency.go
@@ -22,7 +22,6 @@ package pkg
 import (
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/newtutil"
-	"mynewt.apache.org/newt/newt/repo"
 )
 
 type Dependency struct {
@@ -51,10 +50,10 @@ func (dep *Dependency) setRepoAndName(parentRepo interfaces.RepoInterface, str s
 		dep.Repo = repoName
 		dep.Name = pkgName
 	} else {
-		if parentRepo != nil {
+		if parentRepo != nil && !parentRepo.IsLocal() {
 			dep.Repo = parentRepo.Name()
 		} else {
-			dep.Repo = repo.REPO_NAME_LOCAL
+			dep.Repo = ""
 		}
 		dep.Name = str
 	}

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -239,8 +239,6 @@ func (lpkg *LocalPackage) SaveSyscfgVals() error {
 	}
 	sort.Strings(names)
 
-	fmt.Fprintf(file, "### Package: %s\n", lpkg.Name())
-	fmt.Fprintf(file, "\n")
 	fmt.Fprintf(file, "syscfg.vals:\n")
 	for _, name := range names {
 		fmt.Fprintf(file, "    %s: %s\n", name, yaml.EscapeString(syscfgVals[name]))
@@ -264,8 +262,6 @@ func (pkg *LocalPackage) Save() error {
 		return util.NewNewtError(err.Error())
 	}
 	defer file.Close()
-
-	file.WriteString("### Package: " + pkg.Name() + "\n")
 
 	// XXX: Just iterate ycfg object's settings rather than calling out
 	// cached settings individually.

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -445,17 +445,17 @@ func ReadLocalPackageRecursive(repo *repo.Repo,
 		return warnings, nil
 	}
 
-	if oldPkg, ok := pkgList[pkg.Name()]; ok {
+	if oldPkg, ok := pkgList[pkg.FullName()]; ok {
 		oldlPkg := oldPkg.(*LocalPackage)
 		warnings = append(warnings,
 			fmt.Sprintf("Multiple packages with same pkg.name=%s "+
-				"in repo %s; path1=%s path2=%s", oldlPkg.Name(), repo.Name(),
+				"in repo %s; path1=%s path2=%s", oldlPkg.FullName(), repo.Name(),
 				oldlPkg.BasePath(), pkg.BasePath()))
 
 		return warnings, nil
 	}
 
-	pkgList[pkg.Name()] = pkg
+	pkgList[pkg.FullName()] = pkg
 
 	return warnings, nil
 }

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -328,7 +328,7 @@ func (r *Resolver) loadDepsForPkg(rpkg *ResolvePackage) (bool, error) {
 	changed := false
 
 	depEntries := rpkg.Lpkg.PkgY.GetSlice("pkg.deps", settings)
-	depender := rpkg.Lpkg.Name()
+	depender := rpkg.Lpkg.FullName()
 
 	seen := make(map[*ResolvePackage]struct{}, len(rpkg.Deps))
 
@@ -712,7 +712,7 @@ func (res *Resolution) ErrorText() string {
 			rpkgs := res.UnsatisfiedApis[api]
 			pkgNames := make([]string, len(rpkgs))
 			for i, rpkg := range rpkgs {
-				pkgNames[i] = rpkg.Lpkg.Name()
+				pkgNames[i] = rpkg.Lpkg.FullName()
 			}
 			sort.Strings(pkgNames)
 
@@ -740,7 +740,7 @@ func (res *Resolution) WarningText() string {
 			if i != 0 {
 				text += " <-> "
 			}
-			text += rpkg.Lpkg.Name()
+			text += rpkg.Lpkg.FullName()
 		}
 	}
 

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -455,8 +455,8 @@ func (cfg *Cfg) readRestrictions(lpkg *pkg.LocalPackage,
 		if err != nil {
 			return util.PreNewtError(err, "error parsing restriction: %s", rstring)
 		}
-		cfg.PackageRestrictions[lpkg.Name()] =
-			append(cfg.PackageRestrictions[lpkg.Name()], r)
+		cfg.PackageRestrictions[lpkg.FullName()] =
+			append(cfg.PackageRestrictions[lpkg.FullName()], r)
 	}
 
 	return nil

--- a/newt/sysinit/sysinit.go
+++ b/newt/sysinit/sysinit.go
@@ -139,7 +139,7 @@ func writeCalls(sortedInitFuncs []*initFunc, w io.Writer) {
 		}
 
 		fmt.Fprintf(w, "    /* %d.%d: %s (%s) */\n",
-			f.stage, dupCount, f.name, f.pkg.Name())
+			f.stage, dupCount, f.name, f.pkg.FullName())
 		fmt.Fprintf(w, "    %s();\n", f.name)
 	}
 }

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -235,8 +235,6 @@ func (t *Target) Save() error {
 	}
 	defer file.Close()
 
-	file.WriteString("### Target: " + t.Name() + "\n")
-
 	keys := []string{}
 	for k, _ := range t.Vars {
 		keys = append(keys, k)

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -221,24 +221,6 @@ func (target *Target) Bsp() *pkg.LocalPackage {
 	return target.resolvePackageName(target.BspName)
 }
 
-func (target *Target) BinBasePath() string {
-	appPkg := target.App()
-	if appPkg == nil {
-		return ""
-	}
-
-	return appPkg.BasePath() + "/bin/" + target.Name() + "/" +
-		appPkg.Name()
-}
-
-func (target *Target) ElfPath() string {
-	return target.BinBasePath() + ".elf"
-}
-
-func (target *Target) ImagePath() string {
-	return target.BinBasePath() + ".img"
-}
-
 // Save the target's configuration elements
 func (t *Target) Save() error {
 	if err := t.basePkg.Save(); err != nil {

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -128,7 +128,7 @@ func (target *Target) Validate(appRequired bool) error {
 
 	if bsp.Type() != pkg.PACKAGE_TYPE_BSP {
 		return util.FmtNewtError("bsp package (%s) is not of "+
-			"type bsp; type is: %s\n", bsp.Name(),
+			"type bsp; type is: %s\n", bsp.FullName(),
 			pkg.PackageTypeNames[bsp.Type()])
 	}
 
@@ -145,7 +145,7 @@ func (target *Target) Validate(appRequired bool) error {
 
 		if app.Type() != pkg.PACKAGE_TYPE_APP {
 			return util.FmtNewtError("target.app package (%s) is not of "+
-				"type app; type is: %s\n", app.Name(),
+				"type app; type is: %s\n", app.FullName(),
 				pkg.PackageTypeNames[app.Type()])
 		}
 
@@ -159,7 +159,7 @@ func (target *Target) Validate(appRequired bool) error {
 			if loader.Type() != pkg.PACKAGE_TYPE_APP {
 				return util.FmtNewtError(
 					"target.loader package (%s) is not of type app; type "+
-						"is: %s\n", loader.Name(),
+						"is: %s\n", loader.FullName(),
 					pkg.PackageTypeNames[loader.Type()])
 			}
 		}
@@ -262,7 +262,7 @@ func buildTargetMap() error {
 		if err != nil {
 			nerr := err.(*util.NewtError)
 			util.ErrorMessage(util.VERBOSITY_QUIET,
-				"Warning: failed to load target \"%s\": %s\n", pack.Name(),
+				"Warning: failed to load target \"%s\": %s\n", pack.FullName(),
 				nerr.Text)
 		} else {
 			globalTargetMap[pack.FullName()] = target


### PR DESCRIPTION
This fixes #171.

Packages have two forms of "name":
    * Name()
    * FullName()

`Name()` is everything except the repo prefix ("@<repo-name>").  Full name includes the repo prefix.  The normal `Name` was used in several places, causing ambiguity when two repos contained packages with the same name.