### PR TITLE
Bump the Go version requirement from 1.7 to 1.10

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -11,7 +11,7 @@ when available.  To find these, please go to https://mynewt.apache.org/.
 # Installing From Source
 
 The newt tool is written in Go (https://golang.org/).  In order to build Apache
-Mynewt, you must have Go 1.7 or later installed on your system.  Please visit
+Mynewt, you must have Go 1.10 or later installed on your system.  Please visit
 the Golang website for more information on installing Go (https://golang.org/).
 
 Once you have Go installed, you can build newt by running the contained


### PR DESCRIPTION
Attempting to build the project with an earlier Go version will result in the following error:

    newt/builder/targetbuild.go:399: undefined: x509.MarshalPKCS1PublicKey

See: https://golang.org/doc/go1.10#crypto/x509
See: https://stackoverflow.com/a/48902054
