### PR TITLE
Fix expressions in settings restrictions

### DIFF
--- a/newt/syscfg/restrict.go
+++ b/newt/syscfg/restrict.go
@@ -158,7 +158,7 @@ func translateShorthandExpr(expr string, baseSetting string) string {
 	}
 
 	if ifi == -1 {
-		if parse.FindBinaryToken(tokens) == -1 {
+		if parse.FindBinaryToken(tokens) == -1 || len(baseSetting) > 0 {
 			// [!]<req-setting>
 			return fmt.Sprintf("(%s) || !%s", expr, baseSetting)
 		} else {


### PR DESCRIPTION
This patch makes following restrictions possible:
```
  UART_1:
      description: 'Enable nRF52xxx UART1'
      value: 0
      restrictions:
          - 'MCU_TARGET == "nRF52840"'
```
Currently this would be evaluated without translation thus `UART_1` value
does not matter here (as in package restriction). Instead, we want to
make this translated into `(MCU_TARGET == "nRF52840") || (!UART_1)`
which is what this patch does.