### PR TITLE
Resolve transient packages before dep resolution

### DIFF
--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -1108,13 +1108,7 @@ func ResolveFull(
 	// We have now resolved all packages so go through them and emit warning
 	// when using link packages
 	for _, rpkg := range res.MasterSet.Rpkgs {
-		if rpkg.Lpkg.Type() != pkg.PACKAGE_TYPE_TRANSIENT {
-			continue
-		}
-
-		log.Warnf("Transient package %s used, update configuration "+
-			"to use linked package instead (%s)",
-			rpkg.Lpkg.FullName(), rpkg.Lpkg.LinkedName())
+		LogTransientWarning(rpkg.Lpkg)
 	}
 
 	// If there is no loader, then the set of all packages is just the app
@@ -1237,4 +1231,12 @@ func (res *Resolution) WarningText() string {
 
 func (res *Resolution) DeprecatedWarning() []string {
 	return res.Cfg.DeprecatedWarning()
+}
+
+func LogTransientWarning(lpkg *pkg.LocalPackage) {
+	if lpkg.Type() == pkg.PACKAGE_TYPE_TRANSIENT {
+		log.Warnf("Transient package %s used, update configuration "+
+			"to use linked package instead (%s)",
+			lpkg.FullName(), lpkg.LinkedName())
+	}
 }

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -132,7 +132,7 @@ func (target *Target) Validate(appRequired bool) error {
 		return util.NewNewtError("Target does not specify a BSP package " +
 			"(target.bsp)")
 	}
-	bsp := target.resolvePackageName(target.BspName)
+	bsp := target.ResolvePackageName(target.BspName)
 	if bsp == nil {
 		return util.FmtNewtError("Could not resolve BSP package: %s",
 			target.BspName)
@@ -149,7 +149,7 @@ func (target *Target) Validate(appRequired bool) error {
 			return util.NewNewtError("Target does not specify an app " +
 				"package (target.app)")
 		}
-		app := target.resolvePackageName(target.AppName)
+		app := target.ResolvePackageName(target.AppName)
 		if app == nil {
 			return util.FmtNewtError("Could not resolve app package: %s",
 				target.AppName)
@@ -162,7 +162,7 @@ func (target *Target) Validate(appRequired bool) error {
 		}
 
 		if target.LoaderName != "" {
-			loader := target.resolvePackageName(target.LoaderName)
+			loader := target.ResolvePackageName(target.LoaderName)
 			if loader == nil {
 				return util.FmtNewtError(
 					"Could not resolve loader package: %s", target.LoaderName)
@@ -207,7 +207,7 @@ func (target *Target) Clone(newRepo *repo.Repo, newName string) *Target {
 	return &newTarget
 }
 
-func (target *Target) resolvePackageRepoAndName(repo *repo.Repo, name string) *pkg.LocalPackage {
+func (target *Target) ResolvePackageRepoAndName(repo *repo.Repo, name string) *pkg.LocalPackage {
 	dep, err := pkg.NewDependency(repo, name)
 	if err != nil {
 		return nil
@@ -221,8 +221,8 @@ func (target *Target) resolvePackageRepoAndName(repo *repo.Repo, name string) *p
 	return pack
 }
 
-func (target *Target) resolvePackageName(name string) *pkg.LocalPackage {
-	pack := target.resolvePackageYmlName(name)
+func (target *Target) ResolvePackageName(name string) *pkg.LocalPackage {
+	pack := target.ResolvePackageYmlName(name)
 
 	if pack == nil || pack.Type() != pkg.PACKAGE_TYPE_TRANSIENT {
 		return pack
@@ -231,42 +231,42 @@ func (target *Target) resolvePackageName(name string) *pkg.LocalPackage {
 	// We follow only one level of linking here to make things easier and assuming
 	// nested linking means someone using really deprecated packages ;)
 
-	pack = target.resolvePackageRepoAndName(pack.Repo().(*repo.Repo), pack.LinkedName())
+	pack = target.ResolvePackageRepoAndName(pack.Repo().(*repo.Repo), pack.LinkedName())
 
 	return pack
 }
 
-func (target *Target) resolvePackageYmlName(name string) *pkg.LocalPackage {
-	return target.resolvePackageRepoAndName(target.basePkg.Repo().(*repo.Repo), name)
+func (target *Target) ResolvePackageYmlName(name string) *pkg.LocalPackage {
+	return target.ResolvePackageRepoAndName(target.basePkg.Repo().(*repo.Repo), name)
 }
 
 // Methods below resolve package by name and follow links to get proper package
 
 func (target *Target) App() *pkg.LocalPackage {
-	return target.resolvePackageName(target.AppName)
+	return target.ResolvePackageName(target.AppName)
 }
 
 func (target *Target) Loader() *pkg.LocalPackage {
-	return target.resolvePackageName(target.LoaderName)
+	return target.ResolvePackageName(target.LoaderName)
 }
 
 func (target *Target) Bsp() *pkg.LocalPackage {
-	return target.resolvePackageName(target.BspName)
+	return target.ResolvePackageName(target.BspName)
 }
 
 // Methods below resolve package by name as stated in YML file (so do not follow links)
 // e.g. to use as seed for dependencies calculation
 
 func (target *Target) AppYml() *pkg.LocalPackage {
-	return target.resolvePackageYmlName(target.AppName)
+	return target.ResolvePackageYmlName(target.AppName)
 }
 
 func (target *Target) LoaderYml() *pkg.LocalPackage {
-	return target.resolvePackageYmlName(target.LoaderName)
+	return target.ResolvePackageYmlName(target.LoaderName)
 }
 
 func (target *Target) BspYml() *pkg.LocalPackage {
-	return target.resolvePackageYmlName(target.BspName)
+	return target.ResolvePackageYmlName(target.BspName)
 }
 
 // Save the target's configuration elements


### PR DESCRIPTION
This fixes #286.

If a split image specifies a transient package as the loader, newt will fail to build it.

For example, in this target:
```
target.app: "@apache-mynewt-core/apps/splitty"
target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10040"
target.build_profile: optimized
target.loader: "@apache-mynewt-core/apps/bleprph"
```

`@apache-mynewt-core/apps/bleprph` is a transient package; it links to
`@apache-mynewt-nimble/apps/bleprph`. 

Newt reports the following error when asked to build this target:

```
Error: Two app packages in build: apps/splitty, apps/bleprph
```

The bug occurs when newt tries to partition the master set of packages among
the loader and app.  In a split image, all loader packages are shared among
both loader and app, so the app automatically pulls in all the packages in the
loader *with one exception*: The loader's "app" package (confusing terminology)
does not get pulled in.  The app has its own "app" package; it doesn't need the
loader's "app" package.

The problem was that newt couldn't identify the loader's "app" package if it
was transient.  This package's type was "transient" (not "app"), so it got
pulled in to the app.  Consequently, the app contained two "app" packages,
resulting in the error.

The fix is to resolve transient packages among seed packages before performing
dependency resolution.  With this change, the loader's "app" package is
identifiable when newt decides which packages get pulled in to the app.