### PR TITLE
Cmake fixes

### DIFF
--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -229,7 +229,7 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 		elfOutputDir,
 		elfOutputDir,
 		elfOutputDir,
-		strings.Join(lFlags, " "))
+		strings.Replace(strings.Join(lFlags, " "), "\"", "\\\\\\\"", -1))
 
 	fmt.Fprintln(w)
 

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -69,25 +69,6 @@ func extractIncludes(flags *[]string, includes *[]string, other *[]string) {
 	}
 }
 
-func removeDuplicates(elements []string) []string {
-	// Use map to record duplicates as we find them.
-	encountered := map[string]bool{}
-	result := []string{}
-
-	for v := range elements {
-		if encountered[elements[v]] == true {
-			// Do not add duplicate.
-		} else {
-			// Record this element as an encountered element.
-			encountered[elements[v]] = true
-			// Append to result slice.
-			result = append(result, elements[v])
-		}
-	}
-	// Return the new slice.
-	return result
-}
-
 func CmakeSourceObjectWrite(w io.Writer, cj toolchain.CompilerJob, includeDirs *[]string) {
 	c := cj.Compiler
 
@@ -263,7 +244,8 @@ func CmakeCompilerInfoWrite(w io.Writer, archiveFile string, bpkg *BuildPackage,
 	includes = append(includes, c.GetLocalCompilerInfo().Includes...)
 	includes = append(includes, otherIncludes...)
 
-	includes = removeDuplicates(includes)
+	// Sort and remove duplicate flags
+	includes = util.SortFields(includes...)
 	trimProjectPathSlice(includes)
 
 	fmt.Fprintf(w, `set_target_properties(%s

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -92,6 +92,9 @@ func CmakeSourceObjectWrite(w io.Writer, cj toolchain.CompilerJob, includeDirs *
 	extractIncludes(&compileFlags, includeDirs, &otherFlags)
 	cj.Filename = trimProjectPath(cj.Filename)
 
+	// Sort and remove duplicate flags
+	otherFlags = util.SortFields(otherFlags...)
+
 	fmt.Fprintf(w, `set_property(SOURCE %s APPEND_STRING
 														PROPERTY
 														COMPILE_FLAGS


### PR DESCRIPTION
- cmake: Escape quotes in linker flags

- cmake: Fix undeterministic build error by sorting includes
The order of include directories was non-deterministic and caused issues with
including wrong files which resulted in 'undefined reference' errors.
