### PR TITLE
Use "detached head" instead of local branches

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -183,8 +183,10 @@ func syncRunCmd(cmd *cobra.Command, args []string) {
 	proj := TryGetProject()
 	pred := makeRepoPredicate(args)
 
-	if err := proj.SyncIf(
-		newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
+	util.OneTimeWarning("\"sync\" is deprecated.  Use \"upgrade\" instead.")
+
+	if err := proj.InstallIf(
+		true, newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
 
 		NewtUsage(nil, err)
 	}
@@ -239,7 +241,7 @@ func AddProjectCommands(cmd *cobra.Command) {
 	syncHelpEx += "    Syncs the apache-mynewt-core repository."
 	syncCmd := &cobra.Command{
 		Use:     "sync [repo-1] [repo-2] [...]",
-		Short:   "Synchronize project dependencies",
+		Short:   "Synchronize project dependencies (deprecated)",
 		Long:    syncHelpText,
 		Example: syncHelpEx,
 		Run:     syncRunCmd,

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -78,18 +78,15 @@ func normalizeCommit(commit string) string {
 func (r *Repo) CurrentHash() (string, error) {
 	dl := r.downloader
 	if dl == nil {
-		return "",
-			util.FmtNewtError("No downloader for %s",
-				r.Name())
+		return "", util.FmtNewtError("No downloader for %s", r.Name())
 	}
 
-	commit, err := dl.HashFor(r.Path(), "HEAD")
+	hash, err := dl.HashFor(r.Path(), "HEAD")
 	if err != nil {
-		return "",
-			util.FmtNewtError("Error finding current hash for \"%s\": %s",
-				r.Name(), err.Error())
+		return "", err
 	}
-	return commit, nil
+
+	return hash, nil
 }
 
 // Retrieves all commit strings corresponding to the repo's current state.
@@ -293,10 +290,6 @@ func (r *Repo) NormalizeVerReqs(verReqs []newtutil.RepoVersionReq) (
 func (r *Repo) VersionsEqual(v1 newtutil.RepoVersion,
 	v2 newtutil.RepoVersion) bool {
 
-	if newtutil.CompareRepoVersions(v1, v2) == 0 {
-		return true
-	}
-
 	h1, err := r.HashFromVer(v1)
 	if err != nil {
 		return false
@@ -398,7 +391,7 @@ func (r *Repo) inferVersion(commit string, vyVer *newtutil.RepoVersion) (
 				"Version mismatch in %s:%s; repository.yml:%s, version.yml:%s",
 				r.Name(), commit, versString(ryVers), vyVer.String())
 		} else {
-			// If the set of commits don't match a version from
+			// If the set of commits doesn't contain a version from
 			// `repository.yml`, record the commit hash in the version
 			// specifier.  This will distinguish the returned version from its
 			// corresponding official release.
@@ -435,6 +428,9 @@ func (r *Repo) InstalledVersion() (*newtutil.RepoVersion, error) {
 	hash, err := r.CurrentHash()
 	if err != nil {
 		return nil, err
+	}
+	if hash == "" {
+		return nil, nil
 	}
 
 	ver, err := r.inferVersion(hash, vyVer)


### PR DESCRIPTION
## SUMMARY

This PR changes how newt interacts with git.  Newt used to use a mix of "detached head" and local branches.  With this PR, newt uses "detached head" exclusively.

## OLD BEHAVIOR

Newt used a combination of "detached head" and local branches.

* When upgrading to a version mapped to a branch, newt would check out a local branch with the appropriate name.  For example, when upgrading to 0.0.0, newt would check out a local "master" branch.

* When upgrading to a version mapped to a tag or a commit hash, newt would put the repo in a "detached head" state.

This inconsistency comes from the `git checkout` command.  Git puts a repo in a different state depending on the type of commit being checked out.

## NEW BEHAVIOR

Newt uses "detached head" exclusively.  When upgrading to a version mapped to a branch or tag, newt looks up the corresponding commit hash and checks it out.

In addition, this PR adds a clarification in semantics:

> Only the following commands make modifications to git repos:
> * new
> * install
> * upgrade
> * info -r
> 
> All other commands leave the git repos untouched.  E.g., they do not run `git fetch`, `git checkout`, or `git remote set-url`.

This change simplifies working with custom branches.

## IMPROVEMENTS

This change improves newt in several ways:

1. Lower chance of git conflicts.  When newt used local branches, there was always a chance of pulling incompatible commits into an existing branch.  This was especially likely when using `newt sync` and changing a repo's remote URL.

2. No need for the `newt sync` command.  The sync command was only necessary due to newt's use of local branches.  Now, `newt upgrade` alone does the right thing: it fetches from `origin` and checks out the correct commit.  For branch-backed versions, newt checks out the latest
commit in the branch.

The `newt sync` command has been deprecated.  Now it prints a warning message and performs a `newt upgrade`.

3. Proper support for branches and tags in `project.yml`.  Newt has always allowed the `<hash>-commit` notation for a repo version string, but it did not correctly handle `<branch>-commit` or `<tag>-commit`.  Now these version strings work correctly.

## NOTES

In my opinion, we should think about deprecating `newt install`.  This command doesn't seem very useful; just use `newt upgrade`.