### PR TITLE
Don't escape curly braces in an MSYS environment

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -262,9 +262,9 @@ func Init(logLevel log.Level, logFile string, verbosity int) error {
 	return nil
 }
 
-// Escapes special characters for Windows builds.
+// Escapes special characters for Windows builds (not in an MSYS environment).
 func fixupCmdArgs(args []string) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && os.Getenv("MSYSTEM") == "" {
 		for i, _ := range args {
 			args[i] = strings.Replace(args[i], "{", "\\{", -1)
 			args[i] = strings.Replace(args[i], "}", "\\}", -1)


### PR DESCRIPTION
In Windows, curly braces ('{', '}') need to be escaped with backslashes.  However, Unix-like shells that run in Windows do not like these characters to be escaped.  One such shell is MSYS, a shell that comes with mingw.

MSYS can be detected by the presence of the `MSYSTEM` environment variable.  If this is set, then don't escape curly braces.

We should also check if something similar is needed in cygwin.
