### PR TITLE
Use 2.0 image format by default

### DIFF
--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -81,8 +81,8 @@ func createImageRunCmd(cmd *cobra.Command, args []string) {
 		NewtUsage(cmd, util.NewNewtError("Either -1, or -2, but not both"))
 	}
 
-	if !useV2 {
-		useV1 = true
+	if !useV1 {
+		useV2 = true
 	}
 
 	TryGetProject()
@@ -184,7 +184,7 @@ func AddImageCommands(cmd *cobra.Command) {
 	createImageCmd.PersistentFlags().BoolVarP(&useV1,
 		"1", "1", false, "Use old image header format")
 	createImageCmd.PersistentFlags().BoolVarP(&useV2,
-		"2", "2", false, "Use new image header format")
+		"2", "2", false, "Use new image header format (default)")
 	createImageCmd.PersistentFlags().StringVarP(&encKeyFilename,
 		"encrypt", "e", "", "Encrypt image using this public key")
 

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -40,8 +40,8 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 	if useV1 && useV2 {
 		NewtUsage(cmd, util.NewNewtError("Either -1, or -2, but not both"))
 	}
-	if !useV2 {
-		useV1 = true
+	if !useV1 {
+		useV2 = true
 	}
 
 	TryGetProject()
@@ -153,7 +153,7 @@ func AddRunCommands(cmd *cobra.Command) {
 	runCmd.PersistentFlags().BoolVarP(&useV1,
 		"1", "1", false, "Use old image header format")
 	runCmd.PersistentFlags().BoolVarP(&useV2,
-		"2", "2", false, "Use new image header format")
+		"2", "2", false, "Use new image header format (default)")
 
 	cmd.AddCommand(runCmd)
 	AddTabCompleteFn(runCmd, func() []string {


### PR DESCRIPTION
Now that Mynewt switched to mcuboot and removed legacy boootutils it
make sense to use new format by default.