### PR TITLE
Make Windows shell escapes optional

### DIFF
--- a/newt/newt.go
+++ b/newt/newt.go
@@ -29,6 +29,7 @@ import (
 
 	"mynewt.apache.org/newt/newt/cli"
 	"mynewt.apache.org/newt/newt/newtutil"
+	"mynewt.apache.org/newt/newt/settings"
 	"mynewt.apache.org/newt/util"
 )
 
@@ -39,6 +40,7 @@ var newtVerbose bool
 var newtLogFile string
 var newtNumJobs int
 var newtHelp bool
+var newtEscapeShellCmds bool
 
 func newtDfltNumJobs() int {
 	maxProcs := runtime.GOMAXPROCS(0)
@@ -77,6 +79,9 @@ func newtCmd() *cobra.Command {
 		Long:    newtHelpText,
 		Example: newtHelpEx,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Ensure .newtrc file gets read.
+			settings.Newtrc()
+
 			verbosity := util.VERBOSITY_DEFAULT
 			if newtSilent {
 				verbosity = util.VERBOSITY_SILENT
@@ -84,6 +89,10 @@ func newtCmd() *cobra.Command {
 				verbosity = util.VERBOSITY_QUIET
 			} else if newtVerbose {
 				verbosity = util.VERBOSITY_VERBOSE
+			}
+
+			if newtEscapeShellCmds {
+				util.EscapeShellCmds = true
 			}
 
 			var err error
@@ -118,6 +127,8 @@ func newtCmd() *cobra.Command {
 		newtDfltNumJobs(), "Number of concurrent build jobs")
 	newtCmd.PersistentFlags().BoolVarP(&newtHelp, "help", "h",
 		false, "Help for newt commands")
+	newtCmd.PersistentFlags().BoolVarP(&newtEscapeShellCmds, "escape", "",
+		false, "Apply Windows escapes to shell commands")
 
 	versHelpText := cli.FormatHelp(`Display the Newt version number`)
 	versHelpEx := "  newt version"

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -178,6 +178,10 @@ func MakeTempRepoDir() (string, error) {
 }
 
 func ProjRelPath(path string) string {
+	if strings.HasPrefix(path, "/") {
+		return path
+	}
+
 	proj := interfaces.GetProject()
 	return strings.TrimPrefix(path, proj.Path()+"/")
 }

--- a/util/util.go
+++ b/util/util.go
@@ -43,6 +43,7 @@ import (
 var Verbosity int
 var PrintShellCmds bool
 var ExecuteShell bool
+var EscapeShellCmds bool = runtime.GOOS == "windows"
 var logFile *os.File
 
 func ParseEqualsPair(v string) (string, string, error) {
@@ -264,7 +265,7 @@ func Init(logLevel log.Level, logFile string, verbosity int) error {
 
 // Escapes special characters for Windows builds (not in an MSYS environment).
 func fixupCmdArgs(args []string) {
-	if runtime.GOOS == "windows" && os.Getenv("MSYSTEM") == "" {
+	if EscapeShellCmds {
 		for i, _ := range args {
 			args[i] = strings.Replace(args[i], "{", "\\{", -1)
 			args[i] = strings.Replace(args[i], "}", "\\}", -1)


### PR DESCRIPTION
Prior to this PR, newt would decide whether to escape curly braces with backslashes.  Escaping was performed for all non-MSYS Windows machines.  Apparently, not all MSYS machines are the same, so let the user specify whether escaping should happen.

By default, escaping is performed on all Windows machines.

The user can override the default in two ways:

1. Command line:
```
    --escape=true
    --escape=false
```

2. $HOME/.newt/newtrc.yml file:
```
    escape_shell: true
```