### PR TITLE
Upgrade: Ensure "origin" points to correct URL

### DIFF
--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -331,6 +331,13 @@ func (r *Repo) ensureExists() error {
 		}
 	}
 
+	// Make sure the repo's "origin" remote points to the correct URL.  This is
+	// necessary in case the user changed his `project.yml` file to point to a
+	// different fork.
+	if err := r.downloader.FixupOrigin(r.localPath); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
On `newt install`, `newt upgrade`, and `newt sync`, force "origin" remote to point to the URL specified in `project.yml` (or in another repo's dependency specification, if the repo is not described in `project.yml`).

This is necessary when the user changes `project.yml` to have a different URL for an already-installed repo.  This would happen if the user is switching between github forks.