### PR TITLE
$import paths should be relative to project base

### DIFF
--- a/larva/cli/mfg_cmds.go
+++ b/larva/cli/mfg_cmds.go
@@ -332,7 +332,6 @@ func runMfgHashableCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		LarvaUsage(nil, err)
 	}
-
 	// Zero-out hash so that the hash can be recalculated.
 	m.Meta.ClearHash()
 
@@ -578,7 +577,7 @@ func AddMfgCommands(cmd *cobra.Command) {
 
 	hashableCmd := &cobra.Command{
 		Use:   "hashable <mfgimage-dir>",
-		Short: "Replaces an outdated mfgimage hash with an accurate one",
+		Short: "Extracts the hashable / signable content of an mfgimage",
 		Run:   runMfgHashableCmd,
 	}
 	hashableCmd.PersistentFlags().StringVarP(&OptOutFilename, "outfile", "o",

--- a/newt/config/config.go
+++ b/newt/config/config.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cast"
 
+	"mynewt.apache.org/newt/newt/interfaces"
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/ycfg"
 	"mynewt.apache.org/newt/util"
@@ -127,6 +128,12 @@ func readLineage(path string) ([]FileEntry, error) {
 	// Recursively process imports, accumulating file info in `entries`.
 	var iter func(path string, parent *util.FileInfo) error
 	iter = func(path string, parent *util.FileInfo) error {
+		// Relative paths are relative to the project base.
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(interfaces.GetProject().Path(), path)
+		}
+
+		// Only operate on absolute paths to ensure each file has a unique ID.
 		absPath, err := filepath.Abs(path)
 		if err != nil {
 			return parent.ErrTree(err)


### PR DESCRIPTION
Prior to this commit, relative $import paths were relative to the present working directory.  This is wrong: a config file's semantics should not depend on the directory newt was run from.