### PR TITLE
Fix 'newt test' exclude option accepting fully-qualified pkg names

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -263,7 +263,10 @@ func testRunCmd(cmd *cobra.Command, args []string, exclude string, executeShell 
 	packLoop:
 		for _, pack := range orig {
 			for _, excl := range excls {
-				if pack.Name() == excl || strings.HasPrefix(pack.Name(), excl+"/") {
+				if pack.Name() == excl ||
+					strings.HasPrefix(pack.Name(), excl+"/") ||
+					pack.NameWithRepo() == excl ||
+					strings.HasPrefix(pack.NameWithRepo(), excl+"/") {
 					continue packLoop
 				}
 			}

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -96,12 +96,17 @@ func (pkg *LocalPackage) Name() string {
 	return pkg.name
 }
 
+func (pkg *LocalPackage) NameWithRepo() string {
+	r := pkg.Repo()
+	return newtutil.BuildPackageString(r.Name(), pkg.Name())
+}
+
 func (pkg *LocalPackage) FullName() string {
 	r := pkg.Repo()
 	if r.IsLocal() {
 		return pkg.Name()
 	} else {
-		return newtutil.BuildPackageString(r.Name(), pkg.Name())
+		return pkg.NameWithRepo()
 	}
 }
 


### PR DESCRIPTION
`newt test` accepts an `--exclude` or `-e` switch. The argument to this
switch is a comma-separated list of packages to exclude from the test set.

The bug was that these package names must have *not* included their repo name.
The tests were only properly excluded if the repo name was missing.

E.g.,

```
newt test all -e fs/fcb
```
properly excluded the `fs/fcb` test, but

```
newt test all -e @apache-mynewt-core/fs/fcb
```
excluded nothing; the fcb test still run.

With this patch both of these examples correctly exclude fcb tests.