### PR TITLE
Update handling of package-level build profiles

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -39,7 +40,6 @@ import (
 	"mynewt.apache.org/newt/newt/target"
 	"mynewt.apache.org/newt/newt/toolchain"
 	"mynewt.apache.org/newt/util"
-	"runtime"
 )
 
 type Builder struct {

--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -259,13 +259,13 @@ func collectCompileEntriesDir(srcDir string, c *toolchain.Compiler,
 //
 // 3. Else, "" is returned (falls back to the target's general build profile).
 func (b *Builder) buildProfileFor(bpkg *BuildPackage) string {
-	bp := bpkg.BuildProfile(b)
+	tgt := b.targetBuilder.GetTarget()
+	bp := tgt.PkgProfiles[bpkg.rpkg.Lpkg.FullName()]
 	if bp != "" {
 		return bp
 	}
 
-	tgt := b.targetBuilder.GetTarget()
-	return tgt.PkgProfiles[bpkg.rpkg.Lpkg.FullName()]
+	return bpkg.BuildProfile(b)
 }
 
 func (b *Builder) newCompiler(bpkg *BuildPackage,


### PR DESCRIPTION
This fixes two issues with build profiles defined on package-level:

1. Build profile specified for package on target level should take precedence over build profile specified by package itself.
Not sure why this was implemented the other way around (perhaps there was some reason so my fix may break something) but I think this should works the same way as syscfg where target can ultimately override any other settings. Consider following case: package specified build profile which is heavily optimized, but I would like to debug it so I prefer to override this easily in target instead of changing package definition directly.

2. Target build profile should be used if overridden build profile is not supported by compiler
Currently, if package has build profile overridden to something that is not supported by compiler we'll just have default error message which states, that target build profile is not supported by compiler:
```
Error: Compiler doesn't support build profile specified by target on this OS (build_profile="foo" OS="linux")
```
This is confusing since it does not state what actually failed. Instead, let's just emit a more verbose warning and use target build profile instead:
```
2018/10/17 12:10:20.028 [WARNING] Unsupported build profile for package, using default build profile (pkg="@apache-mynewt-core/hw/drivers/rtt" build_profile="foo" OS="linux")
```