### PR TITLE
Remove `newt install`

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -107,8 +107,8 @@ func installRunCmd(cmd *cobra.Command, args []string) {
 	interfaces.SetProject(proj)
 
 	pred := makeRepoPredicate(args)
-	if err := proj.InstallIf(
-		false, newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
+	if err := proj.UpgradeIf(
+		newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
 
 		NewtUsage(nil, err)
 	}
@@ -119,8 +119,8 @@ func upgradeRunCmd(cmd *cobra.Command, args []string) {
 	interfaces.SetProject(proj)
 
 	pred := makeRepoPredicate(args)
-	if err := proj.InstallIf(
-		true, newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
+	if err := proj.UpgradeIf(
+		newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
 
 		NewtUsage(nil, err)
 	}
@@ -183,10 +183,8 @@ func syncRunCmd(cmd *cobra.Command, args []string) {
 	proj := TryGetProject()
 	pred := makeRepoPredicate(args)
 
-	util.OneTimeWarning("\"sync\" is deprecated.  Use \"upgrade\" instead.")
-
-	if err := proj.InstallIf(
-		true, newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
+	if err := proj.UpgradeIf(
+		newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {
 
 		NewtUsage(nil, err)
 	}
@@ -199,11 +197,11 @@ func AddProjectCommands(cmd *cobra.Command) {
 	installHelpEx += "  newt install apache-mynewt-core\n"
 	installHelpEx += "    Installs the apache-mynewt-core repository."
 	installCmd := &cobra.Command{
-		Use:     "install [repo-1] [repo-2] [...]",
-		Short:   "Install project dependencies",
-		Long:    installHelpText,
-		Example: installHelpEx,
-		Run:     installRunCmd,
+		Use:        "install [repo-1] [repo-2] [...]",
+		Deprecated: "use \"upgrade\" instead",
+		Long:       installHelpText,
+		Example:    installHelpEx,
+		Run:        installRunCmd,
 	}
 	installCmd.PersistentFlags().BoolVarP(&newtutil.NewtForce,
 		"force", "f", false,
@@ -240,11 +238,11 @@ func AddProjectCommands(cmd *cobra.Command) {
 	syncHelpEx += "  newt sync apache-mynewt-core\n"
 	syncHelpEx += "    Syncs the apache-mynewt-core repository."
 	syncCmd := &cobra.Command{
-		Use:     "sync [repo-1] [repo-2] [...]",
-		Short:   "Synchronize project dependencies (deprecated)",
-		Long:    syncHelpText,
-		Example: syncHelpEx,
-		Run:     syncRunCmd,
+		Use:        "sync [repo-1] [repo-2] [...]",
+		Deprecated: "use \"upgrade\" instead",
+		Long:       syncHelpText,
+		Example:    syncHelpEx,
+		Run:        syncRunCmd,
 	}
 	syncCmd.PersistentFlags().BoolVarP(&newtutil.NewtForce,
 		"force", "f", false,

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -16,22 +16,12 @@
 // under the License.
 
 // ----------------------------------------------------------------------------
-// install: Handles project installs, upgrades, and syncs.
+// install: Handles project upgrades.
 // ----------------------------------------------------------------------------
 //
-// This file implements three newt operations:
-// * Install - Downloads repos that aren't installed yet.  The downloaded
-//             version matches what `project.yml` specifies.
-//
-// * Upgrade - Ensures the installed version of each repo matches what
-//             `project.yml` specifies.  This is similar to Install, but it
-//             also operates on already-installed repos.
-//
-// * Sync    - Fetches and pulls the latest for each repo, but does not change
-//             the branch (version).
-//
-// All three operations operate on the repos specified in the `project.yml`
-// file and the set of each repo's dependencies.
+// This file implements one newt operation:
+// * Upgrade - Downloads a version of each repo that satisfies `project.yml`
+//             and all repo rependencies.
 //
 // Within the `project.yml` file, repo requirements are expressed with one of
 // the following forms:
@@ -361,31 +351,6 @@ func (inst *Installer) detectIllegalRepoReqs(
 	}
 
 	return nil
-}
-
-// Removes repos that shouldn't be installed from the specified list.  A repo
-// should not be installed if it is already installed (any version).
-//
-// @param repos                 The list of repos to filter.
-//
-// @return []*Repo              The filtered list of repos.
-func (inst *Installer) filterInstallList(
-	vm deprepo.VersionMap) (deprepo.VersionMap, error) {
-
-	filtered := deprepo.VersionMap{}
-
-	for name, ver := range vm {
-		curVer := inst.installedVer(name)
-		if curVer == nil {
-			filtered[name] = ver
-		} else {
-			util.StatusMessage(util.VERBOSITY_DEFAULT,
-				"Skipping \"%s\": already installed (%s)\n",
-				name, curVer.String())
-		}
-	}
-
-	return filtered, nil
 }
 
 // Indicates whether a repo should be upgraded to the specified version.  A
@@ -757,73 +722,6 @@ func verifyNewtCompat(repos []*repo.Repo, vm deprepo.VersionMap) error {
 
 	if errors != nil {
 		return util.NewNewtError(strings.Join(errors, "\n"))
-	}
-
-	return nil
-}
-
-// Installs the specified set of repos.
-func (inst *Installer) Install(
-	candidates []*repo.Repo, force bool, ask bool) error {
-
-	vm, err := inst.calcVersionMap(candidates)
-	if err != nil {
-		return err
-	}
-
-	// Perform some additional filtering on the list of repos to process.
-	if !force {
-		// Don't install a repo if it is already installed (any version).  We
-		// skip this filter for forced reinstalls.
-		vm, err = inst.filterInstallList(vm)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Notify the user of what install operations are about to happen, and
-	// prompt if the `-a` (ask) option was specified.
-	proceed, err := inst.installPrompt(vm, INSTALL_OP_INSTALL, force, ask)
-	if err != nil {
-		return err
-	}
-	if !proceed {
-		return nil
-	}
-
-	repos, err := inst.versionMapRepos(vm)
-	if err != nil {
-		return err
-	}
-
-	if err := verifyNewtCompat(repos, vm); err != nil {
-		return err
-	}
-
-	// For a forced install, delete all existing repos.
-	if force {
-		for _, r := range repos {
-			// Don't delete the local project directory!  And don't delete a
-			// repo that was just cloned during this invocation of newt.
-			if !r.IsLocal() && !r.IsNewlyCloned() {
-				util.StatusMessage(util.VERBOSITY_DEFAULT,
-					"Removing old copy of \"%s\" (%s)\n", r.Name(), r.Path())
-				os.RemoveAll(r.Path())
-				delete(inst.vers, r.Name())
-			}
-		}
-	}
-
-	// Install each repo in the version map.
-	for _, r := range repos {
-		destVer := vm[r.Name()]
-		if err := r.Install(destVer); err != nil {
-			return err
-		}
-
-		util.StatusMessage(util.VERBOSITY_DEFAULT,
-			"%s successfully installed version %s\n",
-			r.Name(), destVer.String())
 	}
 
 	return nil

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -255,9 +255,8 @@ func (proj *Project) SelectRepos(pred func(r *repo.Repo) bool) []*repo.Repo {
 }
 
 // Installs or upgrades repos matching the specified predicate.
-func (proj *Project) InstallIf(
-	upgrade bool, force bool, ask bool,
-	predicate func(r *repo.Repo) bool) error {
+func (proj *Project) UpgradeIf(
+	force bool, ask bool, predicate func(r *repo.Repo) bool) error {
 
 	// Make sure we have an up to date copy of all `repository.yml` files.
 	if err := proj.downloadRepositoryYmlFiles(); err != nil {
@@ -275,11 +274,7 @@ func (proj *Project) InstallIf(
 		return err
 	}
 
-	if upgrade {
-		return inst.Upgrade(specifiedRepoList, force, ask)
-	} else {
-		return inst.Install(specifiedRepoList, force, ask)
-	}
+	return inst.Upgrade(specifiedRepoList, force, ask)
 }
 
 func (proj *Project) InfoIf(predicate func(r *repo.Repo) bool,

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -254,19 +254,6 @@ func (r *Repo) DirtyState() (string, error) {
 	return r.downloader.DirtyState(r.Path())
 }
 
-func (r *Repo) Install(ver newtutil.RepoVersion) error {
-	commit, err := r.CommitFromVer(ver)
-	if err != nil {
-		return err
-	}
-
-	if err := r.updateRepo(commit); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (r *Repo) Upgrade(ver newtutil.RepoVersion) error {
 	commit, err := r.CommitFromVer(ver)
 	if err != nil {


### PR DESCRIPTION
`newt upgrade` does everything that `newt install` does.  Now, `newt install` warns the user and performs an upgrade.
