### PR TITLE
syscfg: Add 'deprecated' field to syscfg.defs

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -202,6 +202,10 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 		log.Debug(warningText)
 	}
 
+	for _, line := range t.res.DeprecatedWarning() {
+		log.Warn(line)
+	}
+
 	if err := syscfg.EnsureWritten(t.res.Cfg,
 		GeneratedIncludeDir(t.target.Name())); err != nil {
 

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -747,3 +747,7 @@ func (res *Resolution) WarningText() string {
 
 	return text + res.Cfg.WarningText()
 }
+
+func (res *Resolution) DeprecatedWarning() []string {
+	return res.Cfg.DeprecatedWarning()
+}


### PR DESCRIPTION
This allows to warn about using deprecated definitions and point users to new ones.