### PR TITLE
larva: Add fixuprt command.

### DIFF
--- a/artifact/manifest/mfg_manifest.go
+++ b/artifact/manifest/mfg_manifest.go
@@ -14,6 +14,7 @@ type MfgManifestTarget struct {
 	BinPath      string `json:"bin_path,omitempty"`
 	ImagePath    string `json:"image_path,omitempty"`
 	ManifestPath string `json:"manifest_path"`
+	IsBoot       bool   `json:"is_boot"`
 }
 
 type MfgManifestMetaMmr struct {

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -258,6 +258,7 @@ func (me *MfgEmitter) emitManifest() ([]byte, error) {
 			Name:         t.Name,
 			ManifestPath: MfgTargetManifestPath(i),
 			Offset:       t.Offset,
+			IsBoot:       t.IsBoot,
 		}
 
 		if t.IsBoot {


### PR DESCRIPTION
This command fixes up the sha256 hashes in a cloud mfgimage's `runtime.json` file