### PR TITLE
Include @<repo> in bin directories and filenames

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -502,7 +502,7 @@ func (b *Builder) PrepBuild() error {
 
 	// All packages have access to the generated code header directory.
 	baseCi.Includes = append(baseCi.Includes,
-		GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.Name()))
+		GeneratedIncludeDir(b.targetPkg.rpkg.Lpkg.FullName()))
 
 	// Let multiplatform libraries know that a Mynewt binary is being build.
 	baseCi.Cflags = append(baseCi.Cflags, "-DMYNEWT=1")
@@ -520,7 +520,7 @@ func (b *Builder) AddCompilerInfo(info *toolchain.CompilerInfo) {
 
 func (b *Builder) addSysinitBpkg() (*BuildPackage, error) {
 	lpkg := pkg.NewLocalPackage(b.targetPkg.rpkg.Lpkg.Repo().(*repo.Repo),
-		GeneratedBaseDir(b.targetPkg.rpkg.Lpkg.Name()))
+		GeneratedBaseDir(b.targetPkg.rpkg.Lpkg.FullName()))
 	lpkg.SetName(pkg.ShortName(b.targetPkg.rpkg.Lpkg) + "-sysinit-" +
 		b.buildName)
 	lpkg.SetType(pkg.PACKAGE_TYPE_GENERATED)

--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -127,47 +127,47 @@ func MfgBootDir(mfgPkgName string) string {
 }
 
 func (b *Builder) BinDir() string {
-	return BinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName)
+	return BinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName)
 }
 
 func (b *Builder) FileBinDir(pkgName string) string {
-	return FileBinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, pkgName)
+	return FileBinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName, pkgName)
 }
 
 func (b *Builder) PkgBinDir(bpkg *BuildPackage) string {
-	return PkgBinDir(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, bpkg.rpkg.Lpkg.Name(),
-		bpkg.rpkg.Lpkg.Type())
+	return PkgBinDir(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		bpkg.rpkg.Lpkg.FullName(), bpkg.rpkg.Lpkg.Type())
 }
 
 // Generates the path+filename of the specified package's .a file.
 func (b *Builder) ArchivePath(bpkg *BuildPackage) string {
-	return ArchivePath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName, bpkg.rpkg.Lpkg.Name(),
-		bpkg.rpkg.Lpkg.Type())
+	return ArchivePath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		bpkg.rpkg.Lpkg.FullName(), bpkg.rpkg.Lpkg.Type())
 }
 
 func (b *Builder) AppTentativeElfPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
-		"_tmp.elf"
+	return b.PkgBinDir(b.appPkg) + "/" +
+		filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) + "_tmp.elf"
 }
 
 func (b *Builder) AppElfPath() string {
-	return AppElfPath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
-		b.appPkg.rpkg.Lpkg.Name())
+	return AppElfPath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		b.appPkg.rpkg.Lpkg.FullName())
 }
 
 func (b *Builder) AppLinkerElfPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
-		"linker.elf"
+	return b.PkgBinDir(b.appPkg) + "/" +
+		filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) + "linker.elf"
 }
 
 func (b *Builder) AppImgPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
-		".img"
+	return b.PkgBinDir(b.appPkg) + "/" +
+		filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) + ".img"
 }
 
 func (b *Builder) AppHexPath() string {
-	return b.PkgBinDir(b.appPkg) + "/" + filepath.Base(b.appPkg.rpkg.Lpkg.Name()) +
-		".hex"
+	return b.PkgBinDir(b.appPkg) + "/" +
+		filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) + ".hex"
 }
 
 func (b *Builder) AppMapPath() string {
@@ -183,18 +183,18 @@ func (b *Builder) AppPath() string {
 }
 
 func (b *Builder) TestExePath() string {
-	return TestExePath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
-		b.testPkg.rpkg.Lpkg.Name(), b.testPkg.rpkg.Lpkg.Type())
+	return TestExePath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		b.testPkg.rpkg.Lpkg.FullName(), b.testPkg.rpkg.Lpkg.Type())
 }
 
 func (b *Builder) ManifestPath() string {
-	return ManifestPath(b.targetPkg.rpkg.Lpkg.Name(), b.buildName,
-		b.appPkg.rpkg.Lpkg.Name())
+	return ManifestPath(b.targetPkg.rpkg.Lpkg.FullName(), b.buildName,
+		b.appPkg.rpkg.Lpkg.FullName())
 }
 
 func (b *Builder) AppBinBasePath() string {
 	return b.PkgBinDir(b.appPkg) + "/" +
-		filepath.Base(b.appPkg.rpkg.Lpkg.Name())
+		filepath.Base(b.appPkg.rpkg.Lpkg.FullName())
 }
 
 func (b *Builder) CompileCmdsPath() string {

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -254,8 +254,8 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 		log.Warn(line)
 	}
 
-	incDir := GeneratedIncludeDir(t.target.Name())
-	srcDir := GeneratedSrcDir(t.target.Name())
+	incDir := GeneratedIncludeDir(t.target.FullName())
+	srcDir := GeneratedSrcDir(t.target.FullName())
 
 	if err := syscfg.EnsureWritten(t.res.Cfg, incDir); err != nil {
 		return err
@@ -448,7 +448,7 @@ func (t *TargetBuilder) autogenKeys() error {
 		return err
 	}
 
-	srcDir := GeneratedSrcDir(t.target.Name())
+	srcDir := GeneratedSrcDir(t.target.FullName())
 
 	f, _ := os.Create(srcDir + "/pubkey-autogen.c")
 	w := bufio.NewWriter(f)

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -211,7 +211,7 @@ func cleanRunCmd(cmd *cobra.Command, args []string) {
 		cleanDir(builder.BinRoot())
 	} else {
 		for _, t := range targets {
-			cleanDir(builder.TargetBinDir(t.Name()))
+			cleanDir(builder.TargetBinDir(t.FullName()))
 		}
 	}
 }


### PR DESCRIPTION
This fixes #171.

Prior to this PR, files and directories under `bin` were named according to package short names.  A pacakge's short name is everything *except* its repo name.  For example,

|     |     |
| --- | --- |
| Full name | @apache-mynewt-core/sys/log/stub |
| Short name | sys/log/stub |

If two packages had the same short name (but different repos), some of their artifacts might have the same filename.  In this case, the binary would fail to link.

After this PR, newt names artifacts based on package full names.  For example, choosing one `.a` file at random:

|     |     |
| --- | --- |
| Before commit |  bin/targets/my_blinky_sim/app/sys/log/stub/sys_log_stub.a |
| After commit | bin/targets/my_blinky_sim/app/@apache-mynewt-core/sys/log/stub/@apache-mynewt-core_sys_log_stub.a |

One annoyance is that the "@" character causes issues with tab completion.  With default settings, bash tab completion requires "@" characters to be escaped with backslashes.  Note: Escaping is not required when specifying the file, it is only required for tab completion to work.

I could certainly be convinced otherwise, but I don't think this tab-completion annoyance is a big enough problem to look for an alternate solution.  I think it is best to use the actual package names in the generated filenames.