### PR TITLE
 newt upgrade: Repo dep reqs not always honored 

### DIFF
--- a/newt/deprepo/deprepo.go
+++ b/newt/deprepo/deprepo.go
@@ -350,5 +350,5 @@ func FindAcceptableVersions(m Matrix, dg DepGraph) (VersionMap, []Conflict) {
 		conflicts[i] = conflict
 	}
 
-	return nil, conflicts
+	return vm, conflicts
 }

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -671,11 +671,10 @@ func (inst *Installer) calcVersionMap(candidates []*repo.Repo) (
 	// Try to find a version set that satisfies the dependency graph.  If no
 	// such set exists, report the conflicts and abort.
 	vm, conflicts := deprepo.FindAcceptableVersions(m, dg)
-	if vm == nil {
+	log.Debugf("Repo version map:\n%s\n", vm.String())
+	if len(conflicts) > 0 {
 		return nil, deprepo.ConflictError(conflicts)
 	}
-
-	log.Debugf("Repo version map:\n%s\n", vm.String())
 
 	// If project.yml specified any specific git commits, ensure we get them.
 	for name, ver := range vm {

--- a/newt/newtutil/repo_version.go
+++ b/newt/newtutil/repo_version.go
@@ -251,7 +251,7 @@ func ParseRepoVersionReqs(versStr string) ([]RepoVersionReq, error) {
 
 	verReqs := []RepoVersionReq{}
 
-	re, err := regexp.Compile(`(<=|>=|==|>|<)([\d\.]+)`)
+	re, err := regexp.Compile(`(<=|>=|==|>|<)(.+)`)
 	if err != nil {
 		return nil, err
 	}

--- a/newt/newtutil/repo_version.go
+++ b/newt/newtutil/repo_version.go
@@ -21,6 +21,7 @@ package newtutil
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -68,7 +69,24 @@ func (vm *RepoVersionReq) String() string {
 	return vm.CompareType + vm.Ver.String()
 }
 
+func (v *RepoVersion) toComparable() RepoVersion {
+	clone := *v
+
+	// 0.0.0 means "latest develop"; it is greater than all over version
+	// numbers.
+	if v.Major == 0 && v.Minor == 0 && v.Revision == 0 {
+		clone.Major = math.MaxInt64
+		clone.Minor = math.MaxInt64
+		clone.Revision = math.MaxInt64
+	}
+
+	return clone
+}
+
 func CompareRepoVersions(v1 RepoVersion, v2 RepoVersion) int64 {
+	v1 = v1.toComparable()
+	v2 = v2.toComparable()
+
 	if r := v1.Major - v2.Major; r != 0 {
 		return r
 	}


### PR DESCRIPTION
This is a bug fix for the `newt upgrade` command.  The problem is difficult to describe.  Here is a concrete example (`project.yml`):

```
repository.apache-mynewt-core:
    type: git
    vers: 0.0.0
    url: 'git@github.com:apache/mynewt-core.git'
repository.apache-mynewt-nimble:
    type: git
    vers: 1.0.0
    url: 'git@github.com:apache/mynewt-nimble.git'
```

Attempting to upgrade this project should fail, because `apache-mynewt-core`,0.0.0 depends on `apache-mynewt-nimble`,1.1.0.  This dependency conflicts with the `apache-mynewt-nimble`,1.0.0 entry in `project.yml`.  But here is the output I get:

```
[ccollins@ccollins:~/proj/myproj]$ newt upgrade
Skipping "apache-mynewt-core": already upgraded (0.0.0)
```

The conflict is not reported, and `apache-mynewt-nimble` isn't even included in the output.

newt uses the following procedure to detect repo dependency conflicts:

1. Generate a "matrix" of all repos on one axis, and all version numbers on the other axis.
2. Prune entries from the matrix that fail to satisfy at least one dependency requirement.
3. For each repo in the matrix, check if at least one of its version numbers satisfies *every* dependency requirement.

If step three fails for a particular repo, a conflict is reported for that repo.

The problem arises when a repo is partially or entirely pruned from the matrix.  When newt checks if version V of repo R is allowed, it is problematic if that version has been pruned.  Due to Go's default initialization semantics, newt infers that version 0.0.0 of R is allowed, even if it is not!  