### PR TITLE
Add diff-friendly output for "newt size"

### DIFF
--- a/newt/builder/size.go
+++ b/newt/builder/size.go
@@ -511,7 +511,7 @@ func (b *Builder) Size() error {
 	return nil
 }
 
-func (t *TargetBuilder) SizeReport(sectionName string) error {
+func (t *TargetBuilder) SizeReport(sectionName string, diffFriendly bool) error {
 
 	err := t.PrepBuild()
 
@@ -520,22 +520,22 @@ func (t *TargetBuilder) SizeReport(sectionName string) error {
 	}
 
 	fmt.Printf("Size of Application Image: %s\n", t.AppBuilder.buildName)
-	err = t.AppBuilder.SizeReport(sectionName)
+	err = t.AppBuilder.SizeReport(sectionName, diffFriendly)
 
 	if err == nil {
 		if t.LoaderBuilder != nil {
 			fmt.Printf("Size of Loader Image: %s\n", t.LoaderBuilder.buildName)
-			err = t.LoaderBuilder.SizeReport(sectionName)
+			err = t.LoaderBuilder.SizeReport(sectionName, diffFriendly)
 		}
 	}
 
 	return err
 }
 
-func (b *Builder) SizeReport(sectionName string) error {
+func (b *Builder) SizeReport(sectionName string, diffFriendly bool) error {
 	srcBase := interfaces.GetProject().Path() + "/"
 
-	err := SizeReport(b.AppElfPath(), srcBase, sectionName)
+	err := SizeReport(b.AppElfPath(), srcBase, sectionName, diffFriendly)
 	if err != nil {
 		return util.NewNewtError(err.Error())
 	}

--- a/newt/builder/size_report.go
+++ b/newt/builder/size_report.go
@@ -315,6 +315,6 @@ func SizeReport(elfFilePath, srcBase string, sectionName string, diffFriendly bo
 		}
 	}
 	fmt.Printf("%s report:\n", sectionName)
-	fmt.Printf("%v", sectionNodes.ToString(sectionRegion.TotalSize))
+	fmt.Printf("%v", sectionNodes.ToString(sectionRegion.TotalSize, diffFriendly))
 	return nil
 }

--- a/newt/builder/size_report.go
+++ b/newt/builder/size_report.go
@@ -290,7 +290,7 @@ func logMemoryRegionStats(memRegion *MemoryRegion, sectionName string) {
 	util.StatusMessage(util.VERBOSITY_VERBOSE, "\n")
 }
 
-func SizeReport(elfFilePath, srcBase string, sectionName string) error {
+func SizeReport(elfFilePath, srcBase string, sectionName string, diffFriendly bool) error {
 	symbolsPath, err := loadSymbolsAndPaths(elfFilePath, srcBase)
 	if err != nil {
 		return err

--- a/newt/builder/symbol_tree.go
+++ b/newt/builder/symbol_tree.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"strconv"
 )
 
 type Symbol struct {
@@ -40,6 +41,44 @@ type Folder struct {
 	Name    string
 	Files   map[string]*File
 	Folders map[string]*Folder
+}
+
+type outputFormatter interface {
+	Header(nameStr string, sizeStr string, percentStr string) string
+	Container(level int, name string, size uint64, percent float64) string
+	Symbol(level int, name string, size uint64, percent float64) string
+	Separator() string
+}
+
+type outputFormatterDefault struct {
+	indentStr string
+	headerStr string
+	symbolStr string
+}
+
+func newSymbolFormatterDefault() *outputFormatterDefault {
+	return &outputFormatterDefault{
+		indentStr: "  ",
+		headerStr: "%-59s %9s %9s\n",
+		symbolStr: "%-59s %9d %8.2f%%\n",
+	}
+}
+
+func (fmtr *outputFormatterDefault) Header(nameStr string, sizeStr string, percentStr string) string {
+	return fmt.Sprintf(fmtr.headerStr, nameStr, sizeStr, percentStr)
+}
+
+func (fmtr *outputFormatterDefault) Container(level int, name string, size uint64, percent float64) string {
+	return fmtr.Symbol(level, name, size, percent)
+}
+
+func (fmtr *outputFormatterDefault) Symbol(level int, name string, size uint64, percent float64) string {
+	return fmt.Sprintf(fmtr.symbolStr, strings.Repeat(fmtr.indentStr, level) + name, size, percent)
+}
+
+func (fmtr *outputFormatterDefault) Separator() string {
+	// -1 is to cut \n
+	return strings.Repeat("=", len(fmtr.Header("", "", "")) - 1) + "\n"
 }
 
 func newFolder(name string) *Folder {
@@ -127,17 +166,14 @@ func (f *Folder) addSymbol(symbol *Symbol, path string) *Symbol {
 	return sym
 }
 
-var outputFormatting string = "%-59s %9d %8.2f%%\n"
-
-func (f *File) String(indent string, level int, total uint64) string {
+func (f *File) toString(fmtr outputFormatter, level int, total uint64) string {
 	var str string
 	if f.sumSize() <= 0 {
 		return ""
 	}
 	size := f.sumSize()
 	percent := 100 * float64(size) / float64(total)
-	str += fmt.Sprintf(outputFormatting, strings.Repeat(indent, level)+
-		f.Name, size, percent)
+	str += fmtr.Container(level, f.Name, size, percent)
 
 	var sorted []string
 	for symName := range f.Symbols {
@@ -148,15 +184,13 @@ func (f *File) String(indent string, level int, total uint64) string {
 		size := f.Symbols[sym].Size
 		percent := 100 * float64(size) / float64(total)
 		if f.Symbols[sym].Size > 0 {
-			str += fmt.Sprintf(outputFormatting,
-				strings.Repeat(indent, level+1)+ f.Symbols[sym].Name,
-				size, percent)
+			str += fmtr.Symbol(level + 1, f.Symbols[sym].Name, size, percent)
 		}
 	}
 	return str
 }
 
-func (f *Folder) StringRec(indent string, level int, total uint64) string {
+func (f *Folder) toString(fmtr outputFormatter, level int, total uint64) string {
 	var str string
 
 	var sorted []string
@@ -172,24 +206,26 @@ func (f *Folder) StringRec(indent string, level int, total uint64) string {
 		if folder, ok := f.Folders[name]; ok {
 			size := folder.sumSize()
 			percent := 100 * float64(size) / float64(total)
-			str += fmt.Sprintf(outputFormatting,
-				strings.Repeat(indent, level)+folder.Name, size, percent)
-			str += folder.StringRec(indent, level+1, total)
+			str += fmtr.Container(level, folder.Name, size, percent)
+			str += folder.toString(fmtr, level+1, total)
 		} else {
-			str += f.Files[name].String(indent, level, total)
+			str += f.Files[name].toString(fmtr, level, total)
 		}
 	}
 	return str
 }
 
 func (f *Folder) ToString(total uint64) string {
-	indent := "  "
 	var str string
-	str += fmt.Sprintf("%-59s %9s %9s\n", "Path", "Size", "%")
-	str += strings.Repeat("=", 79) + "\n"
-	str += f.StringRec(indent, 0, total)
-	str += strings.Repeat("=", 79) + "\n"
-	str += fmt.Sprintf("%-59s %9d %9s\n",
-		"Total symbol size (i.e. excluding padding, etc.)", f.sumSize(), "")
+	var fmtr outputFormatter
+
+	fmtr = newSymbolFormatterDefault()
+
+	str += fmtr.Header("Path", "Size", "%")
+	str += fmtr.Separator()
+	str += f.toString(fmtr, 0, total)
+	str += fmtr.Separator()
+	str += fmtr.Header("Total symbol size (i.e. excluding padding, etc.)",
+		strconv.FormatUint(f.sumSize(), 10), "")
 	return str
 }

--- a/newt/builder/symbol_tree.go
+++ b/newt/builder/symbol_tree.go
@@ -56,6 +56,13 @@ type outputFormatterDefault struct {
 	symbolStr string
 }
 
+type outputFormatterDiffable struct {
+	indentStr    string
+	headerStr    string
+	containerStr string
+	symbolStr    string
+}
+
 func newSymbolFormatterDefault() *outputFormatterDefault {
 	return &outputFormatterDefault{
 		indentStr: "  ",
@@ -77,6 +84,32 @@ func (fmtr *outputFormatterDefault) Symbol(level int, name string, size uint64, 
 }
 
 func (fmtr *outputFormatterDefault) Separator() string {
+	// -1 is to cut \n
+	return strings.Repeat("=", len(fmtr.Header("", "", "")) - 1) + "\n"
+}
+
+func newSymbolFormatterDiffable() *outputFormatterDiffable {
+	return &outputFormatterDiffable{
+		indentStr:    "  ",
+		headerStr:    "%-70s %9s\n",
+		containerStr: "%-70s\n",
+		symbolStr:    "%-70s %9d\n",
+	}
+}
+
+func (fmtr *outputFormatterDiffable) Header(nameStr string, sizeStr string, percentStr string) string {
+	return fmt.Sprintf(fmtr.headerStr, nameStr, sizeStr)
+}
+
+func (fmtr *outputFormatterDiffable) Container(level int, name string, size uint64, percent float64) string {
+	return fmt.Sprintf(fmtr.containerStr, strings.Repeat(fmtr.indentStr, level) + name)
+}
+
+func (fmtr *outputFormatterDiffable) Symbol(level int, name string, size uint64, percent float64) string {
+	return fmt.Sprintf(fmtr.symbolStr, strings.Repeat(fmtr.indentStr, level) + name, size)
+}
+
+func (fmtr *outputFormatterDiffable) Separator() string {
 	// -1 is to cut \n
 	return strings.Repeat("=", len(fmtr.Header("", "", "")) - 1) + "\n"
 }
@@ -215,11 +248,15 @@ func (f *Folder) toString(fmtr outputFormatter, level int, total uint64) string 
 	return str
 }
 
-func (f *Folder) ToString(total uint64) string {
+func (f *Folder) ToString(total uint64, diffFriendly bool) string {
 	var str string
 	var fmtr outputFormatter
 
-	fmtr = newSymbolFormatterDefault()
+	if diffFriendly {
+		fmtr = newSymbolFormatterDiffable()
+	} else {
+		fmtr = newSymbolFormatterDefault()
+	}
 
 	str += fmtr.Header("Path", "Size", "%")
 	str += fmtr.Separator()

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -398,7 +398,7 @@ func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool, section
 
 	if len(sections) > 0 {
 		for _, sectionName := range sections {
-			if err := b.SizeReport(sectionName); err != nil {
+			if err := b.SizeReport(sectionName, true); err != nil {
 				NewtUsage(cmd, err)
 			}
 		}

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -101,6 +101,7 @@ func pkgToUnitTests(pack *pkg.LocalPackage) []*pkg.LocalPackage {
 
 var extraJtagCmd string
 var noGDB_flag bool
+var diffFriendly_flag bool
 
 func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, executeShell bool) {
 	if len(args) < 1 {
@@ -398,7 +399,7 @@ func sizeRunCmd(cmd *cobra.Command, args []string, ram bool, flash bool, section
 
 	if len(sections) > 0 {
 		for _, sectionName := range sections {
-			if err := b.SizeReport(sectionName, true); err != nil {
+			if err := b.SizeReport(sectionName, diffFriendly_flag); err != nil {
 				NewtUsage(cmd, err)
 			}
 		}
@@ -507,6 +508,8 @@ func AddBuildCommands(cmd *cobra.Command) {
 		},
 	}
 
+	sizeCmd.PersistentFlags().BoolVarP(&diffFriendly_flag, "diffable", "d", false,
+		"Produce diff-friendly output of statistics")
 	sizeCmd.Flags().BoolVarP(&ram, "ram", "R", false, "Print RAM statistics")
 	sizeCmd.Flags().BoolVarP(&flash, "flash", "F", false,
 		"Print FLASH statistics")


### PR DESCRIPTION
This adds `-d` flag to `newt size` which enables more diff-friendly output for sections statistics.
    
Diff-friendly output does not include percentages and sizes are only printed for symbols, not for "containers". This means that diff will pick up only lines where size of particular symbol has changed and not lines where percentage or cumulative size also changed.

As an example, diff on standard statistics output for flash where single package (`@apache-mynewt-nimble/host/services/gap`) build profile was changed from `debug` to `optimized`:
```
andk@t480s:~/devel/mynewt$ diff btshell-debug.txt btshell-optimized.txt
5c5
<                                                                182740    89.71%
---
>                                                                182656    89.71%
13,14c13,14
<   repos                                                        182676    89.68%
<     apache-mynewt-core                                          35948    17.65%
---
>   repos                                                        182592    89.68%
>     apache-mynewt-core                                          35948    17.66%
79c79
<       hw                                                         5978     2.93%
---
>       hw                                                         5978     2.94%
156c156
<                 SEGGER_RTT_WriteNoLock                            112     0.05%
---
>                 SEGGER_RTT_WriteNoLock                            112     0.06%
249,251c249,251
<       kernel                                                     8156     4.00%
<         os                                                       8156     4.00%
<           src                                                    8156     4.00%
---
>       kernel                                                     8156     4.01%
>         os                                                       8156     4.01%
>           src                                                    8156     4.01%
289c289
<               os_init_idle_task                                   112     0.05%
---
>               os_init_idle_task                                   112     0.06%
----- 8< ---------------------------------------- >8 -----
4974c4970
<   suffixes.10535                                                  112     0.05%
---
>   suffixes.10535                                                  112     0.06%
4977c4973
< Total symbol size (i.e. excluding padding, etc.)               183378          
---
> Total symbol size (i.e. excluding padding, etc.)               183294          
andk@t480s:~/devel/mynewt$ diff btshell-debug.txt btshell-optimized.txt | wc -l
376
```
The same as above, but `-d` option was used to produce statistics:
```
andk@t480s:~/devel/mynewt$ diff btshell-debug-df.txt btshell-optimized-df.txt
1482,1484c1482,1483
<                   ble_svc_gap_access                                         120
<                   ble_svc_gap_appearance_read_access                          44
<                   ble_svc_gap_appearance_write_access                         14
---
>                   ble_svc_gap_access                                         116
>                   ble_svc_gap_appearance_write_access.isra.1                  14
1486,1488c1485,1486
<                   ble_svc_gap_device_name_read_access                         40
<                   ble_svc_gap_device_name_set                                 40
<                   ble_svc_gap_device_name_write_access                        14
---
>                   ble_svc_gap_device_name_set                                 44
>                   ble_svc_gap_device_name_write_access.isra.0                 14
3961,3963c3959,3960
<                   ble_svc_gap_access                                         120
<                   ble_svc_gap_appearance_read_access                          44
<                   ble_svc_gap_appearance_write_access                         14
---
>                   ble_svc_gap_access                                         116
>                   ble_svc_gap_appearance_write_access.isra.1                  14
3965,3967c3962,3963
<                   ble_svc_gap_device_name_read_access                         40
<                   ble_svc_gap_device_name_set                                 40
<                   ble_svc_gap_device_name_write_access                        14
---
>                   ble_svc_gap_device_name_set                                 44
>                   ble_svc_gap_device_name_write_access.isra.0                 14
4977c4973
< Total symbol size (i.e. excluding padding, etc.)                          183378
---
> Total symbol size (i.e. excluding padding, etc.)                          183294
andk@t480s:~/devel/mynewt$ diff btshell-debug-df.txt btshell-optimized-df.txt | wc -l
32
```