### PR TITLE
Fix IMAGE_F_NON_BOOTABLE definition to match mcuboot

### DIFF
--- a/artifact/image/image.go
+++ b/artifact/image/image.go
@@ -50,8 +50,8 @@ const (
  */
 const (
 	IMAGE_F_PIC          = 0x00000001
-	IMAGE_F_NON_BOOTABLE = 0x00000002 /* non bootable image */
 	IMAGE_F_ENCRYPTED    = 0x00000004 /* encrypted image */
+	IMAGE_F_NON_BOOTABLE = 0x00000010 /* non bootable image */
 )
 
 /*


### PR DESCRIPTION
The correct flag for IMAGE_F_NON_BOOTABLE should be 0x10 instead of 0x02
according to the mcuboot files:
https://github.com/JuulLabs-OSS/mcuboot/blob/3c469bc698a9767859ed73cd0201c44161204d5c/boot/bootutil/include/bootutil/image.h#L46

Split images won't work without the fix :(