### PR TITLE
artifact: add image.CalcHash() function

### DIFF
--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -348,6 +348,10 @@ func (i *Image) Hash() ([]byte, error) {
 	return tlv.Data, nil
 }
 
+func (i *Image) CalcHash() ([]byte, error) {
+	return calcHash(nil, i.Header, i.Pad, i.Body)
+}
+
 func (i *Image) WritePlusOffsets(w io.Writer) (ImageOffsets, error) {
 	offs := ImageOffsets{}
 	offset := 0


### PR DESCRIPTION
Prior to this commit, the only way to calculate an image's hash was to use image.calcHash() (in `artifact/image/create.go`).  This function is private to the `image` package, and it takes a set of parameters that are is not convenient for most cases.

This commit adds a new public function to the `image.Image` type:
```
func (i *Image) CalcHash() ([]byte, error)
```

This function is needed for a change to the imgmod tool (https://github.com/apache/mynewt-imgmod)