### PR TITLE
Run 'newt load' as an interactive shell command

### DIFF
--- a/newt/builder/load.go
+++ b/newt/builder/load.go
@@ -92,7 +92,7 @@ func Load(binBaseName string, bspPkg *pkg.BspPackage,
 	for _, v := range env {
 		util.StatusMessage(util.VERBOSITY_VERBOSE, "* %s\n", v)
 	}
-	if _, err := util.ShellCommand(cmd, env); err != nil {
+	if err := util.ShellInteractiveCommand(cmd, env); err != nil {
 		return err
 	}
 	util.StatusMessage(util.VERBOSITY_VERBOSE, "Successfully loaded image.\n")


### PR DESCRIPTION
Some targets support JTAG Lockout (i.e erasing
flash upon jtag commands for security purposes).
Enable `newt load` command to run the status
checking routines by making it an interactive step,
so that the user has an option to continue or abort
the image load operation.

Note: The check can be  done during `newt debug` as well.
The debug command is already interactive.