### PR TITLE
larva: Replace `swapkey` with `swapisk`, `swapkek`

### DIFF
--- a/artifact/manifest/mfg_manifest.go
+++ b/artifact/manifest/mfg_manifest.go
@@ -31,6 +31,11 @@ type MfgManifestMeta struct {
 	// XXX: refhash
 }
 
+type MfgManifestSig struct {
+	Key string `json:"key"`
+	Sig string `json:"sig"`
+}
+
 type MfgManifest struct {
 	Name       string            `json:"name"`
 	BuildTime  string            `json:"build_time"`
@@ -40,6 +45,7 @@ type MfgManifest struct {
 	Device     int               `json:"device"`
 	BinPath    string            `json:"bin_path"`
 	Bsp        string            `json:"bsp"`
+	Signatures []MfgManifestSig  `json:"signatures,omitempty"`
 	FlashAreas []flash.FlashArea `json:"flash_map"`
 
 	Targets []MfgManifestTarget `json:"targets"`

--- a/artifact/sec/encrypt.go
+++ b/artifact/sec/encrypt.go
@@ -1,0 +1,42 @@
+package sec
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"io"
+
+	"mynewt.apache.org/newt/util"
+)
+
+func EncryptAES(plain []byte, secret []byte) ([]byte, error) {
+	block, err := aes.NewCipher(secret)
+	if err != nil {
+		return nil, util.NewNewtError("Failed to create block cipher")
+	}
+	nonce := make([]byte, 16)
+	stream := cipher.NewCTR(block, nonce)
+
+	dataBuf := make([]byte, 16)
+	encBuf := make([]byte, 16)
+	r := bytes.NewReader(plain)
+	w := bytes.Buffer{}
+	for {
+		cnt, err := r.Read(dataBuf)
+		if err != nil && err != io.EOF {
+			return nil, util.FmtNewtError(
+				"Failed to read from plaintext: %s", err.Error())
+		}
+		if cnt == 0 {
+			break
+		}
+
+		stream.XORKeyStream(encBuf, dataBuf[0:cnt])
+		if _, err = w.Write(encBuf[0:cnt]); err != nil {
+			return nil, util.FmtNewtError(
+				"Failed to write ciphertext: %s", err.Error())
+		}
+	}
+
+	return w.Bytes(), nil
+}

--- a/artifact/sec/pkcs.go
+++ b/artifact/sec/pkcs.go
@@ -18,7 +18,7 @@
  */
 
 // Decoder for PKCS#5 encrypted PKCS#8 private keys.
-package image
+package sec
 
 import (
 	"crypto/aes"
@@ -78,6 +78,7 @@ type hashFunc func() hash.Hash
 
 func parseEncryptedPrivateKey(der []byte) (key interface{}, err error) {
 	var wrapper pkcs5
+	fmt.Printf("unmarshalling %v\n", der)
 	if _, err = asn1.Unmarshal(der, &wrapper); err != nil {
 		return nil, err
 	}

--- a/larva/cli/image_cmds.go
+++ b/larva/cli/image_cmds.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/larva/lvimg"
 	"mynewt.apache.org/newt/util"
 )
@@ -145,7 +146,7 @@ func runSignCmd(cmd *cobra.Command, args []string) {
 		LarvaUsage(cmd, err)
 	}
 
-	keys, err := image.ReadKeys(args[1:])
+	keys, err := sec.ReadKeys(args[1:])
 	if err != nil {
 		LarvaUsage(cmd, err)
 	}

--- a/larva/cli/util.go
+++ b/larva/cli/util.go
@@ -77,6 +77,17 @@ func CopyDir(src string, dst string) error {
 	return nil
 }
 
+func EnsureOutDir(inDir, outDir string) error {
+	if inDir != outDir {
+		// Not an in-place operation; copy input directory.
+		if err := CopyDir(inDir, outDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func CopyFile(src string, dst string) error {
 	if err := util.CopyFile(src, dst); err != nil {
 		return util.FmtNewtError(

--- a/larva/lvimg/lvimg.go
+++ b/larva/lvimg/lvimg.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/util"
 )
 
@@ -134,17 +135,17 @@ func DecryptImage(img image.Image, privKeBytes []byte) (image.Image, error) {
 		return img, err
 	}
 
-	privKe, err := image.ParsePrivKeDer(privKeBytes)
+	privKe, err := sec.ParsePrivKeDer(privKeBytes)
 	if err != nil {
 		return img, err
 	}
 
-	plainSecret, err := image.DecryptSecretRsa(privKe, cipherSecret)
+	plainSecret, err := sec.DecryptSecretRsa(privKe, cipherSecret)
 	if err != nil {
 		return img, err
 	}
 
-	body, err := image.EncryptImageBody(img.Body, plainSecret)
+	body, err := sec.EncryptAES(img.Body, plainSecret)
 	if err != nil {
 		return img, err
 	}
@@ -172,7 +173,7 @@ func EncryptImage(img image.Image, pubKeBytes []byte) (image.Image, error) {
 		return img, err
 	}
 
-	body, err := image.EncryptImageBody(img.Body, plainSecret)
+	body, err := sec.EncryptAES(img.Body, plainSecret)
 	if err != nil {
 		return img, err
 	}

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -34,7 +34,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"mynewt.apache.org/newt/artifact/flash"
-	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/flashmap"
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/pkg"
@@ -420,7 +420,7 @@ func (t *TargetBuilder) autogenKeys() error {
 	// Initially try parsing a private key in PEM format, if it fails try
 	// parsing as PEM public key, otherwise accepted as raw key data (DER)
 
-	privKey, err := image.ParsePrivateKey(keyBytes)
+	privKey, err := sec.ParsePrivateKey(keyBytes)
 	if err == nil {
 		switch pk := privKey.(type) {
 		case *rsa.PrivateKey:

--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/builder"
 	"mynewt.apache.org/newt/newt/imgprod"
 	"mynewt.apache.org/newt/newt/newtutil"
@@ -36,7 +37,7 @@ var useV2 bool
 var encKeyFilename string
 
 // @return                      keys, key ID, error
-func parseKeyArgs(args []string) ([]image.ImageSigKey, uint8, error) {
+func parseKeyArgs(args []string) ([]sec.SignKey, uint8, error) {
 	if len(args) == 0 {
 		return nil, 0, nil
 	}
@@ -58,7 +59,7 @@ func parseKeyArgs(args []string) ([]image.ImageSigKey, uint8, error) {
 		keyFilenames = args
 	}
 
-	keys, err := image.ReadKeys(keyFilenames)
+	keys, err := sec.ReadKeys(keyFilenames)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/newt/cli/mfg_cmds.go
+++ b/newt/cli/mfg_cmds.go
@@ -106,7 +106,12 @@ func mfgCreateRunCmd(cmd *cobra.Command, args []string) {
 		NewtUsage(cmd, err)
 	}
 
-	me, err := mfg.LoadMfgEmitter(lpkg, ver)
+	keys, _, err := parseKeyArgs(args[2:])
+	if err != nil {
+		NewtUsage(nil, err)
+	}
+
+	me, err := mfg.LoadMfgEmitter(lpkg, ver, keys)
 	if err != nil {
 		NewtUsage(nil, err)
 	}
@@ -148,7 +153,7 @@ func mfgDeployRunCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	me, err := mfg.LoadMfgEmitter(lpkg, ver)
+	me, err := mfg.LoadMfgEmitter(lpkg, ver, nil)
 	if err != nil {
 		NewtUsage(nil, err)
 	}
@@ -174,7 +179,8 @@ func AddMfgCommands(cmd *cobra.Command) {
 	cmd.AddCommand(mfgCmd)
 
 	mfgCreateCmd := &cobra.Command{
-		Use:   "create <mfg-package-name> <version #.#.#.#>",
+		Use: "create <mfg-package-name> <version #.#.#.#> [signing-key-1] " +
+			"[signing-key-2] [...]",
 		Short: "Create a manufacturing flash image",
 		Run:   mfgCreateRunCmd,
 	}

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -21,9 +21,11 @@ package cli
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/imgprod"
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/parse"
@@ -93,7 +95,7 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 				NewtUsage(cmd, err)
 			}
 
-			var keys []image.ImageSigKey
+			var keys []sec.SignKey
 
 			if len(args) > 2 {
 				keys, _, err = parseKeyArgs(args[2:])

--- a/newt/imgprod/imgprod.go
+++ b/newt/imgprod/imgprod.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/builder"
 	"mynewt.apache.org/newt/newt/manifest"
 	"mynewt.apache.org/newt/newt/newtutil"
@@ -40,7 +41,7 @@ type ImageProdOpts struct {
 	AppDstFilename    string
 	EncKeyFilename    string
 	Version           image.ImageVersion
-	SigKeys           []image.ImageSigKey
+	SigKeys           []sec.SignKey
 }
 
 type ProducedImage struct {
@@ -235,7 +236,7 @@ func ProduceManifest(opts manifest.ManifestCreateOpts) error {
 }
 
 func OptsFromTgtBldr(b *builder.TargetBuilder, ver image.ImageVersion,
-	sigKeys []image.ImageSigKey, encKeyFilename string) ImageProdOpts {
+	sigKeys []sec.SignKey, encKeyFilename string) ImageProdOpts {
 
 	opts := ImageProdOpts{
 		AppSrcFilename: b.AppBuilder.AppBinPath(),
@@ -254,7 +255,7 @@ func OptsFromTgtBldr(b *builder.TargetBuilder, ver image.ImageVersion,
 }
 
 func ProduceAll(t *builder.TargetBuilder, ver image.ImageVersion,
-	sigKeys []image.ImageSigKey, encKeyFilename string) error {
+	sigKeys []sec.SignKey, encKeyFilename string) error {
 
 	popts := OptsFromTgtBldr(t, ver, sigKeys, encKeyFilename)
 	pset, err := ProduceImages(popts)

--- a/newt/imgprod/v1.go
+++ b/newt/imgprod/v1.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/builder"
 	"mynewt.apache.org/newt/newt/manifest"
 	"mynewt.apache.org/newt/newt/newtutil"
@@ -186,7 +187,7 @@ func ProduceImagesV1(opts ImageProdOpts) (ProducedImageSetV1, error) {
 }
 
 func ProduceAllV1(t *builder.TargetBuilder, ver image.ImageVersion,
-	sigKeys []image.ImageSigKey, encKeyFilename string) error {
+	sigKeys []sec.SignKey, encKeyFilename string) error {
 
 	popts := OptsFromTgtBldr(t, ver, sigKeys, encKeyFilename)
 	pset, err := ProduceImagesV1(popts)

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -30,6 +30,7 @@ import (
 	"mynewt.apache.org/newt/artifact/manifest"
 	"mynewt.apache.org/newt/artifact/mfg"
 	"mynewt.apache.org/newt/artifact/misc"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/builder"
 	"mynewt.apache.org/newt/newt/flashmap"
 	"mynewt.apache.org/newt/newt/target"
@@ -144,7 +145,7 @@ func newMfgEmitMeta(bm MfgBuildMeta, metaOff int) MfgEmitMeta {
 
 // NewMfgEmitter creates an mfg emitter from an mfg builder.
 func NewMfgEmitter(mb MfgBuilder, name string, ver image.ImageVersion,
-	device int) (MfgEmitter, error) {
+	device int, keys []sec.SignKey) (MfgEmitter, error) {
 
 	me := MfgEmitter{
 		Name:     name,

--- a/newt/mfg/misc.go
+++ b/newt/mfg/misc.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"mynewt.apache.org/newt/artifact/image"
+	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/builder"
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/pkg"
@@ -44,7 +45,7 @@ func loadDecodedMfg(basePath string) (DecodedMfg, error) {
 }
 
 func LoadMfgEmitter(basePkg *pkg.LocalPackage,
-	ver image.ImageVersion) (MfgEmitter, error) {
+	ver image.ImageVersion, keys []sec.SignKey) (MfgEmitter, error) {
 
 	dm, err := loadDecodedMfg(basePkg.BasePath())
 	if err != nil {
@@ -61,7 +62,7 @@ func LoadMfgEmitter(basePkg *pkg.LocalPackage,
 		return MfgEmitter{}, err
 	}
 
-	me, err := NewMfgEmitter(mb, basePkg.Name(), ver, device)
+	me, err := NewMfgEmitter(mb, basePkg.Name(), ver, device, keys)
 	if err != nil {
 		return MfgEmitter{}, err
 	}


### PR DESCRIPTION
The two commands are necessary because the KEK length field needs to be updated as well.  The ISK (image signing key) is a public key, so its length is constant.