### PR TITLE
Truncate sub-seconds from file modification times

### DIFF
--- a/newt/toolchain/deps.go
+++ b/newt/toolchain/deps.go
@@ -49,9 +49,13 @@ func NewDepTracker(c *Compiler) DepTracker {
 	return tracker
 }
 
-func (d *DepTracker) SetMostRecent(name string, time time.Time) {
+func (d *DepTracker) SetMostRecent(name string, t time.Time) {
 	d.MostRecentName = name
-	d.MostRecentTime = time
+
+	// Truncate sub-second part of timestamp.  Timestamps of generated files
+	// seems to differ among tools.  See
+	// https://github.com/apache/mynewt-newt/pull/276 for details.
+	d.MostRecentTime = time.Unix(t.Unix(), 0)
 }
 
 // @return string               The name of the dependent file (i.e., the first


### PR DESCRIPTION
This PR addresses a macOS-specific bug.

In macOS sim builds, timestamps of generated files are inconsistent.  In particular, `.a` files are precise to the second, while `.o` files have nanosecond precision.  This is a problem because when a `.a` file is produced immediately after some `.o` files, it appears that the `.a` file is actually older than the `.o` files that form it.  Consequently, newt will rearchive the `.a` file on the next build.

This PR does not fix the underlying issue, but it solves the problem for all intents and purposes.  Now, whenever newt reads a modification time, it truncates its sub-second part.

I'm very puzzled by this issue.  Both clang and gcc produce files with inconsistent timestamp precision, but only in macOS.

Here is an example of the issue being reproduced:
```
[ccollins@ccollins:~/proj/myproj/repos/apache-mynewt-core]$ newt clean all

[ccollins@ccollins:~/proj/myproj/repos/apache-mynewt-core]$ newt test kernel/os
Testing package kernel/os/selftest
Compiling crypto/tinycrypt/src/ctr_mode.c
Compiling crypto/tinycrypt/src/hmac.c
Compiling crypto/tinycrypt/src/cbc_mode.c
Compiling crypto/tinycrypt/src/aes_decrypt.c
<snip>
Compiling util/rwlock/src/rwlock.c
Archiving crypto_tinycrypt.a
Archiving encoding_cborattr.a
Archiving encoding_json.a
Archiving encoding_tinycbor.a
Archiving hw_bsp_native.a
Archiving hw_drivers_flash_enc_flash.a
Archiving hw_drivers_flash_enc_flash_ef_tinycrypt.a
Archiving hw_drivers_uart.a
Archiving hw_drivers_uart_uart_hal.a
Archiving hw_hal.a
Archiving hw_mcu_native.a
Archiving kernel_os.a
Archiving kernel_os_selftest.a
Archiving kernel_sim.a
Archiving kernel_os_selftest-sysinit-app.a
Archiving mgmt_mgmt.a
Archiving net_ip_mn_socket.a
Archiving net_ip_native_sockets.a
Archiving sys_flash_map.a
Archiving sys_log_modlog.a
Archiving sys_log_stub.a
Archiving sys_mfg.a
Archiving sys_sysdown.a
Archiving sys_sysinit.a
Archiving test_runtest.a
Archiving test_testutil.a
Archiving util_mem.a
Archiving util_rwlock.a
Linking /Users/ccollins/proj/myproj/repos/apache-mynewt-core/bin/targets/unittest/kernel_os_selftest/app/kernel/os/selftest/kernel_os_selftest.elf
Executing test: /Users/ccollins/proj/myproj/repos/apache-mynewt-core/bin/targets/unittest/kernel_os_selftest/app/kernel/os/selftest/kernel_os_selftest.elf
Passed tests: [kernel/os/selftest]
All tests passed

[ccollins@ccollins:~/proj/myproj/repos/apache-mynewt-core]$ newt test kernel/os
Testing package kernel/os/selftest
Archiving kernel_sim.a
Archiving net_ip_native_sockets.a
Archiving sys_flash_map.a
Archiving sys_log_modlog.a
Archiving sys_log_stub.a
Archiving sys_mfg.a
Archiving sys_sysdown.a
Archiving sys_sysinit.a
Archiving test_runtest.a
Archiving test_testutil.a
Archiving util_mem.a
Linking /Users/ccollins/proj/myproj/repos/apache-mynewt-core/bin/targets/unittest/kernel_os_selftest/app/kernel/os/selftest/kernel_os_selftest.elf
Executing test: /Users/ccollins/proj/myproj/repos/apache-mynewt-core/bin/targets/unittest/kernel_os_selftest/app/kernel/os/selftest/kernel_os_selftest.elf
Passed tests: [kernel/os/selftest]
All tests passed
```

The second `newt test` command should not have rebuilt those `.a` files.

Using `ls -l --full-time` (gnu ls only), we can see the precise modification time of each file.  I have removed some `.o` entries from the output for succinctness.
```
find bin/targets/unittest/kernel_os_selftest/app -name '*.[ao]' -exec gls -l --full-time {} +
-rw-r--r-- 1 ccollins staff   8592 2019-03-08 11:37:20.229402787 -0800 bin/targets/unittest/kernel_os_selftest/app/crypto/tinycrypt/crypto/tinycrypt/src/aes_decrypt.o
-rw-r--r-- 1 ccollins staff   8092 2019-03-08 11:37:20.228313122 -0800 bin/targets/unittest/kernel_os_selftest/app/crypto/tinycrypt/crypto/tinycrypt/src/aes_encrypt.o
-rw-r--r-- 1 ccollins staff   4156 2019-03-08 11:37:20.215244459 -0800 bin/targets/unittest/kernel_os_selftest/app/crypto/tinycrypt/crypto/tinycrypt/src/cbc_mode.o
-rw-r--r-- 1 ccollins staff   3152 2019-03-08 11:37:20.402557328 -0800 bin/targets/unittest/kernel_os_selftest/app/crypto/tinycrypt/crypto/tinycrypt/src/utils.o
-rw-r--r-- 1 ccollins staff 131960 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/crypto/tinycrypt/crypto_tinycrypt.a
-rw-r--r-- 1 ccollins staff  21356 2019-03-08 11:37:20.495941121 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/cborattr/encoding/cborattr/src/cborattr.o
-rw-r--r-- 1 ccollins staff  21648 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/cborattr/encoding_cborattr.a
-rw-r--r-- 1 ccollins staff  16896 2019-03-08 11:37:20.501426286 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/json/encoding/json/src/json_decode.o
-rw-r--r-- 1 ccollins staff   9536 2019-03-08 11:37:20.451434921 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/json/encoding/json/src/json_encode.o
-rw-r--r-- 1 ccollins staff  27008 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/json/encoding_json.a
-rw-r--r-- 1 ccollins staff  28184 2019-03-08 11:37:20.714115762 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/tinycbor/encoding/tinycbor/src/cbortojson.o
-rw-r--r-- 1 ccollins staff    168 2019-03-08 11:37:20.583587603 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/tinycbor/encoding/tinycbor/src/open_memstream.o
-rw-r--r-- 1 ccollins staff 125480 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/encoding/tinycbor/encoding_tinycbor.a
-rw-r--r-- 1 ccollins staff   6300 2019-03-08 11:37:20.708124074 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/bsp/native/hw/bsp/native/src/hal_bsp.o
-rw-r--r-- 1 ccollins staff   2744 2019-03-08 11:37:20.667451617 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/bsp/native/hw/bsp/native/src/sbrk.o
-rw-r--r-- 1 ccollins staff   9392 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/bsp/native/hw_bsp_native.a
-rw-r--r-- 1 ccollins staff   5028 2019-03-08 11:37:20.739474553 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/flash/enc_flash/ef_tinycrypt/hw/drivers/flash/enc_flash/ef_tinycrypt/src/ef_tinycrypt.o
-rw-r--r-- 1 ccollins staff   5304 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/flash/enc_flash/ef_tinycrypt/hw_drivers_flash_enc_flash_ef_tinycrypt.a
-rw-r--r-- 1 ccollins staff   6928 2019-03-08 11:37:20.731879042 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/flash/enc_flash/hw/drivers/flash/enc_flash/src/enc_flash.o
-rw-r--r-- 1 ccollins staff   7160 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/flash/enc_flash/hw_drivers_flash_enc_flash.a
-rw-r--r-- 1 ccollins staff    168 2019-03-08 11:37:20.640591292 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/uart/hw/drivers/uart/src/uart.o
-rw-r--r-- 1 ccollins staff    336 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/uart/hw_drivers_uart.a
-rw-r--r-- 1 ccollins staff   9732 2019-03-08 11:37:20.770317651 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/uart/uart_hal/hw/drivers/uart/uart_hal/src/uart_hal.o
-rw-r--r-- 1 ccollins staff   9936 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/drivers/uart/uart_hal/hw_drivers_uart_uart_hal.a
-rw-r--r-- 1 ccollins staff   3436 2019-03-08 11:37:20.733245553 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/hal/hw/hal/src/hal_common.o
-rw-r--r-- 1 ccollins staff  10712 2019-03-08 11:37:20.825114845 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/hal/hw/hal/src/hal_flash.o
-rw-r--r-- 1 ccollins staff  14856 2019-03-08 11:37:22.000000000 -0800 bin/targets/unittest/kernel_os_selftest/app/hw/hal/hw_hal.a
```
Notice that all the `.a` files have exact-second timestamps.

If anyone has any idea what is going on here, I would love to hear an explanation!  In the meantime, this PR fixes the problem for me.