### PR TITLE
Don't start an upgrade or sync if repos are dirty

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -91,7 +91,7 @@ func makeRepoPredicate(repoNames []string) func(r *repo.Repo) bool {
 	return func(r *repo.Repo) bool {
 		if !r.IsLocal() {
 			for _, arg := range repoNames {
-				if r.Name() == arg {
+				if strings.TrimPrefix(r.Name(), "@") == arg {
 					return true
 				}
 			}

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -535,6 +535,7 @@ func (inst *Installer) installPrompt(vm deprepo.VersionMap, op installOp,
 	}
 
 	for {
+		fmt.Printf("Proceed? [Y/n] ")
 		line, more, err := bufio.NewReader(os.Stdin).ReadLine()
 		if more || err != nil {
 			return false, util.ChildNewtError(err)

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -898,3 +898,38 @@ func (inst *Installer) Sync(candidates []*repo.Repo,
 
 	return nil
 }
+
+// Prints out information about the specified repos:
+//     * Currently installed version.
+//     * Whether upgrade is possible.
+//     * Whether repo is in a dirty state.
+func (inst *Installer) Info(repos []*repo.Repo) error {
+	vm, err := inst.calcVersionMap(repos)
+	if err != nil {
+		return err
+	}
+
+	util.StatusMessage(util.VERBOSITY_DEFAULT, "Repository info:\n")
+	for _, r := range repos {
+		ver, err := r.InstalledVersion()
+		if err != nil {
+			return err
+		}
+
+		dirty, err := r.DirtyState()
+		if err != nil {
+			return err
+		}
+
+		s := fmt.Sprintf("    * %s: %s", r.Name(), ver.String())
+		if ver == nil || *ver != vm[r.Name()] {
+			s += " (needs upgrade)"
+		}
+		if dirty != "" {
+			s += fmt.Sprintf(" (dirty: %s)", dirty)
+		}
+		util.StatusMessage(util.VERBOSITY_DEFAULT, "%s\n", s)
+	}
+
+	return nil
+}

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -279,7 +279,7 @@ func (proj *Project) InstallIf(
 	}
 
 	if upgrade {
-		return inst.Upgrade(specifiedRepoList, ask)
+		return inst.Upgrade(specifiedRepoList, force, ask)
 	} else {
 		return inst.Install(specifiedRepoList, force, ask)
 	}
@@ -302,7 +302,7 @@ func (proj *Project) SyncIf(
 		return err
 	}
 
-	return inst.Sync(repoList, ask)
+	return inst.Sync(repoList, force, ask)
 }
 
 // Loads a complete repo definition from the appropriate `repository.yml` file.

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -305,6 +305,27 @@ func (proj *Project) SyncIf(
 	return inst.Sync(repoList, force, ask)
 }
 
+func (proj *Project) InfoIf(predicate func(r *repo.Repo) bool) error {
+	// Make sure we have an up to date copy of all `repository.yml` files.
+	if err := proj.downloadRepositoryYmlFiles(); err != nil {
+		return err
+	}
+
+	// Determine which repos the user wants info about.
+	repoList := proj.SelectRepos(predicate)
+
+	inst, err := install.NewInstaller(proj.repos, proj.rootRepoReqs)
+	if err != nil {
+		return err
+	}
+
+	if err := inst.Info(repoList); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Loads a complete repo definition from the appropriate `repository.yml` file.
 // The supplied fields form a basic repo description as read from `project.yml`
 // or from another repo's dependency list.

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -236,6 +236,15 @@ func (r *Repo) updateRepo(commit string) error {
 	return nil
 }
 
+// Indicates whether the specified repo is in a clean or dirty state.
+//
+// @return string               Text describing repo's dirty state, or "" if
+//                                  clean.
+// @return error                Error.
+func (r *Repo) DirtyState() (string, error) {
+	return r.downloader.DirtyState(r.Path())
+}
+
 func (r *Repo) Install(ver newtutil.RepoVersion) error {
 	commit, err := r.CommitFromVer(ver)
 	if err != nil {
@@ -253,17 +262,6 @@ func (r *Repo) Upgrade(ver newtutil.RepoVersion) error {
 	commit, err := r.CommitFromVer(ver)
 	if err != nil {
 		return err
-	}
-
-	changes, err := r.downloader.AreChanges(r.Path())
-	if err != nil {
-		return err
-	}
-
-	if changes {
-		return util.FmtNewtError(
-			"Repository \"%s\" contains local changes.  Please resolve "+
-				"changes manually and try again.", r.Name())
 	}
 
 	if err := r.updateRepo(commit); err != nil {


### PR DESCRIPTION
This PR contains two features:

#### 1. Don't start an upgrade or sync if repos are dirty

Before starting an upgrade or sync operation, check if any repos being operated on are in a dirty state.  If any repo is dirty, abort with a descriptive message.  Optionally, the user can specify `-f` (force) to try the operation anyway.

A repo is dirty if any of the following is true:
* Repo contains local changes
* Repo contains staged changes
* Repo contains unpushed commits

#### 2. Improve `newt info` command

This commit adds some information to the output of the `newt info` command.  If no arguments are specified, the command lists all repos in the project, and appends the following flags as appropriate:

* Upgrade needed
* Dirty: `<description of dirty state>`

If the user provides an argument, the command's old behavior is retained.  I.e., the command prints a list of all packages belonging to the specified repo.