### PR TITLE
cmake: Add CXX to project languages

### DIFF
--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -312,7 +312,7 @@ func CmakeCompilerWrite(w io.Writer, c *toolchain.Compiler) {
 func CmakeHeaderWrite(w io.Writer, c *toolchain.Compiler, targetName string) {
 	fmt.Fprintln(w, "cmake_minimum_required(VERSION 3.7)\n")
 	CmakeCompilerWrite(w, c)
-	fmt.Fprintf(w, "project(%s VERSION 0.0.0 LANGUAGES C ASM)\n\n", targetName)
+	fmt.Fprintf(w, "project(%s VERSION 0.0.0 LANGUAGES C CXX ASM)\n\n", targetName)
 	fmt.Fprintln(w, "SET(CMAKE_C_FLAGS_BACKUP  \"${CMAKE_C_FLAGS}\")")
 	fmt.Fprintln(w, "SET(CMAKE_CXX_FLAGS_BACKUP  \"${CMAKE_CXX_FLAGS}\")")
 	fmt.Fprintln(w, "SET(CMAKE_ASM_FLAGS_BACKUP  \"${CMAKE_ASM_FLAGS}\")")


### PR DESCRIPTION
If a package contains .cpp files, CMake produces the following error:
```
CMake Error: Cannot determine link language for target <package-target>.
CMake Error: CMake can not determine linker language for target: <package-target>
```

Adding CXX to project languages if no package contains .cpp files doesn't affect the build.