### PR TITLE
Update newt version: 1.4.9999 --> 1.5.9900

### DIFF
--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -31,7 +31,7 @@ import (
 	"mynewt.apache.org/newt/yaml"
 )
 
-var NewtVersion Version = Version{1, 4, 9999}
+var NewtVersion Version = Version{1, 5, 9900}
 var NewtVersionStr string = "Apache Newt version: 1.5.0-dev"
 var NewtBlinkyTag string = "master"
 var NewtNumJobs int


### PR DESCRIPTION
This should fix the recent travis failures.

Since this is now 1.5.0-dev, the version number needs to be greater than 1.5.0.  I think using a revision number of 9900 instead of 9999 is a little better - it leaves room for several dev versions.