### PR TITLE
Fix split builds - ensure no duplicate packages

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -91,9 +91,6 @@ func NewBuilder(
 	for api, rpkg := range apiMap {
 		bpkg := b.PkgMap[rpkg]
 		if bpkg == nil {
-			for _, rpkg := range b.SortedRpkgs() {
-				log.Debugf("    * %s", rpkg.Lpkg.Name())
-			}
 			return nil, util.FmtNewtError(
 				"Unexpected unsatisfied API: %s; required by: %s", api,
 				rpkg.Lpkg.Name())


### PR DESCRIPTION
In a split build, three rounds of dependency resolution occur:
1. Master set (all packages in the build)
2. Loader set
3. App set

Each round produces new ResolvePackage objects.  Conceptually, this is wrong, since the loader set and app set are meant to share packages, not duplicate them.  This was causing a problem during API resolution: the Resolution object maps API names to *ResolvePackage, with the package pointers coming from the master set.  During rounds 2 and 3, lookups in this map yield packages that don't exist in the current working set, resulting in this error:

```
Error: Unexpected unsatisfied API: foo; required by: bar
```