### PR TITLE
Allow @repo/cfg.yml style import paths

### DIFF
--- a/newt/config/config.go
+++ b/newt/config/config.go
@@ -130,7 +130,12 @@ func readLineage(path string) ([]FileEntry, error) {
 	iter = func(path string, parent *util.FileInfo) error {
 		// Relative paths are relative to the project base.
 		if !filepath.IsAbs(path) {
-			path = filepath.Join(interfaces.GetProject().Path(), path)
+			proj := interfaces.GetProject()
+			newPath, err := proj.ResolvePath(proj.Path(), path)
+			if err != nil {
+				return err
+			}
+			path = newPath
 		}
 
 		// Only operate on absolute paths to ensure each file has a unique ID.


### PR DESCRIPTION
Prior to this commit, paths specified in `$import` were either:
* absolute path
* relative path (relative to project base).

Now, a third type of import path is supported:
* repo path (e.g., "@apache-mynewt-core/myconfigs/cfg.yml")