### PR TITLE
syscfg: error detection after API resolution

### DIFF
--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -648,6 +648,7 @@ func ResolveFull(
 	if loaderSeeds == nil {
 		res.AppSet.Rpkgs = r.rpkgSlice()
 		res.LoaderSet = nil
+		res.Cfg.DetectErrors(flashMap)
 		return res, nil
 	}
 
@@ -691,6 +692,8 @@ func ResolveFull(
 	if err != nil {
 		return nil, err
 	}
+
+	res.Cfg.DetectErrors(flashMap)
 
 	return res, nil
 }

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -1009,6 +1009,15 @@ func (cfg *Cfg) detectAmbiguities() {
 	}
 }
 
+// Detects and records errors in the build's syscfg.  This should only be
+// called after APIs are resolved to avoid false positives.
+func (cfg *Cfg) DetectErrors(flashMap flash.FlashMap) {
+	cfg.detectAmbiguities()
+	cfg.detectViolations()
+	cfg.detectPriorityViolations()
+	cfg.detectFlashConflicts(flashMap)
+}
+
 func Read(lpkgs []*pkg.LocalPackage, apis []string,
 	injectedSettings map[string]string, settings map[string]string,
 	flashMap flash.FlashMap) (Cfg, error) {
@@ -1068,11 +1077,6 @@ func Read(lpkgs []*pkg.LocalPackage, apis []string,
 			return cfg, err
 		}
 	}
-
-	cfg.detectAmbiguities()
-	cfg.detectViolations()
-	cfg.detectPriorityViolations()
-	cfg.detectFlashConflicts(flashMap)
 
 	return cfg, nil
 }


### PR DESCRIPTION
Prior to this PR, newt detected errors in the syscfg before API requirements were satisfied. Consequently, error detection was happening before the full dependency graph had been generated, resulting in an incomplete set of syscfg settings.  Parsing of restriction strings might fail in this case, as unrecognized setting names are parsed as string literals rather than expanded to the value that the setting would ultimately have.

This PR delays error detection until after API resolution.