### PR TITLE
Allow to override path escaping from command line

### DIFF
--- a/newt/newt.go
+++ b/newt/newt.go
@@ -91,9 +91,7 @@ func newtCmd() *cobra.Command {
 				verbosity = util.VERBOSITY_VERBOSE
 			}
 
-			if newtEscapeShellCmds {
-				util.EscapeShellCmds = true
-			}
+			util.EscapeShellCmds = newtEscapeShellCmds
 
 			var err error
 			NewtLogLevel, err = log.ParseLevel(logLevelStr)
@@ -128,7 +126,7 @@ func newtCmd() *cobra.Command {
 	newtCmd.PersistentFlags().BoolVarP(&newtHelp, "help", "h",
 		false, "Help for newt commands")
 	newtCmd.PersistentFlags().BoolVarP(&newtEscapeShellCmds, "escape", "",
-		false, "Apply Windows escapes to shell commands")
+		runtime.GOOS == "windows", "Apply Windows escapes to shell commands")
 
 	versHelpText := cli.FormatHelp(`Display the Newt version number`)
 	versHelpEx := "  newt version"

--- a/util/util.go
+++ b/util/util.go
@@ -43,7 +43,7 @@ import (
 var Verbosity int
 var PrintShellCmds bool
 var ExecuteShell bool
-var EscapeShellCmds bool = runtime.GOOS == "windows"
+var EscapeShellCmds bool
 var logFile *os.File
 
 func ParseEqualsPair(v string) (string, string, error) {


### PR DESCRIPTION
With this patch it is possible to disable path escaping on Windows.
It looks like some shells on Windows require no escaping.