### PR TITLE
`$import` directive

### DIFF
--- a/newt/cli/vars.go
+++ b/newt/cli/vars.go
@@ -25,10 +25,11 @@ import (
 	"sort"
 	"strings"
 
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/interfaces"
-	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/pkg"
 	"mynewt.apache.org/newt/newt/project"
+	"mynewt.apache.org/newt/newt/toolchain"
 	"mynewt.apache.org/newt/util"
 )
 
@@ -79,8 +80,8 @@ func buildProfileValues() ([]string, error) {
 
 	packs := project.GetProject().PackagesOfType(pkg.PACKAGE_TYPE_COMPILER)
 	for _, pack := range packs {
-		v, err := newtutil.ReadConfig(pack.(*pkg.LocalPackage).BasePath(),
-			"compiler")
+		v, err := config.ReadFile(
+			pack.BasePath() + "/" + toolchain.COMPILER_FILENAME)
 		if err != nil {
 			return nil, err
 		}

--- a/newt/config/config.go
+++ b/newt/config/config.go
@@ -1,0 +1,205 @@
+// The config package handles reading of newt YAML files.
+package config
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cast"
+
+	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/ycfg"
+	"mynewt.apache.org/newt/util"
+	"mynewt.apache.org/newt/yaml"
+)
+
+const (
+	KEYWORD_IMPORT = "$import"
+)
+
+// keywordMap is a map of all supported keywords.  Config keywords always start
+// with "$".
+var keywordMap = map[string]struct{}{
+	KEYWORD_IMPORT: struct{}{},
+}
+
+// FileEntry represents a single YAML file.  It does not contain import
+// information.
+type FileEntry struct {
+	FileInfo *util.FileInfo
+	Settings map[string]interface{}
+}
+
+func readSettings(path string) (map[string]interface{}, error) {
+	file, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, util.ChildNewtError(err)
+	}
+
+	settings := map[string]interface{}{}
+	if err := yaml.Unmarshal(file, &settings); err != nil {
+		return nil, util.FmtNewtError("Failure parsing \"%s\": %s",
+			path, err.Error())
+	}
+
+	return settings, nil
+}
+
+func readFileEntry(path string, parent *util.FileInfo) (FileEntry, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return FileEntry{}, err
+	}
+
+	settings, err := readSettings(absPath)
+	if err != nil {
+		return FileEntry{}, err
+	}
+
+	return FileEntry{
+		FileInfo: &util.FileInfo{
+			Path:   absPath,
+			Parent: parent,
+		},
+		Settings: settings,
+	}, nil
+}
+
+func extractImports(settings map[string]interface{}) ([]string, error) {
+	itf := settings[KEYWORD_IMPORT]
+	if itf == nil {
+		return nil, nil
+	}
+
+	strs, err := cast.ToStringSliceE(itf)
+	if err != nil {
+		return nil, util.FmtNewtError(
+			"invalid %s section; must contain sequence of strings",
+			KEYWORD_IMPORT)
+	}
+
+	return strs, nil
+}
+
+func (fe *FileEntry) warnUnrecognizedKeywords() {
+	m := map[string]struct{}{}
+
+	// Find all unrecognized entries starting with "$".
+	for k, _ := range fe.Settings {
+		if strings.HasPrefix(k, "$") {
+			if _, ok := keywordMap[k]; !ok {
+				m[k] = struct{}{}
+			}
+		}
+	}
+
+	if len(m) == 0 {
+		return
+	}
+
+	keywords := make([]string, 0, len(m))
+	for k, _ := range m {
+		keywords = append(keywords, k)
+	}
+	sort.Strings(keywords)
+
+	s := ""
+	for _, k := range keywords {
+		s += "\n    " + k
+	}
+
+	util.OneTimeWarning(
+		"%s contains unrecognized keywords: %s\n"+
+			"you may need to upgrade your version of newt.",
+		fe.FileInfo.Path, s)
+}
+
+// readLineage reads a configuration file and all files it imports (directly
+// or indirectly).  The resulting []FileEntry is sorted in the order the
+// corresponding files were read.
+func readLineage(path string) ([]FileEntry, error) {
+	entries := []FileEntry{}
+	seen := map[string]struct{}{}
+
+	// Recursively process imports, accumulating file info in `entries`.
+	var iter func(path string, parent *util.FileInfo) error
+	iter = func(path string, parent *util.FileInfo) error {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return parent.ErrTree(err)
+		}
+
+		// Don't process the same config file twice.
+		if _, ok := seen[absPath]; ok {
+			return nil
+		}
+		seen[absPath] = struct{}{}
+
+		entry, err := readFileEntry(path, parent)
+		if err != nil {
+			return parent.ErrTree(err)
+		}
+
+		imports, err := extractImports(entry.Settings)
+		if err != nil {
+			return err
+		}
+
+		for _, imp := range imports {
+			if err := iter(imp, entry.FileInfo); err != nil {
+				return err
+			}
+		}
+
+		// Only add the top-level entry now that the imports have been
+		// processed.  This comes last so that it can override settings
+		// specified by imported files.
+		entries = append(entries, entry)
+
+		return nil
+	}
+
+	// Recursively read imported configuration files.
+	if err := iter(path, nil); err != nil {
+		return nil, err
+	}
+
+	// Log the configuration files that were read.  If there are imports, log
+	// it using a tree notation.
+	if len(entries) == 1 {
+		log.Debugf("Read config file: %s",
+			newtutil.ProjRelPath(entries[0].FileInfo.Path))
+	} else {
+		tree, err := BuildTree(entries)
+		if err != nil {
+			return nil, err
+		}
+		log.Debugf("Read config files:\n%s", TreeString(tree))
+	}
+
+	return entries, nil
+}
+
+// ReadFile reads a YAML file, processes all its `$import` directives, and
+// returns a populated YCfg tree.
+func ReadFile(path string) (ycfg.YCfg, error) {
+	yc := ycfg.NewYCfg(path)
+
+	entries, err := readLineage(path)
+	if err != nil {
+		return yc, err
+	}
+
+	for _, e := range entries {
+		for k, v := range e.Settings {
+			if err := yc.MergeFromFile(k, v, e.FileInfo); err != nil {
+				return yc, e.FileInfo.Parent.ErrTree(err)
+			}
+		}
+	}
+
+	return yc, nil
+}

--- a/newt/config/tree.go
+++ b/newt/config/tree.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"sort"
+	"strings"
+
+	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/util"
+)
+
+type Node struct {
+	Entry    *FileEntry
+	Children []*Node
+}
+
+type nodeSorter struct {
+	nodes []*Node
+}
+
+func (s nodeSorter) Len() int {
+	return len(s.nodes)
+}
+func (s nodeSorter) Swap(i, j int) {
+	s.nodes[i], s.nodes[j] = s.nodes[j], s.nodes[i]
+}
+func (s nodeSorter) Less(i, j int) bool {
+	return s.nodes[i].Entry.FileInfo.Path < s.nodes[j].Entry.FileInfo.Path
+}
+
+func SortNodes(nodes []*Node) {
+	sorter := nodeSorter{
+		nodes: nodes,
+	}
+	sort.Sort(sorter)
+}
+
+func SortTree(root *Node) {
+	SortNodes(root.Children)
+	for _, n := range root.Children {
+		SortTree(n)
+	}
+}
+
+func BuildTree(entries []FileEntry) (*Node, error) {
+	// Create a node for each entry.
+	m := make(map[*util.FileInfo]*Node, len(entries))
+	for i, _ := range entries {
+		e := &entries[i]
+		m[e.FileInfo] = &Node{
+			Entry: e,
+		}
+	}
+
+	// Fill each node's `Children` slice.
+	var root *Node
+	for _, n := range m {
+		if n.Entry.FileInfo.Parent == nil {
+			if root != nil {
+				return nil, util.FmtNewtError(
+					"config tree contains two roots: %s, %s",
+					root.Entry.FileInfo.Path, n.Entry.FileInfo.Path)
+			}
+			root = n
+		} else {
+			parentInfo := n.Entry.FileInfo.Parent
+			parentNode := m[parentInfo]
+			parentNode.Children = append(parentNode.Children, n)
+		}
+	}
+
+	SortTree(root)
+	return root, nil
+}
+
+func TreeString(tree *Node) string {
+	var lines []string
+
+	var appendLines func(n *Node, nestLevel int)
+	appendLines = func(n *Node, nestLevel int) {
+		indent := strings.Repeat(" ", nestLevel*4)
+		path := newtutil.ProjRelPath(n.Entry.FileInfo.Path)
+		lines = append(lines, indent+path)
+
+		for _, child := range n.Children {
+			appendLines(child, nestLevel+1)
+		}
+	}
+
+	appendLines(tree, 1)
+	return strings.Join(lines, "\n")
+}

--- a/newt/mfg/misc.go
+++ b/newt/mfg/misc.go
@@ -25,13 +25,12 @@ import (
 	"mynewt.apache.org/newt/artifact/image"
 	"mynewt.apache.org/newt/artifact/sec"
 	"mynewt.apache.org/newt/newt/builder"
-	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/pkg"
 )
 
 func loadDecodedMfg(basePath string) (DecodedMfg, error) {
-	yc, err := newtutil.ReadConfig(basePath,
-		strings.TrimSuffix(YAML_FILENAME, ".yml"))
+	yc, err := config.ReadFile(basePath + "/" + YAML_FILENAME)
 	if err != nil {
 		return DecodedMfg{}, err
 	}

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"mynewt.apache.org/newt/newt/interfaces"
-	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
 )
 
@@ -178,34 +177,7 @@ func MakeTempRepoDir() (string, error) {
 	return tmpdir, nil
 }
 
-func ReadConfigPath(path string) (ycfg.YCfg, error) {
-	yc := ycfg.NewYCfg(path)
-
-	file, err := ioutil.ReadFile(path)
-	if err != nil {
-		return yc, util.ChildNewtError(err)
-	}
-
-	settings := map[string]interface{}{}
-	if err := yaml.Unmarshal(file, &settings); err != nil {
-		return yc, util.FmtNewtError("Failure parsing \"%s\": %s",
-			path, err.Error())
-	}
-
-	if err := yc.Populate(settings); err != nil {
-		return yc, err
-	}
-
-	return yc, nil
-}
-
-// Read in the configuration file specified by name, in path
-// return a new viper config object if successful, and error if not
-func ReadConfig(dir string, filename string) (ycfg.YCfg, error) {
-	return ReadConfigPath(dir + "/" + filename + ".yml")
-}
-
-// Converts the provided YAML-configuration map to a YAML-encoded string.
-func YCfgToYaml(yc ycfg.YCfg) string {
-	return yaml.MapToYaml(yc.AllSettings())
+func ProjRelPath(path string) string {
+	proj := interfaces.GetProject()
+	return strings.TrimPrefix(path, proj.Path()+"/")
 }

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -28,7 +28,6 @@ import (
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
-	"mynewt.apache.org/newt/yaml"
 )
 
 var NewtVersion = Version{1, 5, 9900}

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -24,9 +24,9 @@ import (
 	"runtime"
 	"strings"
 
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/flashmap"
 	"mynewt.apache.org/newt/newt/interfaces"
-	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
 )
@@ -116,7 +116,7 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 	}
 	settings[strings.ToUpper(runtime.GOOS)] = "1"
 
-	bsp.BspV, err = newtutil.ReadConfigPath(bsp.BspYamlPath())
+	bsp.BspV, err = config.ReadFile(bsp.BspYamlPath())
 	if err != nil {
 		return err
 	}

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -235,7 +235,7 @@ func (lpkg *LocalPackage) SaveSyscfg() error {
 	}
 	defer file.Close()
 
-	s := newtutil.YCfgToYaml(lpkg.SyscfgY)
+	s := lpkg.SyscfgY.YAML()
 	file.WriteString(s)
 
 	return nil

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -28,8 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
-
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/repo"
@@ -291,12 +290,9 @@ func matchNamePath(name, path string) bool {
 
 // Load reads everything that isn't identity specific into the package
 func (pkg *LocalPackage) Load() error {
-	// Load configuration
-	log.Debugf("Loading configuration for package %s", pkg.basePath)
-
 	var err error
 
-	pkg.PkgY, err = newtutil.ReadConfigPath(pkg.PkgYamlPath())
+	pkg.PkgY, err = config.ReadFile(pkg.PkgYamlPath())
 	if err != nil {
 		return err
 	}
@@ -357,7 +353,7 @@ func (pkg *LocalPackage) Load() error {
 	}
 
 	// Load syscfg settings.
-	pkg.SyscfgY, err = newtutil.ReadConfigPath(pkg.SyscfgYamlPath())
+	pkg.SyscfgY, err = config.ReadFile(pkg.SyscfgYamlPath())
 	if err != nil && !util.IsNotExist(err) {
 		return err
 	}
@@ -409,7 +405,8 @@ func LoadLocalPackage(repo *repo.Repo, pkgDir string) (*LocalPackage, error) {
 	pkg := NewLocalPackage(repo, pkgDir)
 	err := pkg.Load()
 	if err != nil {
-		err = util.FmtNewtError("%s; ignoring package.", err.Error())
+		err = util.FmtNewtError("%s; ignoring package %s.",
+			err.Error(), pkgDir)
 		return nil, err
 	}
 

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -29,6 +29,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"mynewt.apache.org/newt/newt/compat"
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/deprepo"
 	"mynewt.apache.org/newt/newt/downloader"
 	"mynewt.apache.org/newt/newt/install"
@@ -511,8 +512,7 @@ func (proj *Project) verifyNewtCompat() error {
 }
 
 func (proj *Project) loadConfig() error {
-	yc, err := newtutil.ReadConfig(proj.BasePath,
-		strings.TrimSuffix(PROJECT_FILE_NAME, ".yml"))
+	yc, err := config.ReadFile(proj.BasePath + "/" + PROJECT_FILE_NAME)
 	if err != nil {
 		return util.NewNewtError(err.Error())
 	}

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cast"
 
 	"mynewt.apache.org/newt/newt/compat"
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/downloader"
 	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/newtutil"
@@ -501,8 +502,7 @@ func (r *Repo) readDepRepos(yc ycfg.YCfg) error {
 func (r *Repo) Read() error {
 	r.Init(r.Name(), r.downloader)
 
-	yc, err := newtutil.ReadConfig(r.repoFilePath(),
-		strings.TrimSuffix(REPO_FILE_NAME, ".yml"))
+	yc, err := config.ReadFile(r.repoFilePath() + "/" + REPO_FILE_NAME)
 	if err != nil {
 		return err
 	}

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/util"
 )
@@ -311,7 +312,7 @@ func (r *Repo) VersionsEqual(v1 newtutil.RepoVersion,
 // Parses the `version.yml` file at the specified path.  On success, the parsed
 // version is returned.
 func parseVersionYml(path string) (newtutil.RepoVersion, error) {
-	yc, err := newtutil.ReadConfigPath(path)
+	yc, err := config.ReadFile(path)
 	if err != nil {
 		if util.IsNotExist(err) {
 			return newtutil.RepoVersion{}, versionYmlMissing

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -20,12 +20,12 @@
 package settings
 
 import (
+	"fmt"
 	"os/user"
-	"strings"
 
 	log "github.com/Sirupsen/logrus"
 
-	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/ycfg"
 )
 
@@ -41,11 +41,10 @@ func readNewtrc() ycfg.YCfg {
 		return ycfg.YCfg{}
 	}
 
-	dir := usr.HomeDir + "/" + NEWTRC_DIR
-	yc, err := newtutil.ReadConfig(dir,
-		strings.TrimSuffix(REPOS_FILENAME, ".yml"))
+	path := fmt.Sprintf("%s/%s/%s", usr.HomeDir, NEWTRC_DIR, REPOS_FILENAME)
+	yc, err := config.ReadFile(path)
 	if err != nil {
-		log.Debugf("Failed to read %s/%s file", dir, REPOS_FILENAME)
+		log.Debugf("Failed to read %s file", path)
 		return ycfg.YCfg{}
 	}
 

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/pkg"
 	"mynewt.apache.org/newt/newt/project"
 	"mynewt.apache.org/newt/newt/repo"
@@ -80,7 +80,7 @@ func (target *Target) TargetYamlPath() string {
 }
 
 func (target *Target) Load(basePkg *pkg.LocalPackage) error {
-	yc, err := newtutil.ReadConfigPath(target.TargetYamlPath())
+	yc, err := config.ReadFile(target.TargetYamlPath())
 	if err != nil {
 		return err
 	}

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -272,7 +272,7 @@ func (t *Target) Save() error {
 	}
 	defer file.Close()
 
-	s := newtutil.YCfgToYaml(t.TargetY)
+	s := t.TargetY.YAML()
 	file.WriteString(s)
 
 	if err := t.basePkg.SaveSyscfg(); err != nil {

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -35,7 +35,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/config"
 	"mynewt.apache.org/newt/newt/project"
 	"mynewt.apache.org/newt/newt/symbol"
 	"mynewt.apache.org/newt/newt/ycfg"
@@ -279,7 +279,7 @@ func loadFlags(yc ycfg.YCfg, settings map[string]string, key string) []string {
 }
 
 func (c *Compiler) load(compilerDir string, buildProfile string) error {
-	yc, err := newtutil.ReadConfig(compilerDir, "compiler")
+	yc, err := config.ReadFile(compilerDir + "/" + COMPILER_FILENAME)
 	if err != nil {
 		return err
 	}

--- a/util/fileinfo.go
+++ b/util/fileinfo.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"fmt"
+)
+
+// FileInfo represents a configuration source.  It is intended to help the user
+// understand how the system acquired its configuration, and to aid in tracking
+// down errors in configuration files.
+type FileInfo struct {
+	Path   string    // Path of configuration file.
+	Parent *FileInfo // File that imported this configuration file, if any.
+}
+
+// ImportString creates a string describing the import hierarchy of the given
+// FileInfo.  It should be called on the *parent* of the file of interest.
+func (fi *FileInfo) ImportString() string {
+	s := ""
+
+	first := true
+	for fi != nil {
+		if !first {
+			s += ", "
+		}
+		first = false
+
+		s += fmt.Sprintf("imported from %s", fi.Path)
+		fi = fi.Parent
+	}
+
+	return s
+}
+
+// ErrTree decorates the given error with a description of the configuration
+// file's import hierarchy.  If a configuration error is encountered, this
+// function should be called on the configuration file's *parent*.
+func (fi *FileInfo) ErrTree(err error) error {
+	if fi == nil {
+		return err
+	}
+
+	return FmtNewtError("%s - %s", err.Error(), fi.ImportString())
+}


### PR DESCRIPTION
### PROBLEM:

Within a project, there can be a lot of duplication among target `syscfg.yml` files.  The Mynewt package hierarchy mitigates this problem to some extent: the BSP defines some settings, the app overrides a few of those, and the target overrides yet more.  This does not resolve the problem fully, however.  Often, a project has several targets that differ only by one or two syscfg overrides.  For example, a project may have `dev`, `prod`, and `qa` targets, all nearly identical to each other.  Duplicating all the target-level overrides in each target is like any kind of duplication: error prone and a maintenance burden.

### PROPOSAL:

A new Mynewt keyword: `$import`.  This allows a Mynewt YAML file to import the contents of other YAML files.

Example (`targets/dev/syscfg.yml`):

```
$import:
    - 'targets/some_target/syscfg.yml'
    - 'targets/another_target/syscfg.yml'

syscfg.vals:
    OS_DEBUG_MODE: 1
```

In this example, the `dev` target's `syscfg.yml` file imports the syscfg files of two other targets.  The target inherits all the setting definitions and values specified in the imported files.

This feature is similar, but not identical, to C's `#include` directive.  Differences between the two features are:

1. Like `#include`, import paths can be absolute or relative.  However, relative paths are always relative to the project base, not to the file doing the importing.

2. The `$import` map can be placed anywhere in the file, but its placement does not affect its behavior.  Imports are always processed before the rest of the file.

3. Unlike `#include`, `$import` does not perform a simple text substitution.  If it did, it would result in an invalid YAML file (multiple `syscfg.defs` or `syscfg.vals` maps).  Instead, maps with the same name are collected from all imported files and merged into the importing file.

### NOTES

1. This feature introduces the concept of newt keywords.  Keywords are special directives in a YAML file that alter newt's behavior.  Keywords always start with "$".  If newt encounters a keyword that it doesn't understand, it warns the user.

2. This feature may make it confusing to trace down the source of a syscfg override.  Overrides are still a package-level concept, so the `target config` and `target [rev]dep` output indicate which package overrides a setting, not which file.  The implementation of the `$import` feature attaches file info to each syscfg setting (file that defines or overrides the setting along with its import tree), but this information is not accessible at the moment.  I imagine we will want an alternative `target config` command which displays the file performing the override rather than the package.