### PR TITLE
Fix regression when verifying newt compatibility

### DIFF
--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -485,6 +485,11 @@ func (proj *Project) verifyNewtCompat() error {
 			continue
 		}
 
+		// Cannot verify version if project is not installed
+		if !proj.RepoIsInstalled(name) {
+			continue
+		}
+
 		ver, err := proj.GetRepoVersion(name)
 		if err != nil {
 			return err


### PR DESCRIPTION
If repo is not installed it is not possible to check version.