### PR TITLE
 Inject target name into syscfg

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -486,7 +486,8 @@ func (b *Builder) PrepBuild() error {
 
 	// Define a cpp symbol indicating the BSP architecture, name of the
 	// BSP and app.
-
+	// The arch, app, and bsp defines are kept here for backwards compatiblity.
+	// Users should prefer the equivalent syscfg defines.
 	archName := b.targetBuilder.bspPkg.Arch
 	bspCi.Cflags = append(bspCi.Cflags, "-DARCH_"+util.CIdentifier(archName))
 	bspCi.Cflags = append(bspCi.Cflags, "-DARCH_NAME="+archName+"")

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -141,6 +141,10 @@ func (t *TargetBuilder) injectBuildSettings() {
 	bspName := filepath.Base(t.bspPkg.Name())
 	t.InjectSetting("BSP_NAME", "\""+bspName+"\"")
 	t.InjectSetting("BSP_"+util.CIdentifier(bspName), "1")
+
+	tgtName := filepath.Base(t.target.Name())
+	t.InjectSetting("TARGET_NAME", "\""+tgtName+"\"")
+	t.InjectSetting("TARGET_"+util.CIdentifier(tgtName), "1")
 }
 
 func (t *TargetBuilder) ensureResolved() error {

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -998,12 +998,8 @@ func (cfg *Cfg) DeprecatedWarning() []string {
 	return lines
 }
 
-func escapeStr(s string) string {
-	return strings.ToUpper(util.CIdentifier(s))
-}
-
 func settingName(setting string) string {
-	return SYSCFG_PREFIX_SETTING + escapeStr(setting)
+	return SYSCFG_PREFIX_SETTING + util.CIdentifier(setting)
 }
 
 func normalizePkgType(typ interfaces.PackageType) interfaces.PackageType {


### PR DESCRIPTION
Newt injects the following settings into syscfg:
```
    TARGET_<target-name> = 1
    TARGET_NAME = "<target-name>"
```