### PR TITLE
newt: Remove "imposter packages" from build graph

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -173,13 +173,17 @@ func NewCfg() Cfg {
 	}
 }
 
-func (cfg *Cfg) SettingValues() map[string]string {
-	values := make(map[string]string, len(cfg.Settings))
-	for k, v := range cfg.Settings {
+func SettingValues(settings map[string]CfgEntry) map[string]string {
+	values := make(map[string]string, len(settings))
+	for k, v := range settings {
 		values[k] = v.Value
 	}
 
 	return values
+}
+
+func (cfg *Cfg) SettingValues() map[string]string {
+	return SettingValues(cfg.Settings)
 }
 
 func ResolveValueRefName(val string) string {


### PR DESCRIPTION
A package is an "imposter package" if it is in the dependency graph by virtue of its own syscfg defines and overrides.  For example, say we have a package `foo`:

```
    pkg.name: foo
    syscfg.defs:
        FOO_SETTING:
               value: 1
```

Then we have a BSP package:

```
    pkg.name: my_bsp
    pkg.deps.FOO_SETTING:
        - foo
```

If this is the only dependency on `foo`, then `foo` is an imposter.  It should be removed from the graph, and its syscfg defines and overrides should be deleted.

Because the syscfg state changes as newt discovers new dependencies, it is possible for imposters to end up in the graph.

It is important to remove these packages from the graph for three reasons:

1. Bogus build failures occur when an imposter package's dependencies cannot be fully satisfied.
2. If the build succeeds, imposter packages may make silent changes to the system via syscfg defines and overrides.
3. Increase build time with no benefit.

This commit prunes imposter packages using the following procedure:
* For each package in the graph, rpkg:
  1. Construct a temporary copy of the syscfg.  Remove rpkg entirely from this copy (all its defines and overrides).
  2. Attempt to trace rpkg back to a seed package via reverse dependencies using the modified syscfg.

If an rpkg cannot be traced back to a seed package using the modified settings (i.e., all links to seed packages are invalid given the modified config), then it is an imposter and it must be removed.

As will the other pruning procedures, the syscfg and dependency graph must be recalculated whenever packages are removed.  This is so because each removal potentially changes the syscfg, and consequently may add or remove dependencies.