### PR TITLE
Add new package type -> transient

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -128,8 +128,8 @@ func (t *TargetBuilder) ensureResolved() error {
 	var loaderSeeds []*pkg.LocalPackage
 	if t.loaderPkg != nil {
 		loaderSeeds = []*pkg.LocalPackage{
-			t.loaderPkg,
-			t.bspPkg.LocalPackage,
+			t.target.LoaderYml(),
+			t.target.BspYml(),
 			t.compilerPkg,
 			t.target.Package(),
 		}
@@ -151,13 +151,13 @@ func (t *TargetBuilder) ensureResolved() error {
 	}
 
 	appSeeds := []*pkg.LocalPackage{
-		t.bspPkg.LocalPackage,
+		t.target.BspYml(),
 		t.compilerPkg,
 		t.target.Package(),
 	}
 
 	if t.appPkg != nil {
-		appSeeds = append(appSeeds, t.appPkg)
+		appSeeds = append(appSeeds, t.target.AppYml())
 	}
 
 	if t.testPkg != nil {

--- a/newt/pkg/package.go
+++ b/newt/pkg/package.go
@@ -37,6 +37,7 @@ const (
 	PACKAGE_TYPE_SDK
 	PACKAGE_TYPE_GENERATED
 	PACKAGE_TYPE_LIB
+	PACKAGE_TYPE_TRANSIENT
 	PACKAGE_TYPE_BSP
 	PACKAGE_TYPE_UNITTEST
 	PACKAGE_TYPE_APP
@@ -49,6 +50,7 @@ var PackageTypeNames = map[interfaces.PackageType]string{
 	PACKAGE_TYPE_SDK:       "sdk",
 	PACKAGE_TYPE_GENERATED: "generated",
 	PACKAGE_TYPE_LIB:       "lib",
+	PACKAGE_TYPE_TRANSIENT: "transient",
 	PACKAGE_TYPE_BSP:       "bsp",
 	PACKAGE_TYPE_UNITTEST:  "unittest",
 	PACKAGE_TYPE_APP:       "app",

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -661,7 +661,7 @@ func ResolveFull(
 		}
 
 		log.Warnf("Transient package %s used, update configuration "+
-			"to use target package instead (%s)",
+			"to use linked package instead (%s)",
 			rpkg.Lpkg.FullName(), rpkg.Lpkg.LinkedName())
 	}
 


### PR DESCRIPTION
**The problem:** we want to move/rename some packages in a backwards-compatible manner.
For `lib` packages we can just move everything to new package and make simple dependency using `pkg.deps` from old (empty) package to new one. This works fine and was used for NimBLE migrations. The only drawback is that `newt` does not warn about the rename.
However, the same approach cannot be used for `bsp` or `app` (and few other types) packages since they are read directly as specified in target settings so cannot be just dummy packages.

**The solution:** use transient packages
Transient package is dummy (empty) package which only link other package. Unlike dependencies it can link only single package. They can be specified in target settings since target package will be used automatically. Other than this, link is resolved just like regular dependency.

To define transient package it's enough to create simple `pkg.yml` file as follows:
```
pkg.name: old-package
pkg.type: transient
pkg.link: @repo/target-package
```

Including transient package in a project will always emit a warning:
```
andk@t480s:~/devel/mynewt$ newt build btshell 
Building target targets/btshell
2018/08/24 21:36:46.229 [WARNING] Transient package @apache-mynewt-core/hw/bsp/nrf52840pdk used, update configuration to use target package instead (@apache-mynewt-core/hw/bsp/nordic_pca10056)
Target successfully built: targets/btshell
```

Some existing PRs using transient packages to test with:
https://github.com/apache/mynewt-core/pull/1346
https://github.com/apache/mynewt-core/pull/1348