### PR TITLE
Allow build_profile to be overridden per package

### DIFF
--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -118,10 +118,18 @@ func expandFlags(flags []string) {
 	}
 }
 
+// Retrieves the build package's build profile override, as specified in its
+// `pkg.yml` file.  If the package does not override the build profile, "" is
+// returned.
+func (bpkg *BuildPackage) BuildProfile(b *Builder) string {
+	settings := b.cfg.AllSettingsForLpkg(bpkg.rpkg.Lpkg)
+	return bpkg.rpkg.Lpkg.PkgY.GetValString("pkg.build_profile", settings)
+}
+
 func (bpkg *BuildPackage) CompilerInfo(
 	b *Builder) (*toolchain.CompilerInfo, error) {
 
-	// If this package's compiler info has already been generated, returned the
+	// If this package's compiler info has already been generated, return the
 	// cached copy.
 	if bpkg.ci != nil {
 		return bpkg.ci, nil
@@ -130,7 +138,7 @@ func (bpkg *BuildPackage) CompilerInfo(
 	ci := toolchain.NewCompilerInfo()
 	settings := b.cfg.AllSettingsForLpkg(bpkg.rpkg.Lpkg)
 
-	// Read each set of flags and expand repo designators ("@<repo-nme>") into
+	// Read each set of flags and expand repo designators ("@<repo-name>") into
 	// paths.
 	ci.Cflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cflags", settings)
 	expandFlags(ci.Cflags)

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -326,7 +326,7 @@ func CMakeTargetGenerate(target *target.Target) error {
 		return err
 	}
 
-	targetCompiler, err := targetBuilder.NewCompiler("")
+	targetCompiler, err := targetBuilder.NewCompiler("", "")
 	if err != nil {
 		return err
 	}

--- a/newt/builder/library.go
+++ b/newt/builder/library.go
@@ -127,7 +127,7 @@ func (b *Builder) ParseObjectElf(elf_file string) (error, *symbol.SymbolMap) {
 func (b *Builder) ParseObjectLibraryFile(bp *BuildPackage,
 	file string, textDataOnly bool) (error, *symbol.SymbolMap) {
 
-	c, err := b.targetBuilder.NewCompiler(b.AppElfPath())
+	c, err := b.targetBuilder.NewCompiler(b.AppElfPath(), "")
 
 	ext := filepath.Ext(file)
 
@@ -206,7 +206,7 @@ func (b *Builder) ParseObjectLibraryFile(bp *BuildPackage,
 }
 
 func (b *Builder) CopySymbols(sm *symbol.SymbolMap) error {
-	c, err := b.targetBuilder.NewCompiler(b.AppElfPath())
+	c, err := b.targetBuilder.NewCompiler(b.AppElfPath(), "")
 
 	if err != nil {
 		return err

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -107,13 +107,15 @@ func NewTargetBuilder(target *target.Target) (*TargetBuilder, error) {
 	return NewTargetTester(target, nil)
 }
 
-func (t *TargetBuilder) NewCompiler(dstDir string) (
+func (t *TargetBuilder) NewCompiler(dstDir string, buildProfile string) (
 	*toolchain.Compiler, error) {
 
+	if buildProfile == "" {
+		buildProfile = t.target.BuildProfile
+	}
+
 	c, err := toolchain.NewCompiler(
-		t.compilerPkg.BasePath(),
-		dstDir,
-		t.target.BuildProfile)
+		t.compilerPkg.BasePath(), dstDir, buildProfile)
 
 	return c, err
 }
@@ -406,7 +408,7 @@ func (t *TargetBuilder) autogenKeys() error {
 	fmt.Fprintln(w, "#include <bootutil/sign_key.h>")
 	fmt.Fprintf(w, "const unsigned char key[] = {")
 	for count, b := range keyBytes {
-		if count % 8 == 0 {
+		if count%8 == 0 {
 			fmt.Fprintf(w, "\n    ")
 		} else {
 			fmt.Fprintf(w, " ")
@@ -421,7 +423,7 @@ func (t *TargetBuilder) autogenKeys() error {
 	fmt.Fprintln(w, "        .len = &key_len,")
 	fmt.Fprintln(w, "    },")
 	fmt.Fprintln(w, "};")
-	fmt.Fprintln(w, "const int bootutil_key_cnt = 1;");
+	fmt.Fprintln(w, "const int bootutil_key_cnt = 1;")
 	w.Flush()
 
 	return nil
@@ -862,7 +864,7 @@ func (t *TargetBuilder) CreateImages(version string,
 	var appImg *image.Image
 	var loaderImg *image.Image
 
-	c, err := t.NewCompiler("")
+	c, err := t.NewCompiler("", "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -648,7 +648,7 @@ func (t *TargetBuilder) createManifest() error {
 
 	manifest.Repos = rm.AllRepos()
 
-	vars := t.GetTarget().Vars
+	vars := t.GetTarget().TargetY.AllSettingsAsStrings()
 	keys := make([]string, 0, len(vars))
 	for k := range vars {
 		keys = append(keys, k)

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -200,7 +200,8 @@ func targetShowCmd(cmd *cobra.Command, args []string) {
 		util.StatusMessage(util.VERBOSITY_DEFAULT, name+"\n")
 
 		target := target.GetTargets()[name]
-		for k, v := range target.Vars {
+		settings := target.TargetY.AllSettingsAsStrings()
+		for k, v := range settings {
 			kvPairs[strings.TrimPrefix(k, "target.")] = v
 		}
 
@@ -321,10 +322,10 @@ func targetSetCmd(cmd *cobra.Command, args []string) {
 		} else {
 			if kv[1] == "" {
 				// User specified empty value; delete variable.
-				delete(t.Vars, kv[0])
+				t.TargetY.Delete(kv[0])
 			} else {
 				// Assign value to specified variable.
-				t.Vars[kv[0]] = kv[1]
+				t.TargetY.Replace(kv[0], kv[1])
 			}
 		}
 	}

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -196,3 +196,8 @@ func ReadConfigPath(path string) (ycfg.YCfg, error) {
 func ReadConfig(dir string, filename string) (ycfg.YCfg, error) {
 	return ReadConfigPath(dir + "/" + filename + ".yml")
 }
+
+// Converts the provided YAML-configuration map to a YAML-encoded string.
+func YCfgToYaml(yc ycfg.YCfg) string {
+	return yaml.MapToYaml(yc.AllSettings())
+}

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -213,36 +212,21 @@ func (pkg *LocalPackage) sequenceString(key string) string {
 	}
 }
 
-func (lpkg *LocalPackage) SaveSyscfgVals() error {
+func (lpkg *LocalPackage) SaveSyscfg() error {
 	dirpath := lpkg.BasePath()
 	if err := os.MkdirAll(dirpath, 0755); err != nil {
 		return util.NewNewtError(err.Error())
 	}
 
 	filepath := dirpath + "/" + SYSCFG_YAML_FILENAME
-
-	syscfgVals := lpkg.SyscfgY.GetValStringMapString("syscfg.vals", nil)
-	if syscfgVals == nil || len(syscfgVals) == 0 {
-		os.Remove(filepath)
-		return nil
-	}
-
 	file, err := os.Create(filepath)
 	if err != nil {
 		return util.NewNewtError(err.Error())
 	}
 	defer file.Close()
 
-	names := make([]string, 0, len(syscfgVals))
-	for k, _ := range syscfgVals {
-		names = append(names, k)
-	}
-	sort.Strings(names)
-
-	fmt.Fprintf(file, "syscfg.vals:\n")
-	for _, name := range names {
-		fmt.Fprintf(file, "    %s: %s\n", name, yaml.EscapeString(syscfgVals[name]))
-	}
+	s := newtutil.YCfgToYaml(lpkg.SyscfgY)
+	file.WriteString(s)
 
 	return nil
 }

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -103,6 +103,8 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 	}
 
 	target.KeyFile = yc.GetValString("target.key_file", nil)
+	target.PkgProfiles = yc.GetValStringMapString(
+		"target.package_profiles", nil)
 
 	// Note: App not required in the case of unit tests.
 

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -22,7 +22,6 @@ package target
 import (
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -32,7 +31,6 @@ import (
 	"mynewt.apache.org/newt/newt/repo"
 	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
-	"mynewt.apache.org/newt/yaml"
 )
 
 const TARGET_FILENAME string = "target.yml"
@@ -235,18 +233,10 @@ func (t *Target) Save() error {
 	}
 	defer file.Close()
 
-	settings := t.TargetY.AllSettingsAsStrings()
-	keys := []string{}
-	for k, _ := range settings {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	s := newtutil.YCfgToYaml(t.TargetY)
+	file.WriteString(s)
 
-	for _, k := range keys {
-		file.WriteString(k + ": " + yaml.EscapeString(settings[k]) + "\n")
-	}
-
-	if err := t.basePkg.SaveSyscfgVals(); err != nil {
+	if err := t.basePkg.SaveSyscfg(); err != nil {
 		return err
 	}
 

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -159,6 +159,15 @@ func NewCompilerInfo() *CompilerInfo {
 // Extracts the base of a flag string.  A flag base is used when detecting flag
 // conflicts.  If two flags have identicial bases, then they are in conflict.
 func flagsBase(cflags string) string {
+	// "-O" (optimization level) is one possible flag base.  By singling these
+	// out, newt can prevent the original optimization flag from being
+	// overwritten by subsequent ones.
+	if cflags == "-O" || len(cflags) == 3 && strings.HasPrefix(cflags, "-O") {
+		return "-O"
+	}
+
+	// Identify <key>=<value> pairs.  Newt prevents subsequent assignments to
+	// the same key from overriding the original.
 	eqIdx := strings.IndexByte(cflags, '=')
 	if eqIdx == -1 {
 		return cflags

--- a/newt/ycfg/ycfg.go
+++ b/newt/ycfg/ycfg.go
@@ -465,6 +465,10 @@ func (node *YCfgNode) FullName() string {
 	return strings.Join(tokens, ".")
 }
 
+func (yc YCfg) Delete(name string) {
+	delete(yc, name)
+}
+
 func (yc YCfg) Traverse(cb func(node *YCfgNode, depth int)) {
 	var traverseLevel func(
 		node *YCfgNode,
@@ -497,6 +501,16 @@ func (yc YCfg) AllSettings() map[string]interface{} {
 	})
 
 	return settings
+}
+
+func (yc YCfg) AllSettingsAsStrings() map[string]string {
+	settings := yc.AllSettings()
+	smap := make(map[string]string, len(settings))
+	for k, v := range settings {
+		smap[k] = fmt.Sprintf("%v", v)
+	}
+
+	return smap
 }
 
 func (yc YCfg) String() string {

--- a/yaml/misc.go
+++ b/yaml/misc.go
@@ -20,13 +20,67 @@
 package yaml
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 )
 
 func EscapeString(s string) string {
-	if s == "" {
-		return ""
-	} else {
+	special := ":{}[],&*#?|-<>=!%@\\\"'"
+	if strings.ContainsAny(s, special) {
 		return "\"" + strings.Replace(s, "\"", "\\\"", -1) + "\""
+	} else {
+		return s
 	}
+}
+
+// Converts a key-value pair to a YAML string.
+func KvToYaml(key string, val interface{}, indent int) string {
+	s := ""
+
+	if key != "" {
+		s += fmt.Sprintf("%*s%s:", indent, "", EscapeString(key))
+	}
+
+	switch v := val.(type) {
+	case []interface{}:
+		s += "\n"
+		for _, elem := range v {
+			s += fmt.Sprintf("%*s- %s\n", indent+4, "", KvToYaml("", elem, 0))
+		}
+
+	case map[interface{}]interface{}:
+		s += "\n"
+
+		subKeys := make([]string, 0, len(v))
+		for sk, _ := range v {
+			subKeys = append(subKeys, sk.(string))
+		}
+		sort.Strings(subKeys)
+
+		for _, sk := range subKeys {
+			s += KvToYaml(sk, v[sk], indent+4)
+		}
+
+	default:
+		valStr := EscapeString(fmt.Sprintf("%v", v))
+		s += fmt.Sprintf(" %v\n", valStr)
+	}
+
+	return s
+}
+
+func MapToYaml(m map[string]interface{}) string {
+	keys := make([]string, 0, len(m))
+	for k, _ := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	s := ""
+	for _, k := range keys {
+		s += KvToYaml(k, m[k], 0)
+	}
+
+	return s
 }


### PR DESCRIPTION
The build profile can be overridden for a particular pacakge in two
ways:

* (1) Specify a "pkg.build_profile" value in the package's `pkg.yml` file.  E.g.,
```
pkg.build_profile: debug
```

* (2) Specify the pacakge in the target's "target.package_profiles" map.  E.g.,
```
target.package_profiles:
    'apps/blinky': debug
    '@apache-mynewt-core/sys/log/full': debug
```

(1) takes priority over (2).

In addition, it is now possible to override the optimization setting ("-O<x>") in a package's `pkg.cflags`.  Prior to this change, the "-O" setting specified by the compiler / build profile would always override what other packages specify.