### PR TITLE
Eliminate unnecessary linker invocations

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -366,19 +366,21 @@ func (b *Builder) link(elfName string, linkerScripts []string,
 	/* Always used the trimmed archive files. */
 	pkgNames := []string{}
 
-	for _, bpkg := range b.PkgMap {
+	for _, bpkg := range b.sortedBuildPackages() {
 		archiveNames, _ := filepath.Glob(b.PkgBinDir(bpkg) + "/*.a")
 		for i, archiveName := range archiveNames {
 			archiveNames[i] = filepath.ToSlash(archiveName)
 		}
 		pkgNames = append(pkgNames, archiveNames...)
 
-		// Collect lflags from all constituent packages.
+		// Collect lflags from all constituent packages.  Discard everything
+		// from the compiler info except lflags; that is all that is relevant
+		// to the link command.
 		ci, err := bpkg.CompilerInfo(b)
 		if err != nil {
 			return err
 		}
-		c.AddInfo(ci)
+		c.AddInfo(&toolchain.CompilerInfo{Lflags: ci.Lflags})
 	}
 
 	c.LinkerScripts = linkerScripts


### PR DESCRIPTION
Somtimes newt would re-link the .elf file when no link was necessary.  This happened because:

1. Newt specified all packages' cflags and lflags in the linker command.
2. When collecting package flags, newt would iterate the list of packages in an unpredictable order.

When invoking the linker, newt sorts the flags alphabetically, so (2) by itself is not an issue.  However, if two or more flags are in conflict, newt resolves the conflict by discarding all but the first.  For example, newt collapses the following:

```
    -std=c99 -std=c89 -std=gnu99
```

into
```
    -std=c99
```

Since the flags are presented in an unpredictable order, the final form of the command is inconsistent from one run to the next.  If newt detects a change in command line since the last linker invocation, it decides that an additional link is required.  Worse, different flags are passed to the linker each time! (though, luckily, it seems these flags are ignored by the linker since they are compiler flags, at least those specified by the apache-mynewt-core packages).

The fixes are:

1. When building the linker command, only extract each package's *lflags* (not cflags).
2. Iterate the package list in a predictable order (alphabetically).