### PR TITLE
Check newt compatibility on install/upgrade and other commands

### DIFF
--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -102,6 +102,10 @@ func (r *Repo) ignoreDir(dir string) bool {
 	return false
 }
 
+func (r *Repo) Downloader() downloader.Downloader {
+	return r.downloader
+}
+
 func (repo *Repo) FilteredSearchList(
 	curPath string, searchedMap map[string]struct{}) ([]string, error) {
 

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -76,6 +76,12 @@ func normalizeCommit(commit string) string {
 // Retrieves the repo's currently checked-out hash.
 func (r *Repo) CurrentHash() (string, error) {
 	dl := r.downloader
+	if dl == nil {
+		return "",
+			util.FmtNewtError("No downloader for %s",
+				r.Name())
+	}
+
 	commit, err := dl.HashFor(r.Path(), "HEAD")
 	if err != nil {
 		return "",


### PR DESCRIPTION
With this patch newt will warn/return error if you use any repository
is incompatible with current newt version. It will also warn/return error
when you are trying to install/upgrade a repository to a version
that is not compatible with current newt.

Example 1 (upgrading to incompatible version):
```
>newt upgrade
Skipping "apache-mynewt-nimble": already upgraded (1.0.0)
Making the following changes to the project:
    upgrade apache-mynewt-core (1.3.0 --> 1.4.1)
Error: This version of newt (1.3.0) is incompatible with your version of the
apache-mynewt-core repo (1.4.1); Please upgrade your newt tool to version 1.4.0
```

Example 2 (using an incompatible version):
```
>newt info
Error: This version of newt (1.3.0) is incompatible with your version of the
apache-mynewt-core repo (1.4.1); Please upgrade your newt tool to version 1.4.0
```