### PR TITLE
Never prune seed packages from build

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -91,9 +91,6 @@ func NewBuilder(
 	for api, rpkg := range apiMap {
 		bpkg := b.PkgMap[rpkg]
 		if bpkg == nil {
-			for _, rpkg := range b.SortedRpkgs() {
-				log.Debugf("    * %s", rpkg.Lpkg.Name())
-			}
 			return nil, util.FmtNewtError(
 				"Unexpected unsatisfied API: %s; required by: %s", api,
 				rpkg.Lpkg.Name())


### PR DESCRIPTION
**NOTE:** This PR includes #293 (another split image fix).  That one should be merged before this.

This is a fix for split images.

During dependency resolution, newt executes a phase called "imposter pruning."  A package is an imposter if it is in the dependency graph by virtue of its own syscfg defines and overrides.  For example, say we have a package `foo`:

```
    pkg.name: foo
    syscfg.defs:
        FOO_SETTING:
            value: 1
```

Then we have a BSP package:

```
    pkg.name: my_bsp
    pkg.deps.FOO_SETTING:
        - foo
```

If this is the only dependency on `foo`, then `foo` is an imposter.  It should be removed from the graph, and its syscfg defines and overrides should be deleted.

This commit changes this procedure slightly.  Now, only *non-seed-packages* are subject to imposter pruning.  This change is necessary due to the way newt builds split images.  A split image consits of two parts: 1) loader, and 2) application.  The loader is self-contained, whereas the application is allowed to depend on packages in the loader.  When newt builds the application, it considers all the packages in the loader to be seed packages for the application.  Since all these packages are guaranteed to be present (they are already built in to the loader), they must not be pruned.

The fix is to never prune seed packages.  While this fix specifically addresses split images, conceptually it makes sense to never prune seed packages for non-split builds as well.  If the `project.yml` file points to a package, that package should be included, even if newt thinks it is not needed.  