### PR TITLE
Export all syscfg settings to download script

### DIFF
--- a/newt/builder/load.go
+++ b/newt/builder/load.go
@@ -146,6 +146,11 @@ func (b *Builder) Load(imageSlot int, extraJtagCmd string) error {
 	envSettings["FLASH_OFFSET"] = "0x" + strconv.FormatInt(int64(tgtArea.Offset), 16)
 	envSettings["FLASH_AREA_SIZE"] = "0x" + strconv.FormatInt(int64(tgtArea.Size), 16)
 
+	// Add all syscfg settings to the environment with the MYNEWT_VAL_ prefix.
+	for k, v := range settings {
+		envSettings["MYNEWT_VAL_"+k] = v
+	}
+
 	// Convert the binary path from absolute to relative.  This is required for
 	// compatibility with unix-in-windows environemnts (e.g., cygwin).
 	binPath := util.TryRelPath(b.AppBinBasePath())


### PR DESCRIPTION
Newt already exports some syscfg settings as environment variables when it runs a download script (e.g., `BOOT_LOADER`).

This PR changes newt such that it exports all settings as environment variables.  The name of each variable uses the `MYNEWT_VAL_` prefix.  For example:

```
MYNEWT_VAL_OS_COREDUMP=1
MYNEWT_VAL_OS_CPUTIME_FREQ=32768
```

This has the potential to create a lot of environment variables. However, some quick testing shows that it should be well within the limits of the OS.  I saw the following limits during testing:

* macOS: 256kB
* Linux (Gentoo): 2MB

A fairly large project generated about 34kB of syscfg settings.