### PR TITLE
Allow choice settings in syscfg

### DIFF
--- a/newt/syscfg/restrict.go
+++ b/newt/syscfg/restrict.go
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-// Currently, three forms of restrictions are supported:
+// Currently, two forms of restrictions are supported:
 // 1. "$notnull"
 // 2. expression
 //


### PR DESCRIPTION
This adds support to have syscfg settings which can be set to one of predefined values. This allows to simplify some settings which now have separate syscfg defined for each choice. With this new setting
newt can guarantee that only single setting for selected choice is configured in `syscfg.h`.

I'm not sure if this is good approach, so perhaps someone has better idea how to achieve the same result. The main disadvantage of current implementation is that it breaks compatibility with old `newt` versions since they do not generate `MYNEWT_VAL_CHOICE` macro in `syscfg.h` which is a helper to check if choice is selected. Anyway, let me explain how this works (snippets below are from https://github.com/apache/mynewt-core/pull/1654)

Sample settings looks like this:
```
    MCU_LFCLK_SOURCE:
        description: >
            Selected source for low frequency clock (LFCLK).
        value:
        choices:
            - LFRC      # 32.768 kHz RC oscillator
            - LFXO      # 32.768 kHz crystal oscillator
            - LFSYNTH   # 32.768 kHz synthesized from HFCLK
```

If `choices` key is present, `value` has to be either empty or one of specified choices. It is valid to leave value empty, thus `$notnull` must be used if setting requires a valid value. List of choices is a list of strings (letters, numbers and underscores allowed) and internally they are handled case-insensitive (thus 'LFRC` and `'lfrc` would be considered the same choice which is invalid).

Assuming `MCU_TARGET: nrf52840`, setting defined as above will generate following defines in `syscfg.h`:
```
/* Overridden by @apache-mynewt-core/hw/bsp/nordic_pca10056 (defined by @apache-mynewt-core/hw/mcu/nordic/nrf52xxx) */
#ifndef MYNEWT_VAL_MCU_LFCLK_SOURCE__LFRC
#define MYNEWT_VAL_MCU_LFCLK_SOURCE__LFRC (0)
#endif
#ifndef MYNEWT_VAL_MCU_LFCLK_SOURCE__LFSYNTH
#define MYNEWT_VAL_MCU_LFCLK_SOURCE__LFSYNTH (0)
#endif
#ifndef MYNEWT_VAL_MCU_LFCLK_SOURCE__LFXO
#define MYNEWT_VAL_MCU_LFCLK_SOURCE__LFXO (1)
#endif
#ifndef MYNEWT_VAL_MCU_LFCLK_SOURCE
#define MYNEWT_VAL_MCU_LFCLK_SOURCE (1)
#endif
```

Main sysycfg name is ehtier `1` when any value is set or `0` otherwise. Each choice listed have separate define which consists of syscfg name and choice name (in lowercase) set to `1` if this is the selected value or `0` otherwise. To make checks easier, `MYNEWT_VAL_CHOICE(_name, _val)` macro is defined which checks for given choice on syscfg value. Note that even though value was specified in lower-case, original spelling of choice is preserved in `syscfg.h`.