### PR TITLE
syscfg: Preserve history during pruning

### DIFF
--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -635,6 +635,9 @@ func (r *Resolver) detectImposter(rpkg *ResolvePackage) (bool, error) {
 		// Copy the source entry in full, then check its history for the
 		// potential imposter.
 		dst := src
+		dst.History = make([]syscfg.CfgPoint, len(src.History))
+		copy(dst.History, src.History)
+
 		for i, _ := range dst.History {
 			if dst.History[i].Source == rpkg.Lpkg {
 				if i == 0 {


### PR DESCRIPTION
During "imposter pruning", newt makes a temporary copy of each syscfg entry and manipulates their histories.  The entry copy's history slice points uses the same underlying array as the original, so modifying the copy makes permanent changes to the original.  The result is: the override history displayed by `newt target config show` is sometimes incorrect.

The fix is to make a copy of the history slice as well.  Then, all modifications are isolated to the temporary copy.
