### PR TITLE
`newt info`: Include git status of project

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -22,6 +23,7 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -38,6 +40,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -131,11 +131,11 @@ func infoRunCmd(cmd *cobra.Command, args []string) {
 
 	// If no arguments specified, print status of all installed repos.
 	if len(args) == 0 {
-		pred := func(r *repo.Repo) bool { return !r.IsLocal() }
-
+		pred := func(r *repo.Repo) bool { return true }
 		if err := proj.InfoIf(pred, infoRemote); err != nil {
 			NewtUsage(nil, err)
 		}
+
 		return
 	}
 

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -565,7 +565,9 @@ func NewLocalRepo(repoName string) (*Repo, error) {
 		local: true,
 	}
 
-	if err := r.Init(repoName, nil); err != nil {
+	// Local repos always get a git downloader.  The downloader is needed to
+	// determine the git state of the project.
+	if err := r.Init(repoName, downloader.NewGitDownloader()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The `newt info` command prints the git commit and dirty state of all the Mynewt repos in the `repos` directory.

This PR adds an additional line of output: the git commit and dirty state of the project itself.  If the project is not a git repo, then this PR has no effect.

Example output:
```
$ newt info
Repository info:
    * apache-mynewt-core: b7a5474d569d5b67152d1773627ddda010c080a3, 1.7.0
    * apache-mynewt-nimble: 5371a45890604d32564c6384eb00dfee74ee7d13, 1.2.0
    * mcuboot: 7fea84665f1306a4f0a6bc3e22ccb61f8af097da, 1.3.1
    * myproj (project): 0301d43a159c92197d22c72ae85769ffb5511bff (dirty: local changes)
```