### PR TITLE
Pass relative bin paths to load and debug scripts.

### DIFF
--- a/newt/builder/load.go
+++ b/newt/builder/load.go
@@ -144,9 +144,10 @@ func (b *Builder) Load(imageSlot int, extraJtagCmd string) error {
 	}
 	envSettings["FLASH_OFFSET"] = "0x" + strconv.FormatInt(int64(tgtArea.Offset), 16)
 
-	if err := Load(b.AppBinBasePath(), b.targetBuilder.bspPkg,
-		envSettings); err != nil {
-
+	// Convert the binary path from absolute to relative.  This is required for
+	// compatibility with unix-in-windows environemnts (e.g., cygwin).
+	binPath := util.TryRelPath(b.AppBinBasePath())
+	if err := Load(binPath, b.targetBuilder.bspPkg, envSettings); err != nil {
 		return err
 	}
 
@@ -213,5 +214,8 @@ func (b *Builder) Debug(extraJtagCmd string, reset bool, noGDB bool) error {
 		return util.NewNewtError("app package not specified")
 	}
 
-	return b.debugBin(b.AppBinBasePath(), extraJtagCmd, reset, noGDB)
+	// Convert the binary path from absolute to relative.  This is required for
+	// Windows compatibility.
+	binPath := util.TryRelPath(b.AppBinBasePath())
+	return b.debugBin(binPath, extraJtagCmd, reset, noGDB)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -651,3 +651,20 @@ func PrintStacks() {
 	stacklen := runtime.Stack(buf, true)
 	fmt.Printf("*** goroutine dump\n%s\n*** end\n", buf[:stacklen])
 }
+
+// Attempts to convert the specified absolute path into a relative path
+// (relative to the current working directory).  If the path cannot be
+// converted, it is returned unchanged.
+func TryRelPath(full string) string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return full
+	}
+
+	rel, err := filepath.Rel(pwd, full)
+	if err != nil {
+		return full
+	}
+
+	return rel
+}


### PR DESCRIPTION
This is required for compatibility with Linux environments running in Windows.  In these environments, absolute paths have unlikely representations (e.g., /c/documents vs. C:\documents).