### PR TITLE
Sync: Pull from current upstream, not origin

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -58,7 +58,7 @@ func newRunCmd(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	if err := dl.DownloadRepo(newtutil.NewtBlinkyTag, tmpdir); err != nil {
+	if err := dl.Clone(newtutil.NewtBlinkyTag, tmpdir); err != nil {
 		NewtUsage(nil, err)
 	}
 

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -44,21 +44,31 @@ const (
 )
 
 type Downloader interface {
-	FetchFile(path string, filename string, dstDir string) error
-	GetCommit() string
-	SetCommit(commit string)
+	// Fetches all remotes and downloads the specified file.
+	FetchFile(commit string, path string, filename string, dstDir string) error
+
+	// Clones the repo and checks out the specified commit.
 	DownloadRepo(commit string, dstPath string) error
+
+	// Determines the equivalent commit hash for the specified commit string.
 	HashFor(path string, commit string) (string, error)
+
+	// Collects all commits that are equivalent to the specified commit string
+	// (i.e., 1 hash, n tags, and n branches).
 	CommitsFor(path string, commit string) ([]string, error)
+
+	// Merges the specified branch into the local repo.
 	UpdateRepo(path string, branchName string) error
+
+	// Indicates whether there are any uncommitted changes to the repo.
 	AreChanges(path string) (bool, error)
+
+	// Determines the type of the specified commit.
 	CommitType(path string, commit string) (DownloaderCommitType, error)
 	FixupOrigin(path string) error
 }
 
 type GenericDownloader struct {
-	commit string
-
 	// Whether 'origin' has been fetched during this run.
 	fetched bool
 }
@@ -409,14 +419,6 @@ func warnWrongOriginUrl(path string, curUrl string, goodUrl string) {
 		curUrl, goodUrl)
 }
 
-func (gd *GenericDownloader) GetCommit() string {
-	return gd.commit
-}
-
-func (gd *GenericDownloader) SetCommit(branch string) {
-	gd.commit = branch
-}
-
 func (gd *GenericDownloader) CommitType(
 	path string, commit string) (DownloaderCommitType, error) {
 
@@ -515,13 +517,13 @@ func (gd *GithubDownloader) authenticatedCommand(path string,
 }
 
 func (gd *GithubDownloader) FetchFile(
-	path string, filename string, dstDir string) error {
+	commit string, path string, filename string, dstDir string) error {
 
 	if err := gd.fetch(path); err != nil {
 		return err
 	}
 
-	if err := showFile(path, gd.GetCommit(), filename, dstDir); err != nil {
+	if err := showFile(path, commit, filename, dstDir); err != nil {
 		return err
 	}
 
@@ -673,13 +675,13 @@ func (gd *GitDownloader) fetch(repoDir string) error {
 }
 
 func (gd *GitDownloader) FetchFile(
-	path string, filename string, dstDir string) error {
+	commit string, path string, filename string, dstDir string) error {
 
 	if err := gd.fetch(path); err != nil {
 		return err
 	}
 
-	if err := showFile(path, gd.GetCommit(), filename, dstDir); err != nil {
+	if err := showFile(path, commit, filename, dstDir); err != nil {
 		return err
 	}
 
@@ -765,7 +767,7 @@ func NewGitDownloader() *GitDownloader {
 }
 
 func (ld *LocalDownloader) FetchFile(
-	path string, filename string, dstDir string) error {
+	commit string, path string, filename string, dstDir string) error {
 
 	srcPath := ld.Path + "/" + filename
 	dstPath := dstDir + "/" + filename

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -48,7 +48,7 @@ type Downloader interface {
 	FetchFile(commit string, path string, filename string, dstDir string) error
 
 	// Clones the repo and checks out the specified commit.
-	DownloadRepo(commit string, dstPath string) error
+	Clone(commit string, dstPath string) error
 
 	// Determines the equivalent commit hash for the specified commit string.
 	HashFor(path string, commit string) (string, error)
@@ -601,7 +601,7 @@ func (gd *GithubDownloader) setRemoteAuth(path string) error {
 	return gd.setOriginUrl(path, url)
 }
 
-func (gd *GithubDownloader) DownloadRepo(commit string, dstPath string) error {
+func (gd *GithubDownloader) Clone(commit string, dstPath string) error {
 	// Currently only the master branch is supported.
 	branch := "master"
 
@@ -709,7 +709,7 @@ func (gd *GitDownloader) AreChanges(path string) (bool, error) {
 	return areChanges(path)
 }
 
-func (gd *GitDownloader) DownloadRepo(commit string, dstPath string) error {
+func (gd *GitDownloader) Clone(commit string, dstPath string) error {
 	// Currently only the master branch is supported.
 	branch := "master"
 
@@ -782,14 +782,14 @@ func (ld *LocalDownloader) FetchFile(
 
 func (ld *LocalDownloader) UpdateRepo(path string, branchName string) error {
 	os.RemoveAll(path)
-	return ld.DownloadRepo(branchName, path)
+	return ld.Clone(branchName, path)
 }
 
 func (ld *LocalDownloader) AreChanges(path string) (bool, error) {
 	return areChanges(path)
 }
 
-func (ld *LocalDownloader) DownloadRepo(commit string, dstPath string) error {
+func (ld *LocalDownloader) Clone(commit string, dstPath string) error {
 	util.StatusMessage(util.VERBOSITY_DEFAULT,
 		"Downloading local repository %s\n", ld.Path)
 

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -57,8 +57,8 @@ type Downloader interface {
 	// (i.e., 1 hash, n tags, and n branches).
 	CommitsFor(path string, commit string) ([]string, error)
 
-	// Merges the specified branch into the local repo.
-	UpdateRepo(path string, branchName string) error
+	// Fetches all remotes and merges the specified branch into the local repo.
+	Pull(path string, branchName string) error
 
 	// Indicates whether there are any uncommitted changes to the repo.
 	AreChanges(path string) (bool, error)
@@ -530,7 +530,7 @@ func (gd *GithubDownloader) FetchFile(
 	return nil
 }
 
-func (gd *GithubDownloader) UpdateRepo(path string, branchName string) error {
+func (gd *GithubDownloader) Pull(path string, branchName string) error {
 	err := gd.fetch(path)
 	if err != nil {
 		return err
@@ -688,7 +688,7 @@ func (gd *GitDownloader) FetchFile(
 	return nil
 }
 
-func (gd *GitDownloader) UpdateRepo(path string, branchName string) error {
+func (gd *GitDownloader) Pull(path string, branchName string) error {
 	err := gd.fetch(path)
 	if err != nil {
 		return err
@@ -780,7 +780,7 @@ func (ld *LocalDownloader) FetchFile(
 	return nil
 }
 
-func (ld *LocalDownloader) UpdateRepo(path string, branchName string) error {
+func (ld *LocalDownloader) Pull(path string, branchName string) error {
 	os.RemoveAll(path)
 	return ld.Clone(branchName, path)
 }

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -487,8 +487,11 @@ func (inst *Installer) installMessageOneRepo(
 	msg := fmt.Sprintf("    %s %s ", verb, repoName)
 	if op == INSTALL_OP_UPGRADE {
 		msg += fmt.Sprintf("(%s --> %s)", curVer.String(), destVer.String())
-	} else {
+	} else if op != INSTALL_OP_SYNC {
 		msg += fmt.Sprintf("(%s)", destVer.String())
+	} else {
+		// Sync operation.  Don't print the project version.  Instead, print
+		// the actual branch name later during the sync.
 	}
 
 	return msg, nil

--- a/newt/project/pkgwriter.go
+++ b/newt/project/pkgwriter.go
@@ -249,7 +249,7 @@ func (pw *PackageWriter) WritePackage() error {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	if err := dl.DownloadRepo(pw.repo.branch, tmpdir); err != nil {
+	if err := dl.Clone(pw.repo.branch, tmpdir); err != nil {
 		return err
 	}
 

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -228,7 +228,7 @@ func (r *Repo) updateRepo(commit string) error {
 	}
 
 	// Fetch and checkout the specified commit.
-	if err := r.downloader.UpdateRepo(r.Path(), commit); err != nil {
+	if err := r.downloader.Pull(r.Path(), commit); err != nil {
 		return util.FmtNewtError(
 			"Error updating \"%s\": %s", r.Name(), err.Error())
 	}

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -343,10 +343,6 @@ func (r *Repo) ensureExists() error {
 
 func (r *Repo) downloadFile(commit string, srcPath string) (string, error) {
 	dl := r.downloader
-	origCommit := dl.GetCommit()
-
-	dl.SetCommit(commit)
-	defer dl.SetCommit(origCommit)
 
 	// Clone the repo if it doesn't exist.
 	if err := r.ensureExists(); err != nil {
@@ -358,7 +354,7 @@ func (r *Repo) downloadFile(commit string, srcPath string) (string, error) {
 		return "", util.ChildNewtError(err)
 	}
 
-	if err := dl.FetchFile(r.localPath, srcPath, cpath); err != nil {
+	if err := dl.FetchFile(commit, r.localPath, srcPath, cpath); err != nil {
 		return "", util.FmtNewtError(
 			"Download of \"%s\" from repo:%s commit:%s failed: %s",
 			srcPath, r.Name(), commit, err.Error())

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -262,8 +262,8 @@ func (r *Repo) Upgrade(ver newtutil.RepoVersion) error {
 
 	if changes {
 		return util.FmtNewtError(
-			"Repository \"%s\" contains local changes.  Provide the "+
-				"-f option to attempt a merge.", r.Name())
+			"Repository \"%s\" contains local changes.  Please resolve "+
+				"changes manually and try again.", r.Name())
 	}
 
 	if err := r.updateRepo(commit); err != nil {
@@ -273,34 +273,60 @@ func (r *Repo) Upgrade(ver newtutil.RepoVersion) error {
 	return nil
 }
 
+// @return bool                 True if the sync succeeded.
+// @return error                Fatal error.
 func (r *Repo) Sync(ver newtutil.RepoVersion) (bool, error) {
-	// Update the repo description
-	if _, err := r.UpdateDesc(); err != nil {
-		return false, util.NewNewtError("Cannot update repository description.")
-	}
-
-	commit, err := r.CommitFromVer(ver)
+	// Sync is only allowed if a branch is checked out.
+	branch, err := r.downloader.CurrentBranch(r.localPath)
 	if err != nil {
 		return false, err
 	}
-	if commit == "" {
-		return false, util.FmtNewtError(
-			"No commit mapping for %s,%s", r.Name(), ver.String())
+
+	if branch == "" {
+		commits, err := r.CurrentCommits()
+		if err != nil {
+			return false, err
+		}
+
+		util.StatusMessage(util.VERBOSITY_DEFAULT,
+			"Skipping \"%s\": not using a branch (current-commits=%v)\n",
+			r.Name(), commits)
+		return false, nil
+	}
+
+	// Determine the upstream associated with the current branch.  This is the
+	// upstream that will be pulled from.
+	upstream, err := r.downloader.UpstreamFor(r.localPath, branch)
+	if err != nil {
+		return false, err
+	}
+	if upstream == "" {
+		util.StatusMessage(util.VERBOSITY_QUIET,
+			"Failed to sync repo \"%s\": no upstream being tracked "+
+				"(branch=%s)\n",
+			r.Name(), branch)
+		return false, nil
 	}
 
 	util.StatusMessage(util.VERBOSITY_DEFAULT,
-		"Syncing repository \"%s\"... ", r.Name())
-	err = r.updateRepo(commit)
+		"Syncing repository \"%s\" (%s)... ", r.Name(), upstream)
+
+	// Pull from upstream.
+	err = r.updateRepo(branch)
 	if err == nil {
 		util.StatusMessage(util.VERBOSITY_DEFAULT, "success\n")
-		return true, err
+		return true, nil
 	} else {
 		util.StatusMessage(util.VERBOSITY_QUIET, "failed: %s\n",
-			err.Error())
-		return false, err
+			strings.TrimSpace(err.Error()))
+		return false, nil
 	}
 }
 
+// Fetches all remotes and downloads an up to date copy of `repository.yml`
+// from master.  The repo object is then populated with the contents of the
+// downladed file.  If this repo has already had its descriptor updated, this
+// function is a no-op.
 func (r *Repo) UpdateDesc() (bool, error) {
 	var err error
 
@@ -310,10 +336,12 @@ func (r *Repo) UpdateDesc() (bool, error) {
 
 	util.StatusMessage(util.VERBOSITY_VERBOSE, "[%s]:\n", r.Name())
 
+	// Download `repository.yml`.
 	if err = r.DownloadDesc(); err != nil {
 		return false, err
 	}
 
+	// Read `repository.yml` and populate this repo object.
 	if err := r.Read(); err != nil {
 		return false, err
 	}
@@ -375,7 +403,7 @@ func (r *Repo) downloadRepositoryYml() error {
 	return nil
 }
 
-// Download the repository description.
+// Downloads the repository description, i.e., `repository.yml`.
 func (r *Repo) DownloadDesc() error {
 	util.StatusMessage(util.VERBOSITY_VERBOSE, "Downloading "+
 		"repository description\n")

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -200,7 +200,7 @@ func (r *Repo) downloadRepo(commit string) error {
 	defer os.RemoveAll(tmpdir)
 
 	// Download the git repo, returns the git repo, checked out to that commit
-	if err := dl.DownloadRepo(commit, tmpdir); err != nil {
+	if err := dl.Clone(commit, tmpdir); err != nil {
 		return util.FmtNewtError("Error downloading repository %s: %s",
 			r.Name(), err.Error())
 	}


### PR DESCRIPTION
Prior to this commit, the `newt sync` command would assume the current branch's upstream is origin.  This caused a number of issues:

1. If branch has an upstream other than origin, but there exists an identically named branch in origin, then `origin/<branch>` is pulled into the current checkout.  So, updates to one branch would get merged into another, i.e., totally wrong.

2. If origin does not have an identically named branch, then the sync operation would have no effect.

This commit changes newt to just pull from the currently tracked upstream.
