### PR TITLE
Remember which packages satisfy API requirements

### DIFF
--- a/newt/parse/expr.go
+++ b/newt/parse/expr.go
@@ -9,6 +9,16 @@ type ExprSet map[string]*Node
 // ExprMap is a collection of named expression sets.
 type ExprMap map[string]ExprSet
 
+func NewExprSet(exprs []*Node) ExprSet {
+	if len(exprs) == 0 {
+		return nil
+	}
+
+	es := make(ExprSet, len(exprs))
+	es.Add(exprs)
+	return es
+}
+
 // Exprs returns a slice of all expressions contained in the expression set.
 // The resulting slice is sorted.
 func (es ExprSet) Exprs() []*Node {

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -233,6 +233,13 @@ func (rpkg *ResolvePackage) AddDep(
 func (rpkg *ResolvePackage) AddApiDep(
 	depPkg *ResolvePackage, api string, exprs []*parse.Node) {
 
+	// Satisfy the API dependency.
+	rpkg.reqApiMap[api] = resolveReqApi{
+		satisfied: true,
+		exprs:     parse.NewExprSet(exprs),
+	}
+
+	// Add a reverse dependency to the API-supplier.
 	dep := rpkg.Deps[depPkg]
 	if dep == nil {
 		dep = &ResolveDep{
@@ -240,7 +247,6 @@ func (rpkg *ResolvePackage) AddApiDep(
 		}
 		rpkg.Deps[depPkg] = dep
 	}
-
 	if dep.ApiExprMap == nil {
 		dep.ApiExprMap = parse.ExprMap{}
 	}


### PR DESCRIPTION
This is a fix for an error reporting bug.  When any API requirement was unsatisfied, newt would report all APIs as unsatisfied.

For example, mynewt-blinky at commit
`06536d2a86a4eaf8d619fe2bad75a4cdf9b77cc8` is broken.  The blinky app has an unsatisfied `log` dependency.  When I try building it, I get the following error:

```
    Error: Unsatisfied APIs detected:
        * console, required by: hw/mcu/native, kernel/os
        * log, required by: sys/log/modlog
```

The `console` API is satisfied, so it should not be reported.

This newt bug was introduced in `a2573a97549cc05dd4949ffca3f87165b239f8aa`.  Prior to that commit, each satisfied API dependency was tracked in two directions: the depender remembers which package satisfies its API requirement, and the dependee remembers who requires the API.  In the bad commit, the first of these was accidentally removed.

The fix is to add the missing code back.  Now, the depender remembers which packages satisfy its API requirements again.

NOTE: This bug would have been caught by the "dump" tests in https://github.com/JuulLabs-OSS/mynewt-travis-ci... if we were testing targets with unsatisfied API dependencies!  I plan to add a bunch more targets to that test to catch problems like this.