### PR TITLE
Merge conflicting dependency conditionals

### DIFF
--- a/newt/builder/depgraph.go
+++ b/newt/builder/depgraph.go
@@ -118,8 +118,9 @@ func depString(dep *resolve.ResolveDep) string {
 		reasons = append(reasons, fmt.Sprintf("api:%s", dep.Api))
 	}
 
-	if dep.Expr != "" {
-		reasons = append(reasons, fmt.Sprintf("syscfg:%s", dep.Expr))
+	exprStr := dep.ExprString()
+	if exprStr != "" {
+		reasons = append(reasons, fmt.Sprintf("syscfg:%s", exprStr))
 	}
 
 	if len(reasons) > 0 {

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -35,7 +35,6 @@ import (
 	"mynewt.apache.org/newt/newt/resolve"
 	"mynewt.apache.org/newt/newt/syscfg"
 	"mynewt.apache.org/newt/newt/target"
-	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
 )
 
@@ -304,7 +303,7 @@ func targetSetCmd(cmd *cobra.Command, args []string) {
 		// A few variables are special cases; they get set in the base package
 		// instead of the target.
 		if kv[0] == "target.syscfg" {
-			t.Package().SyscfgY = ycfg.YCfg{}
+			t.Package().SyscfgY.Clear()
 			kv, err := syscfg.KeyValueFromStr(kv[1])
 			if err != nil {
 				NewtUsage(cmd, err)

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -30,7 +30,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/settings"
 	"mynewt.apache.org/newt/util"
 )
@@ -421,7 +420,7 @@ func setRemoteUrl(path string, remote string, url string, logCmd bool) error {
 }
 
 func warnWrongOriginUrl(path string, curUrl string, goodUrl string) {
-	newtutil.OneTimeWarning(
+	util.OneTimeWarning(
 		"Repo's \"origin\" remote points to unexpected URL: "+
 			"%s; correcting it to %s.  Repo contents may be incorrect.",
 		curUrl, goodUrl)

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -157,7 +157,7 @@ func detectVersion(r *repo.Repo) (newtutil.RepoVersion, error) {
 			Commit: commit,
 		}
 
-		newtutil.OneTimeWarning(
+		util.OneTimeWarning(
 			"Could not detect version of installed repo \"%s\"; assuming %s",
 			r.Name(), ver.String())
 	}
@@ -292,7 +292,7 @@ func (inst *Installer) inferReqVers(repos []*repo.Repo) error {
 					}
 
 					if ver == nil {
-						newtutil.OneTimeWarning(
+						util.OneTimeWarning(
 							"Could not detect version of requested repo "+
 								"%s:%s; assuming 0.0.0",
 							r.Name(), req.Ver.Commit)
@@ -732,7 +732,7 @@ func verifyRepoDirtyState(repos []*repo.Repo, force bool) error {
 			s += "Specify the `-f` (force) switch to attempt anyway"
 			return util.NewNewtError(s)
 		} else {
-			newtutil.OneTimeWarning("%s", s)
+			util.OneTimeWarning("%s", s)
 		}
 	}
 
@@ -749,7 +749,7 @@ func verifyNewtCompat(repos []*repo.Repo, vm deprepo.VersionMap) error {
 
 		switch code {
 		case compat.NEWT_COMPAT_WARN:
-			newtutil.OneTimeWarning("%s", msg)
+			util.OneTimeWarning("%s", msg)
 		case compat.NEWT_COMPAT_ERROR:
 			errors = append(errors, msg)
 		}

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -178,17 +178,17 @@ func MakeTempRepoDir() (string, error) {
 func ReadConfigPath(path string) (ycfg.YCfg, error) {
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, util.NewNewtError(fmt.Sprintf("Error reading %s: %s",
-			path, err.Error()))
+		return ycfg.YCfg{}, util.FmtNewtError("Error reading %s: %s",
+			path, err.Error())
 	}
 
 	settings := map[string]interface{}{}
 	if err := yaml.Unmarshal(file, &settings); err != nil {
-		return nil, util.FmtNewtError("Failure parsing \"%s\": %s",
+		return ycfg.YCfg{}, util.FmtNewtError("Failure parsing \"%s\": %s",
 			path, err.Error())
 	}
 
-	return ycfg.NewYCfg(settings)
+	return ycfg.NewYCfg(path, settings)
 }
 
 // Read in the configuration file specified by name, in path
@@ -200,18 +200,4 @@ func ReadConfig(dir string, filename string) (ycfg.YCfg, error) {
 // Converts the provided YAML-configuration map to a YAML-encoded string.
 func YCfgToYaml(yc ycfg.YCfg) string {
 	return yaml.MapToYaml(yc.AllSettings())
-}
-
-// Keeps track of warnings that have already been reported.
-// [warning-text] => struct{}
-var warnings = map[string]struct{}{}
-
-// Displays the specified warning if it has not been displayed yet.
-func OneTimeWarning(text string, args ...interface{}) {
-	if _, ok := warnings[text]; !ok {
-		warnings[text] = struct{}{}
-
-		body := fmt.Sprintf(text, args...)
-		util.StatusMessage(util.VERBOSITY_QUIET, "WARNING: %s\n", body)
-	}
 }

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -176,19 +176,24 @@ func MakeTempRepoDir() (string, error) {
 }
 
 func ReadConfigPath(path string) (ycfg.YCfg, error) {
+	yc := ycfg.NewYCfg(path)
+
 	file, err := ioutil.ReadFile(path)
 	if err != nil {
-		return ycfg.YCfg{}, util.FmtNewtError("Error reading %s: %s",
-			path, err.Error())
+		return yc, util.ChildNewtError(err)
 	}
 
 	settings := map[string]interface{}{}
 	if err := yaml.Unmarshal(file, &settings); err != nil {
-		return ycfg.YCfg{}, util.FmtNewtError("Failure parsing \"%s\": %s",
+		return yc, util.FmtNewtError("Failure parsing \"%s\": %s",
 			path, err.Error())
 	}
 
-	return ycfg.NewYCfg(path, settings)
+	if err := yc.Populate(settings); err != nil {
+		return yc, err
+	}
+
+	return yc, nil
 }
 
 // Read in the configuration file specified by name, in path

--- a/newt/parse/parse.go
+++ b/newt/parse/parse.go
@@ -554,6 +554,21 @@ func Eval(expr *Node, settings map[string]string) (bool, error) {
 	}
 }
 
+func lexAndParse(expr string) (*Node, error) {
+	tokens, err := Lex(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := Parse(tokens)
+	if err != nil {
+		return nil, util.FmtNewtError("error parsing [%s]: %s",
+			expr, err.Error())
+	}
+
+	return n, nil
+}
+
 // Parses and evaluates string containing a syscfg expression.
 //
 // @param expr                  The expression to parse.
@@ -561,18 +576,27 @@ func Eval(expr *Node, settings map[string]string) (bool, error) {
 //
 // @return bool                 Whether the expression evaluates to true.
 func ParseAndEval(expr string, settings map[string]string) (bool, error) {
-	tokens, err := Lex(expr)
+	n, err := lexAndParse(expr)
 	if err != nil {
 		return false, err
 	}
 
-	n, err := Parse(tokens)
-	if err != nil {
-		return false, fmt.Errorf("error parsing [%s]: %s\n", expr, err.Error())
-	}
-
 	v, err := Eval(n, settings)
 	return v, err
+}
+
+// Parses an expression and converts it to its normalized text form.
+func NormalizeExpr(expr string) (string, error) {
+	n, err := lexAndParse(expr)
+	if err != nil {
+		return "", err
+	}
+
+	if n == nil {
+		return "", nil
+	}
+
+	return n.String(), nil
 }
 
 // Evaluates the truthfulness of a text expression.

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -392,7 +392,7 @@ func (proj *Project) checkNewtVer() error {
 	case compat.NEWT_COMPAT_GOOD:
 		return nil
 	case compat.NEWT_COMPAT_WARN:
-		newtutil.OneTimeWarning("%s", msg)
+		util.OneTimeWarning("%s", msg)
 		return nil
 	case compat.NEWT_COMPAT_ERROR:
 		return util.NewNewtError(msg)
@@ -496,7 +496,7 @@ func (proj *Project) verifyNewtCompat() error {
 			switch code {
 			case compat.NEWT_COMPAT_GOOD:
 			case compat.NEWT_COMPAT_WARN:
-				newtutil.OneTimeWarning("%s", msg)
+				util.OneTimeWarning("%s", msg)
 			case compat.NEWT_COMPAT_ERROR:
 				errors = append(errors, msg)
 			}

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -392,7 +392,7 @@ func (r *Repo) inferVersion(commit string, vyVer *newtutil.RepoVersion) (
 				}
 			}
 
-			newtutil.OneTimeWarning(
+			util.OneTimeWarning(
 				"Version mismatch in %s:%s; repository.yml:%s, version.yml:%s",
 				r.Name(), commit, versString(ryVers), vyVer.String())
 		} else {
@@ -463,11 +463,11 @@ func (r *Repo) NonInstalledVersion(
 
 	if ver == nil {
 		if versionYmlErr == versionYmlMissing {
-			newtutil.OneTimeWarning(
+			util.OneTimeWarning(
 				"%s:%s does not contain a `version.yml` file.",
 				r.Name(), commit)
 		} else if versionYmlErr == versionYmlBad {
-			newtutil.OneTimeWarning(
+			util.OneTimeWarning(
 				"%s:%s contains a malformed `version.yml` file.",
 				r.Name(), commit)
 		}

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -33,7 +33,7 @@ const NEWTRC_DIR string = ".newt"
 const REPOS_FILENAME string = "repos.yml"
 
 // Contains general newt settings read from $HOME/.newt
-var newtrc ycfg.YCfg
+var newtrc *ycfg.YCfg
 
 func readNewtrc() ycfg.YCfg {
 	usr, err := user.Current()
@@ -54,9 +54,10 @@ func readNewtrc() ycfg.YCfg {
 
 func Newtrc() ycfg.YCfg {
 	if newtrc != nil {
-		return newtrc
+		return *newtrc
 	}
 
-	newtrc = readNewtrc()
-	return newtrc
+	yc := readNewtrc()
+	newtrc = &yc
+	return yc
 }

--- a/newt/syscfg/restrict.go
+++ b/newt/syscfg/restrict.go
@@ -59,8 +59,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/parse"
+	"mynewt.apache.org/newt/util"
 )
 
 type CfgRestrictionCode int
@@ -201,7 +201,7 @@ func (cfg *Cfg) restrictionMet(
 
 		val, err := parse.ParseAndEval(expr, settings)
 		if err != nil {
-			newtutil.OneTimeWarning(
+			util.OneTimeWarning(
 				"Ignoring illegal expression for setting \"%s\": "+
 					"`%s` %s\n", r.BaseSetting, r.Expr, err.Error())
 			return true

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -20,10 +20,10 @@
 package target
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/pkg"
@@ -56,9 +56,13 @@ type Target struct {
 
 func NewTarget(basePkg *pkg.LocalPackage) *Target {
 	target := &Target{
-		TargetY: ycfg.YCfg{},
+		basePkg: basePkg,
 	}
-	target.Init(basePkg)
+
+	if basePkg.SyscfgY.Tree() == nil {
+		panic("Fatal: target missing syscfg")
+	}
+	target.TargetY = ycfg.NewYCfg(target.TargetYamlPath())
 	return target
 }
 
@@ -71,13 +75,12 @@ func LoadTarget(basePkg *pkg.LocalPackage) (*Target, error) {
 	return target, nil
 }
 
-func (target *Target) Init(basePkg *pkg.LocalPackage) {
-	target.basePkg = basePkg
+func (target *Target) TargetYamlPath() string {
+	return fmt.Sprintf("%s/%s", target.basePkg.BasePath(), TARGET_FILENAME)
 }
 
 func (target *Target) Load(basePkg *pkg.LocalPackage) error {
-	yc, err := newtutil.ReadConfig(basePkg.BasePath(),
-		strings.TrimSuffix(TARGET_FILENAME, ".yml"))
+	yc, err := newtutil.ReadConfigPath(target.TargetYamlPath())
 	if err != nil {
 		return err
 	}
@@ -110,7 +113,7 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 
 	// Remember the name of the configuration file so that it can be specified
 	// as a dependency to the compiler.
-	target.basePkg.AddCfgFilename(basePkg.BasePath() + TARGET_FILENAME)
+	target.basePkg.AddCfgFilename(target.TargetYamlPath())
 
 	return nil
 }
@@ -263,9 +266,7 @@ func (t *Target) Save() error {
 		return err
 	}
 
-	dirpath := t.basePkg.BasePath()
-	filepath := dirpath + "/" + TARGET_FILENAME
-	file, err := os.Create(filepath)
+	file, err := os.Create(t.TargetYamlPath())
 	if err != nil {
 		return util.NewNewtError(err.Error())
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -713,3 +713,18 @@ func FileContains(contents []byte, path string) (bool, error) {
 	rc := bytes.Compare(oldSrc, contents)
 	return rc == 0, nil
 }
+
+// Keeps track of warnings that have already been reported.
+// [warning-text] => struct{}
+var warnings = map[string]struct{}{}
+
+// Displays the specified warning if it has not been displayed yet.
+func OneTimeWarning(text string, args ...interface{}) {
+	body := fmt.Sprintf(text, args...)
+	if _, ok := warnings[body]; !ok {
+		warnings[body] = struct{}{}
+
+		body := fmt.Sprintf(text, args...)
+		StatusMessage(VERBOSITY_QUIET, "WARNING: %s\n", body)
+	}
+}


### PR DESCRIPTION
**NOTE:** This PR includes #235.  That should be merged before this one.

This PR addresses the following example:
```
    pkg.deps.FOO:
        - my_pkg
    pkg.deps.BAR:
        - my_pkg
```

This package has two conflicting conditional dependencies.

Before this PR, newt would only process one of the dependencies, and it did so in an inconsistent order.  So, the build would end up with one or the other of the dependencies, but never both.

Now, newt merges such conflicting conditional dependencies into a single dependency.  The resulting dependency is conditional on the union of all the sub expreessions.  Newt would (internally) convert the above example to:                  
```
    pkg.deps.'(FOO) || (BAR)'
        - my_pkg
```

Alternatively, the user could perform this transformation manually, but that could get messy with complicated `pkg.yml` files.
