### PR TITLE
Allow setting value to reference other setting

### DIFF
--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -567,17 +567,34 @@ func printSetting(entry syscfg.CfgEntry) {
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			"default=%s\n", entry.History[0].Value)
 	}
+	if len(entry.ValueRefName) > 0 {
+		util.StatusMessage(util.VERBOSITY_DEFAULT,
+			"    * Copied from: %s\n",
+			entry.ValueRefName)
+	}
 }
 
 func printBriefSetting(entry syscfg.CfgEntry) {
 	util.StatusMessage(util.VERBOSITY_DEFAULT, "  %s: %s",
 		entry.Name, entry.Value)
 
+	var extras []string
+
 	if len(entry.History) > 1 {
-		util.StatusMessage(util.VERBOSITY_DEFAULT,
-			" (overridden by %s)",
+		s := fmt.Sprintf("overridden by %s",
 			entry.History[len(entry.History)-1].Source.FullName())
+		extras = append(extras, s)
 	}
+	if len(entry.ValueRefName) > 0 {
+		s := fmt.Sprintf("copied from %s", entry.ValueRefName)
+		extras = append(extras, s)
+	}
+
+	if len(extras) > 0{
+		util.StatusMessage(util.VERBOSITY_DEFAULT, " (%s)",
+			strings.Join(extras, ", "))
+	}
+
 	util.StatusMessage(util.VERBOSITY_DEFAULT, "\n")
 }
 

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -417,6 +417,8 @@ func (r *Resolver) reloadCfg() (bool, error) {
 		return false, err
 	}
 
+	cfg.ResolveValueRefs()
+
 	// Determine if any settings have changed.
 	for k, v := range cfg.Settings {
 		oldval, ok := r.cfg.Settings[k]


### PR DESCRIPTION
Currently the only way to have one setting copy value from other setting is to do as follows:
```
syscfg.vals:
    FOO: 'MYNEWT_VAL_BAR'
```
The problem with the above is that `newt` handles value of `FOO` as a string which is then resolved by preprocessor during build so this won't evaluate properly if used inside `syscfg.restrictions`

This PR allows one setting value to explicitly reference other setting and have other value copied by `newt`. The syntax is the same as used in C code:
```
syscfg.vals:
    FOO: 'MYNEWT_VAL(BAR)'
````

For now it does not support recursive references but I think we can live with it until I can figure out how to do this in Go ;-)