### PR TITLE
 Allow branches with no default upstream

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -30,6 +30,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/settings"
 	"mynewt.apache.org/newt/util"
 )
@@ -420,9 +421,9 @@ func setRemoteUrl(path string, remote string, url string, logCmd bool) error {
 }
 
 func warnWrongOriginUrl(path string, curUrl string, goodUrl string) {
-	util.StatusMessage(util.VERBOSITY_QUIET,
-		"WARNING: Repo's \"origin\" remote points to unexpected URL: "+
-			"%s; correcting it to %s.  Repo contents may be incorrect.\n",
+	newtutil.OneTimeWarning(
+		"Repo's \"origin\" remote points to unexpected URL: "+
+			"%s; correcting it to %s.  Repo contents may be incorrect.",
 		curUrl, goodUrl)
 }
 

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -557,13 +557,18 @@ func (gd *GenericDownloader) DirtyState(path string) (string, error) {
 		return "staged changes", nil
 	}
 
-	// If on a branch, check for unpushed commits.
+	// If on a branch with a configured upstream, check for unpushed commits.
 	branch, err := gd.CurrentBranch(path)
 	if err != nil {
 		return "", err
 	}
 
-	if branch != "" {
+	upstream, err := upstreamFor(path, "HEAD")
+	if err != nil {
+		return "", err
+	}
+
+	if upstream != "" && branch != "" {
 		cmd = []string{
 			"rev-list",
 			"@{u}..",

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -121,11 +121,11 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"mynewt.apache.org/newt/newt/compat"
 	"mynewt.apache.org/newt/newt/deprepo"
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/repo"
 	"mynewt.apache.org/newt/util"
-	"mynewt.apache.org/newt/newt/compat"
 )
 
 type installOp int
@@ -157,9 +157,9 @@ func detectVersion(r *repo.Repo) (newtutil.RepoVersion, error) {
 			Commit: commit,
 		}
 
-		util.StatusMessage(util.VERBOSITY_QUIET,
-			"WARNING: Could not detect version of installed repo \"%s\"; "+
-				"assuming %s\n", r.Name(), ver.String())
+		newtutil.OneTimeWarning(
+			"Could not detect version of installed repo \"%s\"; assuming %s",
+			r.Name(), ver.String())
 	}
 
 	log.Debugf("currently installed version of repo \"%s\": %s",
@@ -292,9 +292,9 @@ func (inst *Installer) inferReqVers(repos []*repo.Repo) error {
 					}
 
 					if ver == nil {
-						util.StatusMessage(util.VERBOSITY_QUIET,
-							"WARNING: Could not detect version of "+
-								"requested repo %s:%s; assuming 0.0.0\n",
+						newtutil.OneTimeWarning(
+							"Could not detect version of requested repo "+
+								"%s:%s; assuming 0.0.0",
 							r.Name(), req.Ver.Commit)
 
 						ver = &req.Ver
@@ -732,7 +732,7 @@ func verifyRepoDirtyState(repos []*repo.Repo, force bool) error {
 			s += "Specify the `-f` (force) switch to attempt anyway"
 			return util.NewNewtError(s)
 		} else {
-			util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s\n", s)
+			newtutil.OneTimeWarning("%s", s)
 		}
 	}
 
@@ -749,7 +749,7 @@ func verifyNewtCompat(repos []*repo.Repo, vm deprepo.VersionMap) error {
 
 		switch code {
 		case compat.NEWT_COMPAT_WARN:
-			util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s\n", msg)
+			newtutil.OneTimeWarning("%s", msg)
 		case compat.NEWT_COMPAT_ERROR:
 			errors = append(errors, msg)
 		}

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -935,7 +935,7 @@ func (inst *Installer) Sync(candidates []*repo.Repo,
 }
 
 type repoInfo struct {
-	installedVer *newtutil.RepoVersion
+	installedVer *newtutil.RepoVersion // nil if not installed.
 	errorText    string
 	dirtyState   string
 	needsUpgrade bool
@@ -953,12 +953,12 @@ func (inst *Installer) gatherInfo(r *repo.Repo,
 		return ri
 	}
 
-	ver, err := r.InstalledVersion()
+	ver, err := detectVersion(r)
 	if err != nil {
 		ri.errorText = strings.TrimSpace(err.Error())
 		return ri
 	}
-	ri.installedVer = ver
+	ri.installedVer = &ver
 
 	dirty, err := r.DirtyState()
 	if err != nil {
@@ -968,7 +968,7 @@ func (inst *Installer) gatherInfo(r *repo.Repo,
 	ri.dirtyState = dirty
 
 	if vm != nil {
-		if ver == nil || *ver != (*vm)[r.Name()] {
+		if ver != (*vm)[r.Name()] {
 			ri.needsUpgrade = true
 		}
 	}

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -201,3 +201,17 @@ func ReadConfig(dir string, filename string) (ycfg.YCfg, error) {
 func YCfgToYaml(yc ycfg.YCfg) string {
 	return yaml.MapToYaml(yc.AllSettings())
 }
+
+// Keeps track of warnings that have already been reported.
+// [warning-text] => struct{}
+var warnings = map[string]struct{}{}
+
+// Displays the specified warning if it has not been displayed yet.
+func OneTimeWarning(text string, args ...interface{}) {
+	if _, ok := warnings[text]; !ok {
+		warnings[text] = struct{}{}
+
+		body := fmt.Sprintf(text, args...)
+		util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s\n", body)
+	}
+}

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -210,10 +210,6 @@ func (proj *Project) GetRepoVersion(
 
 		if _, ok := proj.unknownRepoVers[rname]; !ok {
 			proj.unknownRepoVers[rname] = struct{}{}
-
-			util.StatusMessage(util.VERBOSITY_QUIET,
-				"WARNING: Could not detect version of installed repo \"%s\"; "+
-					"assuming 0.0.0/%s\n", r.Name(), commit)
 		}
 		ver = &newtutil.RepoVersion{
 			Commit: commit,

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -396,7 +396,7 @@ func (proj *Project) checkNewtVer() error {
 	case compat.NEWT_COMPAT_GOOD:
 		return nil
 	case compat.NEWT_COMPAT_WARN:
-		util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s.\n", msg)
+		newtutil.OneTimeWarning("%s", msg)
 		return nil
 	case compat.NEWT_COMPAT_ERROR:
 		return util.NewNewtError(msg)
@@ -500,7 +500,7 @@ func (proj *Project) verifyNewtCompat() error {
 			switch code {
 			case compat.NEWT_COMPAT_GOOD:
 			case compat.NEWT_COMPAT_WARN:
-				util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s.\n", msg)
+				newtutil.OneTimeWarning("%s", msg)
 			case compat.NEWT_COMPAT_ERROR:
 				errors = append(errors, msg)
 			}

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -392,9 +392,8 @@ func (r *Repo) inferVersion(commit string, vyVer *newtutil.RepoVersion) (
 				}
 			}
 
-			util.StatusMessage(util.VERBOSITY_QUIET,
-				"WARNING: Version mismatch in %s:%s; "+
-					"repository.yml:%s, version.yml:%s\n",
+			newtutil.OneTimeWarning(
+				"Version mismatch in %s:%s; repository.yml:%s, version.yml:%s",
 				r.Name(), commit, versString(ryVers), vyVer.String())
 		} else {
 			// If the set of commits don't match a version from
@@ -464,12 +463,12 @@ func (r *Repo) NonInstalledVersion(
 
 	if ver == nil {
 		if versionYmlErr == versionYmlMissing {
-			util.StatusMessage(util.VERBOSITY_QUIET,
-				"WARNING: %s:%s does not contain a `version.yml` file.\n",
+			newtutil.OneTimeWarning(
+				"%s:%s does not contain a `version.yml` file.",
 				r.Name(), commit)
 		} else if versionYmlErr == versionYmlBad {
-			util.StatusMessage(util.VERBOSITY_QUIET,
-				"WARNING: %s:%s contains a malformed `version.yml` file.\n",
+			newtutil.OneTimeWarning(
+				"%s:%s contains a malformed `version.yml` file.",
 				r.Name(), commit)
 		}
 	}

--- a/newt/syscfg/restrict.go
+++ b/newt/syscfg/restrict.go
@@ -59,8 +59,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/parse"
-	"mynewt.apache.org/newt/util"
 )
 
 type CfgRestrictionCode int
@@ -201,8 +201,8 @@ func (cfg *Cfg) restrictionMet(
 
 		val, err := parse.ParseAndEval(expr, settings)
 		if err != nil {
-			util.StatusMessage(util.VERBOSITY_QUIET,
-				"WARNING: ignoring illegal expression for setting \"%s\": "+
+			newtutil.OneTimeWarning(
+				"Ignoring illegal expression for setting \"%s\": "+
 					"`%s` %s\n", r.BaseSetting, r.Expr, err.Error())
 			return true
 		}


### PR DESCRIPTION
Some commands would fail when a repo had a branch with no default upstream checked out.  The failures were as follows:

* `newt info`: Displayed a git "fatal" error instead of the correct version (inferred version if `version.yml` is not present).
* `newt upgrade`: Aborted without performing the upgrade (displayed the same "fatal" git error).