### PR TITLE
Fix `newt upgrade <repo-list>`

### DIFF
--- a/newt/deprepo/deprepo.go
+++ b/newt/deprepo/deprepo.go
@@ -231,6 +231,24 @@ func PruneMatrix(m *Matrix, repos RepoMap, rootReqs RequirementMap) error {
 	return nil
 }
 
+// PruneDepGraph removes all entries from a depgraph that aren't in the given
+// repo slice.  This is necessary when the user wants to upgrade only a subset
+// of repos in the project.
+func PruneDepGraph(dg DepGraph, keep []*repo.Repo) {
+	for k, _ := range dg {
+		found := false
+		for _, r := range keep {
+			if r.Name() == k.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			delete(dg, k)
+		}
+	}
+}
+
 // Produces an error describing the specified set of repo conflicts.
 func ConflictError(conflicts []Conflict) error {
 	s := ""

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -669,6 +669,10 @@ func (inst *Installer) calcVersionMap(candidates []*repo.Repo) (
 	log.Debugf("Repo dependency graph:\n%s\n", dg.String())
 	log.Debugf("Repo reverse dependency graph:\n%s\n", dg.Reverse().String())
 
+	// Don't consider repos that the user excluded (if a repo list was
+	// specified).
+	deprepo.PruneDepGraph(dg, candidates)
+
 	// Try to find a version set that satisfies the dependency graph.  If no
 	// such set exists, report the conflicts and abort.
 	vm, conflicts := deprepo.FindAcceptableVersions(m, dg)

--- a/newt/logcfg/logcfg.go
+++ b/newt/logcfg/logcfg.go
@@ -74,11 +74,12 @@ type LCfg struct {
 // Maps numeric log levels to their string representations.  Used when
 // generating the C log macros.
 var logLevelNames = []string{
-	0: "DEBUG",
-	1: "INFO",
-	2: "WARN",
-	3: "ERROR",
-	4: "CRITICAL",
+	0:  "DEBUG",
+	1:  "INFO",
+	2:  "WARN",
+	3:  "ERROR",
+	4:  "CRITICAL",
+	15: "DISABLED",
 }
 
 func LogLevelString(level int) string {


### PR DESCRIPTION
The `newt upgrade` command optionally takes a list of repos to upgrade.  The intended behavior is: when specified, only these repos (and their dependencies) get upgraded rather than the entire project.

This was broken by a recent commit (6a51e35565323ebe8feb8d1aa6e00960b6ce662e).  If a repo list is specified, newt reports repository conflicts for all repos in the project that were not specified.

Now, newt correctly upgrades only the specified repos and their dependencies.  No conflicts are reported for other repos.

(As always, if no repo list is specified, all repos in the project get upgraded.) 
