### PR TITLE
Always report the reason for rebuilding a file

### DIFF
--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -578,7 +578,7 @@ func (c *Compiler) CompileFile(file string, compilerType int) error {
 	}
 
 	// Tell the dependency tracker that an object file was just rebuilt.
-	c.depTracker.MostRecent = time.Now()
+	c.depTracker.SetMostRecent(objPath, time.Now())
 
 	return nil
 }


### PR DESCRIPTION
Prior to this commit, newt only reported a rebuild reason when it compiled a source file.

Now, newt reports a reason whenever it rebuilds any file (source file, archive, or elf).  The message also includes both filenames - source and destination.