### PR TITLE
Fix `install -f` for non-master repo commits

### DIFF
--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -729,8 +729,9 @@ func (inst *Installer) Install(
 	// For a forced install, delete all existing repos.
 	if force {
 		for _, r := range repos {
-			// Don't delete the local project directory!
-			if !r.IsLocal() {
+			// Don't delete the local project directory!  And don't delete a
+			// repo that was just cloned during this invocation of newt.
+			if !r.IsLocal() && !r.IsNewlyCloned() {
 				util.StatusMessage(util.VERBOSITY_DEFAULT,
 					"Removing old copy of \"%s\" (%s)\n", r.Name(), r.Path())
 				os.RemoveAll(r.Path())

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -222,17 +222,15 @@ func (r *Repo) checkExists() bool {
 }
 
 func (r *Repo) updateRepo(commit string) error {
-	err := r.downloader.UpdateRepo(r.Path(), commit)
-	if err != nil {
-		// If the update failed because the repo directory has been deleted,
-		// clone the repo again.
-		if util.IsNotExist(err) {
-			err = r.downloadRepo(commit)
-		}
-		if err != nil {
-			return util.FmtNewtError(
-				"Error updating \"%s\": %s", r.Name(), err.Error())
-		}
+	// Clone the repo if it doesn't exist.
+	if err := r.ensureExists(); err != nil {
+		return err
+	}
+
+	// Fetch and checkout the specified commit.
+	if err := r.downloader.UpdateRepo(r.Path(), commit); err != nil {
+		return util.FmtNewtError(
+			"Error updating \"%s\": %s", r.Name(), err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
If the `project.yml` file specified a repo version that maps to a tag, then force installs (`install -f`) consistently failed with a message similar to the following:

```
Error: Error updating "apache-mynewt-nimble": Cannot determine commit type of "nimble_1_0_0_tag"
```

The problem was caused by this sequence of events:

1. Newt fetches latest commits, branches, and tags.
2. Newt deletes old repo (due to `-f` flag).
3. Newt clones repo again.
4. Newt attempts to checkout the desired commit.

Step 4 failed because newt never re-fetched the list of tags.  The fix is to retrieve the list of tags between steps 3 and 4.