### PR TITLE
Revert "Always refer to packages by their full name"

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -92,11 +92,11 @@ func NewBuilder(
 		bpkg := b.PkgMap[rpkg]
 		if bpkg == nil {
 			for _, rpkg := range b.sortedRpkgs() {
-				log.Debugf("    * %s", rpkg.Lpkg.FullName())
+				log.Debugf("    * %s", rpkg.Lpkg.Name())
 			}
 			return nil, util.FmtNewtError(
 				"Unexpected unsatisfied API: %s; required by: %s", api,
-				rpkg.Lpkg.FullName())
+				rpkg.Lpkg.Name())
 		}
 
 		b.apiMap[api] = bpkg
@@ -152,8 +152,8 @@ func (b *Builder) addPackage(rpkg *resolve.ResolvePackage) (
 func pkgTypeConflictErr(p1 *BuildPackage, p2 *BuildPackage) error {
 	return util.FmtNewtError("Two %s packages in build: %s, %s",
 		pkg.PackageTypeNames[p1.rpkg.Lpkg.Type()],
-		p1.rpkg.Lpkg.FullName(),
-		p2.rpkg.Lpkg.FullName())
+		p1.rpkg.Lpkg.Name(),
+		p2.rpkg.Lpkg.Name())
 }
 
 // Recursively compiles all the .c and .s files in the specified directory.
@@ -333,7 +333,7 @@ func (b *Builder) createArchive(c *toolchain.Compiler,
 func (b *Builder) RemovePackages(cmn map[string]bool) error {
 	for pkgName, _ := range cmn {
 		for lp, bpkg := range b.PkgMap {
-			if bpkg.rpkg.Lpkg.FullName() == pkgName {
+			if bpkg.rpkg.Lpkg.Name() == pkgName {
 				delete(b.PkgMap, lp)
 			}
 		}
@@ -448,12 +448,12 @@ func (b *Builder) PrepBuild() error {
 	bspCi.Cflags = append(bspCi.Cflags, "-DARCH_NAME="+archName+"")
 
 	if b.appPkg != nil {
-		appName := filepath.Base(b.appPkg.rpkg.Lpkg.FullName())
+		appName := filepath.Base(b.appPkg.rpkg.Lpkg.Name())
 		bspCi.Cflags = append(bspCi.Cflags, "-DAPP_"+util.CIdentifier(appName))
 		bspCi.Cflags = append(bspCi.Cflags, "-DAPP_NAME="+appName+"")
 	}
 
-	bspName := filepath.Base(b.bspPkg.rpkg.Lpkg.FullName())
+	bspName := filepath.Base(b.bspPkg.rpkg.Lpkg.Name())
 	bspCi.Cflags = append(bspCi.Cflags, "-DBSP_"+util.CIdentifier(bspName))
 	bspCi.Cflags = append(bspCi.Cflags, "-DBSP_NAME="+bspName+"")
 
@@ -461,7 +461,7 @@ func (b *Builder) PrepBuild() error {
 
 	// All packages have access to the generated code header directory.
 	baseCi.Includes = append(baseCi.Includes,
-		GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.FullName()))
+		GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.Name()))
 
 	// Let multiplatform libraries know that a Mynewt binary is being build.
 	baseCi.Cflags = append(baseCi.Cflags, "-DMYNEWT=1")
@@ -479,7 +479,7 @@ func (b *Builder) AddCompilerInfo(info *toolchain.CompilerInfo) {
 
 func (b *Builder) addSysinitBpkg() (*BuildPackage, error) {
 	lpkg := pkg.NewLocalPackage(b.targetPkg.rpkg.Lpkg.Repo().(*repo.Repo),
-		GeneratedBaseDir(b.targetPkg.rpkg.Lpkg.FullName()))
+		GeneratedBaseDir(b.targetPkg.rpkg.Lpkg.Name()))
 	lpkg.SetName(pkg.ShortName(b.targetPkg.rpkg.Lpkg) + "-sysinit-" +
 		b.buildName)
 	lpkg.SetType(pkg.PACKAGE_TYPE_GENERATED)
@@ -666,7 +666,7 @@ func (b *Builder) FetchSymbolMap() (error, *symbol.SymbolMap) {
 		err, sm := b.ParseObjectLibrary(bpkg)
 		if err == nil {
 			util.StatusMessage(util.VERBOSITY_VERBOSE,
-				"Size of %s Loader Map %d\n", bpkg.rpkg.Lpkg.FullName(), len(*sm))
+				"Size of %s Loader Map %d\n", bpkg.rpkg.Lpkg.Name(), len(*sm))
 			loaderSm, err = loaderSm.Merge(sm)
 			if err != nil {
 				return err, nil

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -61,7 +61,7 @@ func (bpkg *BuildPackage) collectDepsAux(b *Builder,
 		dbpkg := b.PkgMap[dep.Rpkg]
 		if dbpkg == nil {
 			return util.FmtNewtError("Package not found %s; required by %s",
-				dep.Rpkg.Lpkg.FullName(), bpkg.rpkg.Lpkg.FullName())
+				dep.Rpkg.Lpkg.Name(), bpkg.rpkg.Lpkg.Name())
 		}
 
 		if err := dbpkg.collectDepsAux(b, set); err != nil {
@@ -204,7 +204,7 @@ func (bpkg *BuildPackage) findSdkIncludes() []string {
 }
 
 func (bpkg *BuildPackage) publicIncludeDirs(bspPkg *pkg.BspPackage) []string {
-	pkgBase := filepath.Base(bpkg.rpkg.Lpkg.FullName())
+	pkgBase := filepath.Base(bpkg.rpkg.Lpkg.Name())
 	bp := bpkg.rpkg.Lpkg.BasePath()
 
 	incls := []string{

--- a/newt/builder/buildutil.go
+++ b/newt/builder/buildutil.go
@@ -67,7 +67,7 @@ func (b bpkgSorter) Swap(i, j int) {
 	b.bpkgs[i], b.bpkgs[j] = b.bpkgs[j], b.bpkgs[i]
 }
 func (b bpkgSorter) Less(i, j int) bool {
-	return b.bpkgs[i].rpkg.Lpkg.FullName() < b.bpkgs[j].rpkg.Lpkg.FullName()
+	return b.bpkgs[i].rpkg.Lpkg.Name() < b.bpkgs[j].rpkg.Lpkg.Name()
 }
 
 func (b *Builder) sortedBuildPackages() []*BuildPackage {

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -149,7 +149,7 @@ func (b *Builder) CMakeBuildPackageWrite(w io.Writer, bpkg *BuildPackage) (*Buil
 		return nil, nil
 	}
 
-	pkgName := bpkg.rpkg.Lpkg.FullName()
+	pkgName := bpkg.rpkg.Lpkg.Name()
 
 	util.StatusMessage(util.VERBOSITY_DEFAULT, "Generating CMakeLists.txt for %s\n", pkgName)
 	fmt.Fprintf(w, "# Generating CMakeLists.txt for %s\n\n", pkgName)
@@ -188,7 +188,7 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 
 	for _, bpkg := range builtPackages {
 		targetObjectsBuffer.WriteString(fmt.Sprintf("%s ",
-			EscapeName(bpkg.rpkg.Lpkg.FullName())))
+			EscapeName(bpkg.rpkg.Lpkg.Name())))
 	}
 
 	elfOutputDir := trimProjectPath(filepath.Dir(b.AppElfPath()))
@@ -266,14 +266,14 @@ func CmakeCompilerInfoWrite(w io.Writer, archiveFile string, bpkg *BuildPackage,
 							ARCHIVE_OUTPUT_DIRECTORY %s
 							LIBRARY_OUTPUT_DIRECTORY %s
 							RUNTIME_OUTPUT_DIRECTORY %s)`,
-		EscapeName(bpkg.rpkg.Lpkg.FullName()),
+		EscapeName(bpkg.rpkg.Lpkg.Name()),
 		archiveFile,
 		archiveFile,
 		archiveFile,
 	)
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "target_include_directories(%s PUBLIC %s)\n\n",
-		EscapeName(bpkg.rpkg.Lpkg.FullName()),
+		EscapeName(bpkg.rpkg.Lpkg.Name()),
 		strings.Join(includes, " "))
 }
 

--- a/newt/builder/library.go
+++ b/newt/builder/library.go
@@ -162,7 +162,7 @@ func (b *Builder) ParseObjectLibraryFile(bp *BuildPackage,
 
 			/* assign the library */
 			if bp != nil {
-				(*si).Bpkg = bp.rpkg.Lpkg.FullName()
+				(*si).Bpkg = bp.rpkg.Lpkg.Name()
 			} else {
 				(*si).Bpkg = "elf"
 			}

--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -21,7 +21,6 @@ package builder
 
 import (
 	"path/filepath"
-	"strings"
 
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/pkg"
@@ -32,28 +31,16 @@ import (
 const BUILD_NAME_APP = "app"
 const BUILD_NAME_LOADER = "loader"
 
-// Removes odd characters from paths.
-func fixPath(s string) string {
-	s = strings.Replace(s, "@", "", -1)
-	s = strings.Replace(s, " ", "_", -1)
-	s = strings.Replace(s, "\t", "_", -1)
-	s = strings.Replace(s, "\n", "_", -1)
-
-	return s
-}
-
 func BinRoot() string {
 	return project.GetProject().Path() + "/bin"
 }
 
 func TargetBinDir(targetName string) string {
-	targetName = util.FilenameFromPath(targetName)
 	return BinRoot() + "/" + targetName
 }
 
 func GeneratedBaseDir(targetName string) string {
-	targetName = util.FilenameFromPath(targetName)
-	return fixPath(BinRoot() + "/" + targetName + "/generated")
+	return BinRoot() + "/" + targetName + "/generated"
 }
 
 func GeneratedSrcDir(targetName string) string {
@@ -77,11 +64,11 @@ func PkgSyscfgPath(pkgPath string) string {
 }
 
 func BinDir(targetName string, buildName string) string {
-	return fixPath(BinRoot() + "/" + targetName + "/" + buildName)
+	return BinRoot() + "/" + targetName + "/" + buildName
 }
 
 func FileBinDir(targetName string, buildName string, pkgName string) string {
-	return fixPath(BinDir(targetName, buildName) + "/" + pkgName)
+	return BinDir(targetName, buildName) + "/" + pkgName
 }
 
 func PkgBinDir(targetName string, buildName string, pkgName string,
@@ -99,12 +86,12 @@ func ArchivePath(targetName string, buildName string, pkgName string,
 	pkgType interfaces.PackageType) string {
 
 	filename := util.FilenameFromPath(pkgName) + ".a"
-	return fixPath(PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" + filename)
+	return PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" + filename
 }
 
 func AppElfPath(targetName string, buildName string, appName string) string {
-	return fixPath(FileBinDir(targetName, buildName, appName) + "/" +
-		filepath.Base(appName) + ".elf")
+	return FileBinDir(targetName, buildName, appName) + "/" +
+		filepath.Base(appName) + ".elf"
 }
 
 func AppBinPath(targetName string, buildName string, appName string) string {
@@ -114,8 +101,8 @@ func AppBinPath(targetName string, buildName string, appName string) string {
 func TestExePath(targetName string, buildName string, pkgName string,
 	pkgType interfaces.PackageType) string {
 
-	return fixPath(PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" +
-		TestTargetName(pkgName) + ".elf")
+	return PkgBinDir(targetName, buildName, pkgName, pkgType) + "/" +
+		TestTargetName(pkgName) + ".elf"
 }
 
 func ManifestPath(targetName string, buildName string, pkgName string) string {
@@ -123,12 +110,12 @@ func ManifestPath(targetName string, buildName string, pkgName string) string {
 }
 
 func AppImgPath(targetName string, buildName string, appName string) string {
-	return fixPath(FileBinDir(targetName, buildName, appName) + "/" +
-		filepath.Base(appName) + ".img")
+	return FileBinDir(targetName, buildName, appName) + "/" +
+		filepath.Base(appName) + ".img"
 }
 
 func MfgBinDir(mfgPkgName string) string {
-	return fixPath(BinRoot() + "/" + mfgPkgName)
+	return BinRoot() + "/" + mfgPkgName
 }
 
 func MfgBootDir(mfgPkgName string) string {
@@ -136,46 +123,46 @@ func MfgBootDir(mfgPkgName string) string {
 }
 
 func (b *Builder) BinDir() string {
-	return BinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName)
+	return BinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName)
 }
 
 func (b *Builder) FileBinDir(pkgName string) string {
-	return FileBinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName, pkgName)
+	return FileBinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, pkgName)
 }
 
 func (b *Builder) PkgBinDir(bpkg *BuildPackage) string {
-	return PkgBinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName, bpkg.rpkg.Lpkg.FullName(),
+	return PkgBinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, bpkg.rpkg.Lpkg.Name(),
 		bpkg.rpkg.Lpkg.Type())
 }
 
 // Generates the path+filename of the specified package's .a file.
 func (b *Builder) ArchivePath(bpkg *BuildPackage) string {
-	return ArchivePath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName, bpkg.rpkg.Lpkg.FullName(),
+	return ArchivePath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, bpkg.rpkg.Lpkg.Name(),
 		bpkg.rpkg.Lpkg.Type())
 }
 
 func (b *Builder) AppTentativeElfPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
 		"_tmp.elf"
 }
 
 func (b *Builder) AppElfPath() string {
-	return AppElfPath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
-		b.appPkg.rpkg.Lpkg.FullName())
+	return AppElfPath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
+		b.appPkg.rpkg.Lpkg.Name())
 }
 
 func (b *Builder) AppLinkerElfPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
 		"linker.elf"
 }
 
 func (b *Builder) AppImgPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
 		".img"
 }
 
 func (b *Builder) AppHexPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) +
+	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
 		".hex"
 }
 
@@ -188,18 +175,18 @@ func (b *Builder) AppPath() string {
 }
 
 func (b *Builder) TestExePath() string {
-	return TestExePath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
-		b.testPkg.rpkg.Lpkg.FullName(), b.testPkg.rpkg.Lpkg.Type())
+	return TestExePath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
+		b.testPkg.rpkg.Lpkg.Name(), b.testPkg.rpkg.Lpkg.Type())
 }
 
 func (b *Builder) ManifestPath() string {
-	return ManifestPath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
-		b.appPkg.rpkg.Lpkg.FullName())
+	return ManifestPath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
+		b.appPkg.rpkg.Lpkg.Name())
 }
 
 func (b *Builder) AppBinBasePath() string {
 	return b.PkgBinDir(b.appPkg) + "/" +
-		filepath.Base(b.appPkg.rpkg.Lpkg.FullName())
+		filepath.Base(b.appPkg.rpkg.Lpkg.Name())
 }
 
 func (b *Builder) CompileCmdsPath() string {

--- a/newt/builder/selftest.go
+++ b/newt/builder/selftest.go
@@ -117,7 +117,7 @@ func (t *TargetBuilder) SelfTestDebug() error {
 
 func (b *Builder) testOwner(bpkg *BuildPackage) *BuildPackage {
 	if bpkg.rpkg.Lpkg.Type() != pkg.PACKAGE_TYPE_UNITTEST {
-		panic("Expected unittest package; got: " + bpkg.rpkg.Lpkg.FullName())
+		panic("Expected unittest package; got: " + bpkg.rpkg.Lpkg.Name())
 	}
 
 	curPath := bpkg.rpkg.Lpkg.BasePath()
@@ -152,7 +152,7 @@ func (b *Builder) SelfTestExecute(testRpkg *resolve.ResolvePackage) error {
 	if _, err := util.ShellCommand(cmd, nil); err != nil {
 		newtError := err.(*util.NewtError)
 		newtError.Text = fmt.Sprintf("Test failure (%s):\n%s",
-			testRpkg.Lpkg.FullName(), newtError.Text)
+			testRpkg.Lpkg.Name(), newtError.Text)
 		return newtError
 	}
 

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -203,7 +203,7 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 	}
 
 	if err := syscfg.EnsureWritten(t.res.Cfg,
-		GeneratedIncludeDir(t.target.FullName())); err != nil {
+		GeneratedIncludeDir(t.target.Name())); err != nil {
 
 		return err
 	}
@@ -216,7 +216,7 @@ func (t *TargetBuilder) generateSysinit() error {
 		return err
 	}
 
-	srcDir := GeneratedSrcDir(t.target.FullName())
+	srcDir := GeneratedSrcDir(t.target.Name())
 
 	if t.res.LoaderSet != nil {
 		lpkgs := resolve.RpkgSliceToLpkgSlice(t.res.LoaderSet.Rpkgs)
@@ -233,8 +233,8 @@ func (t *TargetBuilder) generateSysinit() error {
 
 func (t *TargetBuilder) generateFlashMap() error {
 	return t.bspPkg.FlashMap.EnsureWritten(
-		GeneratedSrcDir(t.target.FullName()),
-		GeneratedIncludeDir(t.target.FullName()),
+		GeneratedSrcDir(t.target.Name()),
+		GeneratedIncludeDir(t.target.Name()),
 		pkg.ShortName(t.target.Package()))
 }
 
@@ -337,7 +337,7 @@ func (t *TargetBuilder) buildLoader() error {
 	}
 
 	/* The app can ignore these packages next time */
-	delete(commonPkgs, t.bspPkg.FullName())
+	delete(commonPkgs, t.bspPkg.Name())
 	t.AppBuilder.RemovePackages(commonPkgs)
 
 	/* create the special elf to link the app against */
@@ -480,11 +480,11 @@ func (t *TargetBuilder) RelinkLoader() (error, map[string]bool,
 	/* fetch symbols from the elf and from the libraries themselves */
 	log.Debugf("Loader packages:")
 	for _, rpkg := range t.LoaderBuilder.sortedRpkgs() {
-		log.Debugf("    * %s", rpkg.Lpkg.FullName())
+		log.Debugf("    * %s", rpkg.Lpkg.Name())
 	}
 	log.Debugf("App packages:")
 	for _, rpkg := range t.AppBuilder.sortedRpkgs() {
-		log.Debugf("    * %s", rpkg.Lpkg.FullName())
+		log.Debugf("    * %s", rpkg.Lpkg.Name())
 	}
 	err, appLibSym := t.AppBuilder.ExtractSymbolInfo()
 	if err != nil {
@@ -518,14 +518,14 @@ func (t *TargetBuilder) RelinkLoader() (error, map[string]bool,
 	uncommonPkgs := smNomatch.Packages()
 
 	/* ensure that the loader and app packages are never shared */
-	delete(commonPkgs, t.AppBuilder.appPkg.rpkg.Lpkg.FullName())
-	uncommonPkgs[t.AppBuilder.appPkg.rpkg.Lpkg.FullName()] = true
-	ma := smMatch.FilterPkg(t.AppBuilder.appPkg.rpkg.Lpkg.FullName())
+	delete(commonPkgs, t.AppBuilder.appPkg.rpkg.Lpkg.Name())
+	uncommonPkgs[t.AppBuilder.appPkg.rpkg.Lpkg.Name()] = true
+	ma := smMatch.FilterPkg(t.AppBuilder.appPkg.rpkg.Lpkg.Name())
 	smMatch.RemoveMap(ma)
 
-	delete(commonPkgs, t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName())
-	uncommonPkgs[t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName()] = true
-	ml := smMatch.FilterPkg(t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName())
+	delete(commonPkgs, t.LoaderBuilder.appPkg.rpkg.Lpkg.Name())
+	uncommonPkgs[t.LoaderBuilder.appPkg.rpkg.Lpkg.Name()] = true
+	ml := smMatch.FilterPkg(t.LoaderBuilder.appPkg.rpkg.Lpkg.Name())
 	smMatch.RemoveMap(ml)
 
 	util.StatusMessage(util.VERBOSITY_VERBOSE,
@@ -536,9 +536,9 @@ func (t *TargetBuilder) RelinkLoader() (error, map[string]bool,
 	var symbolStr string
 	for v, _ := range uncommonPkgs {
 		if t.AppBuilder.appPkg != nil &&
-			t.AppBuilder.appPkg.rpkg.Lpkg.FullName() != v &&
+			t.AppBuilder.appPkg.rpkg.Lpkg.Name() != v &&
 			t.LoaderBuilder.appPkg != nil &&
-			t.LoaderBuilder.appPkg.rpkg.Lpkg.FullName() != v {
+			t.LoaderBuilder.appPkg.rpkg.Lpkg.Name() != v {
 
 			trouble := smNomatch.FilterPkg(v)
 

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -144,7 +144,7 @@ func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, execute
 		t := ResolveTarget(targets[i].FullName())
 		if t == nil {
 			NewtUsage(nil, util.NewNewtError("Failed to resolve target: "+
-				targets[i].FullName()))
+				targets[i].Name()))
 		}
 
 		util.StatusMessage(util.VERBOSITY_DEFAULT, "Building target %s\n",
@@ -160,7 +160,7 @@ func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, execute
 		}
 
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
-			"Target successfully built: %s\n", t.FullName())
+			"Target successfully built: %s\n", t.Name())
 	}
 }
 
@@ -199,7 +199,7 @@ func cleanRunCmd(cmd *cobra.Command, args []string) {
 		cleanDir(builder.BinRoot())
 	} else {
 		for _, t := range targets {
-			cleanDir(builder.TargetBinDir(t.FullName()))
+			cleanDir(builder.TargetBinDir(t.Name()))
 		}
 	}
 }
@@ -208,7 +208,7 @@ func pkgnames(pkgs []*pkg.LocalPackage) string {
 	s := ""
 
 	for _, p := range pkgs {
-		s += p.FullName() + " "
+		s += p.Name() + " "
 	}
 
 	return s
@@ -263,7 +263,7 @@ func testRunCmd(cmd *cobra.Command, args []string, exclude string, executeShell 
 	packLoop:
 		for _, pack := range orig {
 			for _, excl := range excls {
-				if pack.FullName() == excl || strings.HasPrefix(pack.FullName(), excl+"/") {
+				if pack.Name() == excl || strings.HasPrefix(pack.Name(), excl+"/") {
 					continue packLoop
 				}
 			}
@@ -283,7 +283,7 @@ func testRunCmd(cmd *cobra.Command, args []string, exclude string, executeShell 
 			NewtUsage(nil, err)
 		}
 
-		t, err := ResolveUnittest(pack.FullName())
+		t, err := ResolveUnittest(pack.Name())
 		if err != nil {
 			NewtUsage(nil, err)
 		}

--- a/newt/cli/complete_cmd.go
+++ b/newt/cli/complete_cmd.go
@@ -73,7 +73,7 @@ func pkgNameList(filterCb func(*pkg.LocalPackage) bool) []string {
 func targetList() []string {
 	targetNames := pkgNameList(func(pack *pkg.LocalPackage) bool {
 		return pack.Type() == pkg.PACKAGE_TYPE_TARGET &&
-			!strings.HasSuffix(pack.FullName(), "/unittest")
+			!strings.HasSuffix(pack.Name(), "/unittest")
 	})
 
 	// Remove "targets/" prefix.

--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -161,8 +161,8 @@ func infoRunCmd(cmd *cobra.Command, args []string) {
 				// it.
 				// XXX: This is a hack; come up with a better solution for
 				// unit testing.
-				if !strings.HasSuffix(pack.FullName(), "/unittest") {
-					packNames = append(packNames, pack.FullName())
+				if !strings.HasSuffix(pack.Name(), "/unittest") {
+					packNames = append(packNames, pack.Name())
 				}
 			}
 

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -561,7 +561,7 @@ func printSetting(entry syscfg.CfgEntry) {
 			"    * Overridden: ")
 		for i := 1; i < len(entry.History); i++ {
 			util.StatusMessage(util.VERBOSITY_DEFAULT, "%s, ",
-				entry.History[i].Source.FullName())
+				entry.History[i].Source.Name())
 		}
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			"default=%s\n", entry.History[0].Value)
@@ -674,7 +674,7 @@ func targetConfigShowCmd(cmd *cobra.Command, args []string) {
 		}
 
 		res := targetBuilderConfigResolve(b)
-		printCfg(b.GetTarget().FullName(), res.Cfg)
+		printCfg(b.GetTarget().Name(), res.Cfg)
 	}
 }
 

--- a/newt/cli/util.go
+++ b/newt/cli/util.go
@@ -182,7 +182,7 @@ func PackageNameList(pkgs []*pkg.LocalPackage) string {
 		if i != 0 {
 			buffer.WriteString(" ")
 		}
-		buffer.WriteString(pack.FullName())
+		buffer.WriteString(pack.Name())
 	}
 
 	return buffer.String()
@@ -274,7 +274,7 @@ func ResolveTargetOrUnittest(pkgName string) (
 			pkg.PackageTypeNames[pack.Type()])
 	}
 
-	t, err := ResolveUnittest(pack.FullName())
+	t, err := ResolveUnittest(pack.Name())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/newt/image/image.go
+++ b/newt/image/image.go
@@ -1175,7 +1175,7 @@ func (r *RepoManager) GetImageManifestPkg(
 	lpkg *pkg.LocalPackage) *ImageManifestPkg {
 
 	ip := &ImageManifestPkg{
-		Name: lpkg.FullName(),
+		Name: lpkg.Name(),
 	}
 
 	var path string

--- a/newt/mfg/create.go
+++ b/newt/mfg/create.go
@@ -44,8 +44,8 @@ type mfgManifest struct {
 }
 
 type mfgSection struct {
-	offset int
-	blob   []byte
+	offset     int
+	blob       []byte
 }
 
 type createState struct {
@@ -283,13 +283,13 @@ func areaNameFromImgIdx(imgIdx int) (string, error) {
 func bootLoaderFromPaths(t *target.Target) []string {
 	return []string{
 		/* boot.elf */
-		builder.AppElfPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
+		builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
 
 		/* boot.elf.bin */
-		builder.AppBinPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
+		builder.AppBinPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
 
 		/* manifest.json */
-		builder.ManifestPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
+		builder.ManifestPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
 	}
 }
 
@@ -300,25 +300,25 @@ func loaderFromPaths(t *target.Target) []string {
 
 	return []string{
 		/* <loader>.elf */
-		builder.AppElfPath(t.FullName(), builder.BUILD_NAME_LOADER,
-			t.Loader().FullName()),
+		builder.AppElfPath(t.Name(), builder.BUILD_NAME_LOADER,
+			t.Loader().Name()),
 
 		/* <app>.img */
-		builder.AppImgPath(t.FullName(), builder.BUILD_NAME_LOADER,
-			t.Loader().FullName()),
+		builder.AppImgPath(t.Name(), builder.BUILD_NAME_LOADER,
+			t.Loader().Name()),
 	}
 }
 
 func appFromPaths(t *target.Target) []string {
 	return []string{
 		/* <app>.elf */
-		builder.AppElfPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
+		builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
 
 		/* <app>.img */
-		builder.AppImgPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
+		builder.AppImgPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
 
 		/* manifest.json */
-		builder.ManifestPath(t.FullName(), builder.BUILD_NAME_APP, t.App().FullName()),
+		builder.ManifestPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name()),
 	}
 }
 
@@ -342,14 +342,14 @@ func (mi *MfgImage) copyBinFile(srcPath string, dstDir string) error {
 }
 
 func (mi *MfgImage) copyBinFiles() error {
-	dstPath := MfgBinDir(mi.basePkg.FullName())
+	dstPath := MfgBinDir(mi.basePkg.Name())
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
 		return util.ChildNewtError(err)
 	}
 
 	bootPaths := bootLoaderFromPaths(mi.boot)
 	for _, path := range bootPaths {
-		dstDir := MfgBootDir(mi.basePkg.FullName())
+		dstDir := MfgBootDir(mi.basePkg.Name())
 		if err := mi.copyBinFile(path, dstDir); err != nil {
 			return err
 		}
@@ -357,7 +357,7 @@ func (mi *MfgImage) copyBinFiles() error {
 
 	for i, imgTarget := range mi.images {
 		imgPaths := imageFromPaths(imgTarget)
-		dstDir := MfgImageBinDir(mi.basePkg.FullName(), i)
+		dstDir := MfgImageBinDir(mi.basePkg.Name(), i)
 		for _, path := range imgPaths {
 			if err := mi.copyBinFile(path, dstDir); err != nil {
 				return err
@@ -374,7 +374,7 @@ func (mi *MfgImage) dstBootBinPath() string {
 	}
 
 	return fmt.Sprintf("%s/%s.elf.bin",
-		MfgBootDir(mi.basePkg.FullName()),
+		MfgBootDir(mi.basePkg.Name()),
 		pkg.ShortName(mi.boot.App()))
 }
 
@@ -413,7 +413,7 @@ func (mi *MfgImage) dstImgPath(slotIdx int) string {
 	}
 
 	return fmt.Sprintf("%s/%s.img",
-		MfgImageBinDir(mi.basePkg.FullName(), imgIdx), pkg.ShortName(pack))
+		MfgImageBinDir(mi.basePkg.Name(), imgIdx), pkg.ShortName(pack))
 }
 
 // Returns a slice containing the path of each file required to build the
@@ -505,18 +505,18 @@ func (mi *MfgImage) CreateMfgImage() ([]string, error) {
 		return nil, err
 	}
 
-	sectionDir := MfgSectionBinDir(mi.basePkg.FullName())
+	sectionDir := MfgSectionBinDir(mi.basePkg.Name())
 	if err := os.MkdirAll(sectionDir, 0755); err != nil {
 		return nil, util.ChildNewtError(err)
 	}
 
 	for device, section := range cs.dsMap {
-		sectionPath := MfgSectionBinPath(mi.basePkg.FullName(), device)
+		sectionPath := MfgSectionBinPath(mi.basePkg.Name(), device)
 		err := ioutil.WriteFile(sectionPath, section.blob[section.offset:], 0644)
 		if err != nil {
 			return nil, util.ChildNewtError(err)
 		}
-		hexPath := MfgSectionHexPath(mi.basePkg.FullName(), device)
+		hexPath := MfgSectionHexPath(mi.basePkg.Name(), device)
 		mi.compiler.ConvertBinToHex(sectionPath, hexPath, section.offset)
 	}
 

--- a/newt/mfg/load.go
+++ b/newt/mfg/load.go
@@ -64,7 +64,7 @@ func sortParts(parts []mfgPart) []mfgPart {
 func (mi *MfgImage) loadError(
 	msg string, args ...interface{}) *util.NewtError {
 
-	return util.FmtNewtError("Error in %s mfg: %s", mi.basePkg.FullName(),
+	return util.FmtNewtError("Error in %s mfg: %s", mi.basePkg.Name(),
 		fmt.Sprintf(msg, args...))
 
 }
@@ -298,14 +298,14 @@ func Load(basePkg *pkg.LocalPackage) (*MfgImage, error) {
 	for _, imgTarget := range mi.images {
 		if len(mi.images) > 1 && imgTarget.LoaderName != "" {
 			return nil, mi.loadError("only one image allowed in "+
-				"split image mode (%s is a split build)", imgTarget.FullName())
+				"split image mode (%s is a split build)", imgTarget.Name())
 		}
 
 		if imgTarget.Bsp() != mi.bsp.LocalPackage {
 			return nil, mi.loadError(
 				"image target \"%s\" specified conflicting BSP; "+
 					"boot loader uses %s, image uses %s",
-				imgTarget.FullName(), mi.bsp.FullName(), imgTarget.BspName)
+				imgTarget.Name(), mi.bsp.Name(), imgTarget.BspName)
 		}
 	}
 

--- a/newt/mfg/paths.go
+++ b/newt/mfg/paths.go
@@ -88,7 +88,7 @@ func MfgManifestPath(mfgPkgName string) string {
 }
 
 func (mi *MfgImage) ManifestPath() string {
-	return MfgManifestPath(mi.basePkg.FullName())
+	return MfgManifestPath(mi.basePkg.Name())
 }
 
 func (mi *MfgImage) BootBinPath() string {
@@ -96,7 +96,7 @@ func (mi *MfgImage) BootBinPath() string {
 		return ""
 	}
 
-	return MfgBootBinPath(mi.basePkg.FullName(),
+	return MfgBootBinPath(mi.basePkg.Name(),
 		pkg.ShortName(mi.boot.App()))
 }
 
@@ -105,7 +105,7 @@ func (mi *MfgImage) BootElfPath() string {
 		return ""
 	}
 
-	return MfgBootElfPath(mi.basePkg.FullName(), pkg.ShortName(mi.boot.App()))
+	return MfgBootElfPath(mi.basePkg.Name(), pkg.ShortName(mi.boot.App()))
 }
 
 func (mi *MfgImage) BootManifestPath() string {
@@ -113,7 +113,7 @@ func (mi *MfgImage) BootManifestPath() string {
 		return ""
 	}
 
-	return MfgBootManifestPath(mi.basePkg.FullName(),
+	return MfgBootManifestPath(mi.basePkg.Name(),
 		pkg.ShortName(mi.boot.App()))
 }
 
@@ -123,7 +123,7 @@ func (mi *MfgImage) AppImgPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageImgPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(app))
+	return MfgImageImgPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(app))
 }
 
 func (mi *MfgImage) AppElfPath(imageIdx int) string {
@@ -132,7 +132,7 @@ func (mi *MfgImage) AppElfPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageElfPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(app))
+	return MfgImageElfPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(app))
 }
 
 func (mi *MfgImage) LoaderImgPath(imageIdx int) string {
@@ -141,7 +141,7 @@ func (mi *MfgImage) LoaderImgPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageImgPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(loader))
+	return MfgImageImgPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(loader))
 }
 
 func (mi *MfgImage) LoaderElfPath(imageIdx int) string {
@@ -150,7 +150,7 @@ func (mi *MfgImage) LoaderElfPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageElfPath(mi.basePkg.FullName(), imageIdx, pkg.ShortName(loader))
+	return MfgImageElfPath(mi.basePkg.Name(), imageIdx, pkg.ShortName(loader))
 }
 
 func (mi *MfgImage) ImageManifestPath(imageIdx int) string {
@@ -158,7 +158,7 @@ func (mi *MfgImage) ImageManifestPath(imageIdx int) string {
 		return ""
 	}
 
-	return MfgImageManifestPath(mi.basePkg.FullName(), imageIdx)
+	return MfgImageManifestPath(mi.basePkg.Name(), imageIdx)
 }
 
 func (mi *MfgImage) SectionBinPaths() []string {
@@ -166,7 +166,7 @@ func (mi *MfgImage) SectionBinPaths() []string {
 
 	paths := make([]string, len(sectionIds))
 	for i, sectionId := range sectionIds {
-		paths[i] = MfgSectionBinPath(mi.basePkg.FullName(), sectionId)
+		paths[i] = MfgSectionBinPath(mi.basePkg.Name(), sectionId)
 	}
 	return paths
 }
@@ -176,7 +176,7 @@ func (mi *MfgImage) SectionHexPaths() []string {
 
 	paths := make([]string, len(sectionIds))
 	for i, sectionId := range sectionIds {
-		paths[i] = MfgSectionHexPath(mi.basePkg.FullName(), sectionId)
+		paths[i] = MfgSectionHexPath(mi.basePkg.Name(), sectionId)
 	}
 	return paths
 }

--- a/newt/mfg/read.go
+++ b/newt/mfg/read.go
@@ -28,7 +28,7 @@ import (
 // @return						mfg-image-path, error
 func (mi *MfgImage) Upload() (string, error) {
 	// For now, we always upload section 0 only.
-	section0Path := MfgSectionBinPath(mi.basePkg.FullName(), 0)
+	section0Path := MfgSectionBinPath(mi.basePkg.Name(), 0)
 	baseName := strings.TrimSuffix(section0Path, ".bin")
 
 	envSettings := map[string]string{"MFG_IMAGE": "1"}

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -57,7 +57,7 @@ func (bsp *BspPackage) resolvePathSetting(
 	if err != nil {
 		return "", util.PreNewtError(err,
 			"BSP \"%s\" specifies invalid %s setting",
-			bsp.FullName(), key)
+			bsp.Name(), key)
 	}
 	return path, nil
 }
@@ -91,7 +91,7 @@ func (bsp *BspPackage) resolveLinkerScriptSetting(
 			if err != nil {
 				return nil, util.PreNewtError(err,
 					"BSP \"%s\" specifies invalid %s setting",
-					bsp.FullName(), key)
+					bsp.Name(), key)
 			}
 
 			if path != "" {

--- a/newt/pkg/dependency.go
+++ b/newt/pkg/dependency.go
@@ -35,7 +35,15 @@ func (dep *Dependency) String() string {
 }
 
 func (dep *Dependency) SatisfiesDependency(pkg interfaces.PackageInterface) bool {
-	return dep.String() == pkg.FullName()
+	if dep.Name != pkg.Name() {
+		return false
+	}
+
+	if dep.Repo != pkg.Repo().Name() {
+		return false
+	}
+
+	return true
 }
 
 func (dep *Dependency) setRepoAndName(parentRepo interfaces.RepoInterface, str string) error {

--- a/newt/pkg/dependency.go
+++ b/newt/pkg/dependency.go
@@ -22,6 +22,7 @@ package pkg
 import (
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/repo"
 )
 
 type Dependency struct {
@@ -50,10 +51,10 @@ func (dep *Dependency) setRepoAndName(parentRepo interfaces.RepoInterface, str s
 		dep.Repo = repoName
 		dep.Name = pkgName
 	} else {
-		if parentRepo != nil && !parentRepo.IsLocal() {
+		if parentRepo != nil {
 			dep.Repo = parentRepo.Name()
 		} else {
-			dep.Repo = ""
+			dep.Repo = repo.REPO_NAME_LOCAL
 		}
 		dep.Name = str
 	}

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -445,17 +445,17 @@ func ReadLocalPackageRecursive(repo *repo.Repo,
 		return warnings, nil
 	}
 
-	if oldPkg, ok := pkgList[pkg.FullName()]; ok {
+	if oldPkg, ok := pkgList[pkg.Name()]; ok {
 		oldlPkg := oldPkg.(*LocalPackage)
 		warnings = append(warnings,
 			fmt.Sprintf("Multiple packages with same pkg.name=%s "+
-				"in repo %s; path1=%s path2=%s", oldlPkg.FullName(), repo.Name(),
+				"in repo %s; path1=%s path2=%s", oldlPkg.Name(), repo.Name(),
 				oldlPkg.BasePath(), pkg.BasePath()))
 
 		return warnings, nil
 	}
 
-	pkgList[pkg.FullName()] = pkg
+	pkgList[pkg.Name()] = pkg
 
 	return warnings, nil
 }

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -328,7 +328,7 @@ func (r *Resolver) loadDepsForPkg(rpkg *ResolvePackage) (bool, error) {
 	changed := false
 
 	depEntries := rpkg.Lpkg.PkgY.GetSlice("pkg.deps", settings)
-	depender := rpkg.Lpkg.FullName()
+	depender := rpkg.Lpkg.Name()
 
 	seen := make(map[*ResolvePackage]struct{}, len(rpkg.Deps))
 
@@ -712,7 +712,7 @@ func (res *Resolution) ErrorText() string {
 			rpkgs := res.UnsatisfiedApis[api]
 			pkgNames := make([]string, len(rpkgs))
 			for i, rpkg := range rpkgs {
-				pkgNames[i] = rpkg.Lpkg.FullName()
+				pkgNames[i] = rpkg.Lpkg.Name()
 			}
 			sort.Strings(pkgNames)
 
@@ -740,7 +740,7 @@ func (res *Resolution) WarningText() string {
 			if i != 0 {
 				text += " <-> "
 			}
-			text += rpkg.Lpkg.FullName()
+			text += rpkg.Lpkg.Name()
 		}
 	}
 

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -455,8 +455,8 @@ func (cfg *Cfg) readRestrictions(lpkg *pkg.LocalPackage,
 		if err != nil {
 			return util.PreNewtError(err, "error parsing restriction: %s", rstring)
 		}
-		cfg.PackageRestrictions[lpkg.FullName()] =
-			append(cfg.PackageRestrictions[lpkg.FullName()], r)
+		cfg.PackageRestrictions[lpkg.Name()] =
+			append(cfg.PackageRestrictions[lpkg.Name()], r)
 	}
 
 	return nil

--- a/newt/sysinit/sysinit.go
+++ b/newt/sysinit/sysinit.go
@@ -139,7 +139,7 @@ func writeCalls(sortedInitFuncs []*initFunc, w io.Writer) {
 		}
 
 		fmt.Fprintf(w, "    /* %d.%d: %s (%s) */\n",
-			f.stage, dupCount, f.name, f.pkg.FullName())
+			f.stage, dupCount, f.name, f.pkg.Name())
 		fmt.Fprintf(w, "    %s();\n", f.name)
 	}
 }

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -128,7 +128,7 @@ func (target *Target) Validate(appRequired bool) error {
 
 	if bsp.Type() != pkg.PACKAGE_TYPE_BSP {
 		return util.FmtNewtError("bsp package (%s) is not of "+
-			"type bsp; type is: %s\n", bsp.FullName(),
+			"type bsp; type is: %s\n", bsp.Name(),
 			pkg.PackageTypeNames[bsp.Type()])
 	}
 
@@ -145,7 +145,7 @@ func (target *Target) Validate(appRequired bool) error {
 
 		if app.Type() != pkg.PACKAGE_TYPE_APP {
 			return util.FmtNewtError("target.app package (%s) is not of "+
-				"type app; type is: %s\n", app.FullName(),
+				"type app; type is: %s\n", app.Name(),
 				pkg.PackageTypeNames[app.Type()])
 		}
 
@@ -159,7 +159,7 @@ func (target *Target) Validate(appRequired bool) error {
 			if loader.Type() != pkg.PACKAGE_TYPE_APP {
 				return util.FmtNewtError(
 					"target.loader package (%s) is not of type app; type "+
-						"is: %s\n", loader.FullName(),
+						"is: %s\n", loader.Name(),
 					pkg.PackageTypeNames[loader.Type()])
 			}
 		}
@@ -262,7 +262,7 @@ func buildTargetMap() error {
 		if err != nil {
 			nerr := err.(*util.NewtError)
 			util.ErrorMessage(util.VERBOSITY_QUIET,
-				"Warning: failed to load target \"%s\": %s\n", pack.FullName(),
+				"Warning: failed to load target \"%s\": %s\n", pack.Name(),
 				nerr.Text)
 		} else {
 			globalTargetMap[pack.FullName()] = target


### PR DESCRIPTION
This reverts most of PR #172.  That PR caused some unexpected side effects:
* Path of binary output changed, causing inconsistency among newt versions.
* Failure to resolve BSP package local to the project.