### PR TITLE
Ed25519 encrypted keys

### DIFF
--- a/artifact/sec/key.go
+++ b/artifact/sec/key.go
@@ -55,7 +55,7 @@ type ed25519Pkcs struct {
 var oidPrivateKeyEd25519 = asn1.ObjectIdentifier{1, 3, 101, 112}
 
 // Parse an ed25519 PKCS#8 certificate
-func parseEd25519Pkcs8(der []byte) (key *ed25519.PrivateKey, err error) {
+func ParseEd25519Pkcs8(der []byte) (key *ed25519.PrivateKey, err error) {
 	var privKey ed25519Pkcs
 	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
 		return nil, util.FmtNewtError("Error parsing ASN1 key")
@@ -133,8 +133,10 @@ func ParsePrivateKey(keyBytes []byte) (interface{}, error) {
 		// the key itself.
 		privKey, err = x509.ParsePKCS8PrivateKey(block.Bytes)
 		if err != nil {
+			// Try also parsing as ed25519, whose OID is not
+			// yet supported by upstream x509 parser
 			var _privKey interface{}
-			_privKey, err = parseEd25519Pkcs8(block.Bytes)
+			_privKey, err = ParseEd25519Pkcs8(block.Bytes)
 			if err != nil {
 				return nil, util.FmtNewtError(
 					"Private key parsing failed: %s", err)

--- a/artifact/sec/pkcs.go
+++ b/artifact/sec/pkcs.go
@@ -153,7 +153,17 @@ func unwrapPbes2Pbkdf2(param *pbkdf2Param, size int, iv []byte, hashNew hashFunc
 		return nil, err
 	}
 
-	return x509.ParsePKCS8PrivateKey(plain)
+	privKey, err := x509.ParsePKCS8PrivateKey(plain)
+	if err != nil {
+		var _privKey interface{}
+		_privKey, _err := ParseEd25519Pkcs8(plain)
+		// If this is not an ed25519 key, return
+		// error from x509 parser
+		if _err == nil {
+			return _privKey, _err
+		}
+	}
+	return privKey, err
 }
 
 // Verify that PKCS#7 padding is correct on this plaintext message.

--- a/artifact/sec/pkcs.go
+++ b/artifact/sec/pkcs.go
@@ -78,7 +78,6 @@ type hashFunc func() hash.Hash
 
 func parseEncryptedPrivateKey(der []byte) (key interface{}, err error) {
 	var wrapper pkcs5
-	fmt.Printf("unmarshalling %v\n", der)
 	if _, err = asn1.Unmarshal(der, &wrapper); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows parsing encrypted ed25519 keys.

Encryted keys can be generated with:

`openssl genpkey -algorithm ed25519 -out ed25519_priv.pem -aes-128-cbc`

and the public key can be extracted with:

`openssl pkey -in ed25519_priv.pem -pubout -outform DER -out ed25519_pub.der`

Or `imgtool` from MCUBoot can be used.