### PR TITLE
logcfg: Don't generate macros for nameless levels

### DIFF
--- a/newt/logcfg/logcfg.go
+++ b/newt/logcfg/logcfg.go
@@ -270,11 +270,13 @@ func (lcfg *LCfg) writeLogMacros(w io.Writer) {
 
 		levelInt, _ := util.AtoiNoOct(l.Level.Value)
 		for i, levelStr := range logLevelNames {
-			if i < levelInt {
-				writeLogStub(l.Name, levelStr, w)
-			} else {
-				modInt, _ := l.Module.IntVal()
-				writeLogMacro(l.Name, modInt, levelStr, w)
+			if levelStr != "" {
+				if i < levelInt {
+					writeLogStub(l.Name, levelStr, w)
+				} else {
+					modInt, _ := l.Module.IntVal()
+					writeLogMacro(l.Name, modInt, levelStr, w)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The generated `logcfg.h` file contains some extraneous macros.  For
example:
```
    #define DFLT_LOG_DEBUG(...) IGNORE(__VA_ARGS__)
    #define DFLT_LOG_INFO(...) MODLOG_INFO(0, __VA_ARGS__)
    #define DFLT_LOG_WARN(...) MODLOG_WARN(0, __VA_ARGS__)
    #define DFLT_LOG_ERROR(...) MODLOG_ERROR(0, __VA_ARGS__)
    #define DFLT_LOG_CRITICAL(...) MODLOG_CRITICAL(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_(...) MODLOG_(0, __VA_ARGS__)
    #define DFLT_LOG_DISABLED(...) MODLOG_DISABLED(0, __VA_ARGS__)
```
The generated code should look like this:
```
    #define DFLT_LOG_DEBUG(...) IGNORE(__VA_ARGS__)
    #define DFLT_LOG_INFO(...) MODLOG_INFO(0, __VA_ARGS__)
    #define DFLT_LOG_WARN(...) MODLOG_WARN(0, __VA_ARGS__)
    #define DFLT_LOG_ERROR(...) MODLOG_ERROR(0, __VA_ARGS__)
    #define DFLT_LOG_CRITICAL(...) MODLOG_CRITICAL(0, __VA_ARGS__)
    #define DFLT_LOG_DISABLED(...) MODLOG_DISABLED(0, __VA_ARGS__)
```
The extraneous macros are generated because log levels 5 through 14 do
not have names (between CRITICAL and DISABLED).

This PR removes the extraneous macros from the generated code.