### PR TITLE
Run custom commands at build time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
 	github.com/apache/mynewt-artifact v0.0.3
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -312,6 +312,14 @@ func (t *TargetBuilder) CMakeTargetBuilderWrite(w io.Writer, targetCompiler *too
 		return err
 	}
 
+	if len(t.res.PreBuildCmdCfg.StageFuncs) > 0 ||
+		len(t.res.PreLinkCmdCfg.StageFuncs) > 0 ||
+		len(t.res.PostBuildCmdCfg.StageFuncs) > 0 {
+
+		util.OneTimeWarning(
+			"custom commands not included in cmake output (unsupported)")
+	}
+
 	/* Build the Apps */
 	project.ResetDeps(t.AppList)
 

--- a/newt/builder/extcmd.go
+++ b/newt/builder/extcmd.go
@@ -1,0 +1,235 @@
+package builder
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/kballard/go-shellquote"
+	log "github.com/sirupsen/logrus"
+	"mynewt.apache.org/newt/newt/stage"
+	"mynewt.apache.org/newt/util"
+)
+
+// replaceArtifactsIfChanged compares the artifacts just produced (temp
+// directory) to those from the previous build (user bin directory).  If they
+// are different, it replaces the old with the new so that they get relinked
+// during this build.
+func replaceArtifactsIfChanged(oldDir string, newDir string) error {
+	eq, err := util.DirsAreEqual(oldDir, newDir)
+	if err != nil {
+		return err
+	}
+
+	if eq {
+		// No changes detected.
+		return nil
+	}
+
+	log.Debugf("changes detected; replacing %s with %s", oldDir, newDir)
+	os.RemoveAll(oldDir)
+	if err := os.Rename(newDir, oldDir); err != nil {
+		return util.ChildNewtError(err)
+	}
+
+	return nil
+}
+
+// createTempUserDirs creates a set of temporary directories for holding build
+// inputs.  It returns:
+//     * base-dir
+//     * src-dir
+//     * include-dir
+func createTempUserDirs(label string) (string, string, string, error) {
+	tmpDir, err := ioutil.TempDir("", "mynewt-user-"+label)
+	if err != nil {
+		return "", "", "", util.ChildNewtError(err)
+	}
+	log.Debugf("created user %s dir: %s", label, tmpDir)
+
+	tmpSrcDir := UserTempSrcDir(tmpDir)
+	log.Debugf("creating user %s src dir: %s", label, tmpSrcDir)
+	if err := os.MkdirAll(tmpSrcDir, 0755); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", "", "", util.ChildNewtError(err)
+	}
+
+	tmpIncDir := UserTempIncludeDir(tmpDir)
+	log.Debugf("creating user %s include dir: %s", label, tmpIncDir)
+	if err := os.MkdirAll(tmpIncDir, 0755); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", "", "", util.ChildNewtError(err)
+	}
+
+	return tmpDir, tmpSrcDir, tmpIncDir, nil
+}
+
+// envVarsForCmd calculates the set of environment variables to export for the
+// specified external command.
+func (t *TargetBuilder) envVarsForCmd(sf stage.StageFunc, userSrcDir string,
+	userIncDir string, workDir string) (map[string]string, error) {
+
+	// Determine whether the owning package is part of the loader or the app.
+	slot := 0
+	buildName := "app"
+
+	if t.LoaderBuilder != nil {
+		rpkg := t.res.LpkgRpkgMap[sf.Pkg]
+		if rpkg == nil {
+			return nil, util.FmtNewtError(
+				"resolution missing expected package: %s", sf.Pkg.FullName())
+		}
+
+		if t.LoaderBuilder.PkgMap[rpkg] != nil {
+			buildName = "loader"
+		} else {
+			slot = 1
+		}
+	}
+
+	env, err := t.AppBuilder.EnvVars(slot)
+	if err != nil {
+		return nil, err
+	}
+
+	p := UserEnvParams{
+		Lpkg:       sf.Pkg,
+		TargetName: t.target.FullName(),
+		AppName:    t.appPkg.FullName(),
+		BuildName:  buildName,
+		UserSrcDir: userSrcDir,
+		UserIncDir: userIncDir,
+		WorkDir:    workDir,
+	}
+	uenv := UserEnvVars(p)
+
+	for k, v := range uenv {
+		env[k] = v
+	}
+
+	return env, nil
+}
+
+// execExtCmds executes a set of user scripts.
+func (t *TargetBuilder) execExtCmds(sf stage.StageFunc, userSrcDir string,
+	userIncDir string, workDir string) error {
+
+	env, err := t.envVarsForCmd(sf, userSrcDir, userIncDir, workDir)
+	if err != nil {
+		return err
+	}
+
+	envs := EnvVarsToSlice(env)
+	toks, err := shellquote.Split(sf.Name)
+	if err != nil {
+		return util.FmtNewtError(
+			"invalid command string: \"%s\": %s", sf.Name, err.Error())
+	}
+
+	// If the command is in the user's PATH, expand it to its real location.
+	cmd, err := exec.LookPath(toks[0])
+	if err == nil {
+		toks[0] = cmd
+	}
+
+	util.StatusMessage(util.VERBOSITY_DEFAULT, "Executing %s\n", sf.Name)
+	if err := util.ShellInteractiveCommand(toks, envs, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// execPreBuildCmds runs the target's set of pre-build user commands.  It is an
+// error if any command fails (exits with a nonzero status).
+func (t *TargetBuilder) execPreBuildCmds(workDir string) error {
+	// Create temporary directories where scripts can put build inputs.
+	tmpDir, tmpSrcDir, tmpIncDir, err := createTempUserDirs("pre-build")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		log.Debugf("removing user pre-build dir: %s", tmpDir)
+		os.RemoveAll(tmpDir)
+	}()
+
+	for _, sf := range t.res.PreBuildCmdCfg.StageFuncs {
+		if err := t.execExtCmds(sf, tmpSrcDir, tmpIncDir, workDir); err != nil {
+			return err
+		}
+	}
+
+	srcDir := UserPreBuildSrcDir(t.target.FullName())
+	if err := replaceArtifactsIfChanged(srcDir, tmpSrcDir); err != nil {
+		return err
+	}
+
+	incDir := UserPreBuildIncludeDir(t.target.FullName())
+	if err := replaceArtifactsIfChanged(incDir, tmpIncDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// execPreLinkCmds runs the target's set of post-build user commands.  It is
+// an error if any command fails (exits with a nonzero status).
+func (t *TargetBuilder) execPreLinkCmds(workDir string) error {
+	// Create temporary directories where scripts can put build inputs.
+	tmpDir, tmpSrcDir, _, err := createTempUserDirs("pre-link")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		log.Debugf("removing user pre-link dir: %s", tmpDir)
+		os.RemoveAll(tmpDir)
+	}()
+
+	for _, sf := range t.res.PreLinkCmdCfg.StageFuncs {
+		if err := t.execExtCmds(sf, tmpSrcDir, "", workDir); err != nil {
+			return err
+		}
+	}
+
+	srcDir := UserPreLinkSrcDir(t.target.FullName())
+	err = replaceArtifactsIfChanged(srcDir, tmpSrcDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// execPostBuildCmds runs the target's set of post-build user commands.  It is
+// an error if any command fails (exits with a nonzero status).
+func (t *TargetBuilder) execPostBuildCmds(workDir string) error {
+	for _, sf := range t.res.PostBuildCmdCfg.StageFuncs {
+		if err := t.execExtCmds(sf, "", "", workDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// makeUserDir creates a temporary directory where scripts can put build
+// inputs.
+func makeUserDir() (string, error) {
+	tmpDir, err := ioutil.TempDir("", "mynewt-user")
+	if err != nil {
+		return "", util.ChildNewtError(err)
+	}
+	log.Debugf("created user dir: %s", tmpDir)
+
+	return tmpDir, nil
+}
+
+func makeUserWorkDir() (string, error) {
+	tmpDir, err := ioutil.TempDir("", "mynewt-user-work")
+	if err != nil {
+		return "", util.ChildNewtError(err)
+	}
+	log.Debugf("created user work dir: %s", tmpDir)
+
+	return tmpDir, nil
+}

--- a/newt/builder/load.go
+++ b/newt/builder/load.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"sort"
 	"strings"
 	"syscall"
 
@@ -126,17 +125,7 @@ func Load(binBasePath string, bspPkg *pkg.BspPackage,
 	for k, v := range extraEnvSettings {
 		env[k] = v
 	}
-
-	sortedKeys := make([]string, 0, len(env))
-	for k, _ := range env {
-		sortedKeys = append(sortedKeys, k)
-	}
-	sort.Strings(sortedKeys)
-
-	envSlice := []string{}
-	for _, key := range sortedKeys {
-		envSlice = append(envSlice, fmt.Sprintf("%s=%s", key, env[key]))
-	}
+	envSlice := EnvVarsToSlice(env)
 
 	RunOptionalCheck(bspPkg.OptChkScript, envSlice)
 	// bspPath, binBasePath are passed in command line for backwards

--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -63,6 +63,38 @@ func SysinitArchivePath(targetName string) string {
 	return GeneratedBinDir(targetName) + "/sysinit.a"
 }
 
+func UserBaseDir(targetName string) string {
+	return BinRoot() + "/" + targetName + "/user"
+}
+
+func UserPreBuildDir(targetName string) string {
+	return UserBaseDir(targetName) + "/pre_build"
+}
+
+func UserPreLinkDir(targetName string) string {
+	return UserBaseDir(targetName) + "/pre_link"
+}
+
+func UserPreBuildSrcDir(targetName string) string {
+	return UserPreBuildDir(targetName) + "/src"
+}
+
+func UserPreBuildIncludeDir(targetName string) string {
+	return UserPreBuildDir(targetName) + "/include"
+}
+
+func UserPreLinkSrcDir(targetName string) string {
+	return UserPreLinkDir(targetName) + "/src"
+}
+
+func UserTempSrcDir(tempDir string) string {
+	return tempDir + "/src"
+}
+
+func UserTempIncludeDir(tempDir string) string {
+	return tempDir + "/include"
+}
+
 func PkgSyscfgPath(pkgPath string) string {
 	return pkgPath + "/" + pkg.SYSCFG_YAML_FILENAME
 }

--- a/newt/extcmd/extcmd.go
+++ b/newt/extcmd/extcmd.go
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package extcmd
+
+import (
+	"fmt"
+
+	"mynewt.apache.org/newt/newt/pkg"
+	"mynewt.apache.org/newt/newt/stage"
+	"mynewt.apache.org/newt/newt/syscfg"
+)
+
+// ExtCmdCfg represents an ordered list of external commands that get run
+// during the build (aka "user scripts").
+type ExtCmdCfg struct {
+	// Used in diagnostic messages only (example: "pre_build_cmds").
+	Name string
+
+	// Sorted in call order (stage-num,command-string).
+	StageFuncs []stage.StageFunc
+
+	// Strings describing errors encountered while parsing the extcmd config.
+	InvalidSettings []string
+}
+
+// GetMapFn retrieves a set of ordered external commands from a package.  For
+// example, one GetMapFn instance might retrieve a package's pre-build
+// commands.
+type GetMapFn func(
+	lpkg *pkg.LocalPackage, settings map[string]string) map[string]string
+
+func (ecfg *ExtCmdCfg) readOnePkg(lpkg *pkg.LocalPackage, cfg *syscfg.Cfg,
+	getMapCb GetMapFn) {
+
+	settings := cfg.AllSettingsForLpkg(lpkg)
+	cmdMap := getMapCb(lpkg, settings)
+
+	for name, stageStr := range cmdMap {
+		sf, err := stage.NewStageFunc(name, stageStr, lpkg, cfg)
+		if err != nil {
+			text := fmt.Sprintf("%s: %s", lpkg.FullName(), err.Error())
+			ecfg.InvalidSettings = append(ecfg.InvalidSettings, text)
+		} else {
+			ecfg.StageFuncs = append(ecfg.StageFuncs, sf)
+		}
+	}
+}
+
+// Read constructs an external command configuration from a full set of
+// packages.
+func Read(name string, lpkgs []*pkg.LocalPackage, cfg *syscfg.Cfg,
+	getMapCb GetMapFn) ExtCmdCfg {
+
+	ecfg := ExtCmdCfg{
+		Name: name,
+	}
+
+	for _, lpkg := range lpkgs {
+		ecfg.readOnePkg(lpkg, cfg, getMapCb)
+	}
+
+	stage.SortStageFuncs(ecfg.StageFuncs, ecfg.Name)
+
+	return ecfg
+}
+
+// If any errors were encountered while parsing extcmd definitions, this
+// function returns a string indicating the errors.  If no errors were
+// encountered, "" is returned.
+func (ecfg *ExtCmdCfg) ErrorText() string {
+	str := ""
+
+	if len(ecfg.InvalidSettings) > 0 {
+		str += fmt.Sprintf("Invalid %s definitions detected:", ecfg.Name)
+		for _, e := range ecfg.InvalidSettings {
+			str += "\n    " + e
+		}
+	}
+
+	return str
+}

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -377,6 +377,24 @@ func (pkg *LocalPackage) DownFuncs(
 	return pkg.PkgY.GetValStringMapString("pkg.down", settings)
 }
 
+func (pkg *LocalPackage) PreBuildCmds(
+	settings map[string]string) map[string]string {
+
+	return pkg.PkgY.GetValStringMapString("pkg.pre_build_cmds", settings)
+}
+
+func (pkg *LocalPackage) PreLinkCmds(
+	settings map[string]string) map[string]string {
+
+	return pkg.PkgY.GetValStringMapString("pkg.pre_link_cmds", settings)
+}
+
+func (pkg *LocalPackage) PostBuildCmds(
+	settings map[string]string) map[string]string {
+
+	return pkg.PkgY.GetValStringMapString("pkg.post_build_cmds", settings)
+}
+
 func (pkg *LocalPackage) InjectedSettings() map[string]string {
 	return pkg.injectedSettings
 }

--- a/newt/stage/stage.go
+++ b/newt/stage/stage.go
@@ -59,9 +59,9 @@ func NewStageFunc(name string, textVal string,
 
 	// Ensure setting resolves to an integer.
 	if _, err := vs.IntVal(); err != nil {
-		return StageFunc{}, util.FmtNewtError("Invalid stage setting: %s=%s; "+
-			"value does not resolve to an integer",
-			name, textVal)
+		return StageFunc{}, util.FmtNewtError("Invalid setting: \"%s: %s\"; "+
+			"value \"%s\" does not resolve to an integer",
+			name, textVal, textVal)
 	}
 
 	sf := StageFunc{

--- a/newt/stage/stage.go
+++ b/newt/stage/stage.go
@@ -73,58 +73,36 @@ func NewStageFunc(name string, textVal string,
 	return sf, nil
 }
 
-type stageFuncSorter struct {
-	// Used in logging; either "sysinit" or "sysdown".
-	funcType string
-	// Array of functions to be sorted.
-	fns []StageFunc
-}
-
-func (s stageFuncSorter) Len() int {
-	return len(s.fns)
-}
-
-func (s stageFuncSorter) Swap(i, j int) {
-	s.fns[i], s.fns[j] = s.fns[j], s.fns[i]
-}
-
-func (s stageFuncSorter) Less(i, j int) bool {
-	a := s.fns[i]
-	b := s.fns[j]
-
-	inta, _ := a.Stage.IntVal()
-	intb, _ := b.Stage.IntVal()
-
-	// 1: Sort by stage number.
-	if inta < intb {
-		return true
-	} else if intb < inta {
-		return false
-	}
-
-	// 2: Sort by function name.
-	switch strings.Compare(a.Name, b.Name) {
-	case -1:
-		return true
-	case 1:
-		return false
-	}
-
-	// Same stage and function name?
-	log.Warnf("Warning: Identical %s functions detected: %s",
-		s.funcType, a.Name)
-
-	return true
-}
-
 // SortStageFuncs performs an in-place sort of the provided StageFunc slice.
-func SortStageFuncs(unsorted []StageFunc, funcType string) {
-	s := stageFuncSorter{
-		funcType: funcType,
-		fns:      unsorted,
-	}
+func SortStageFuncs(sfs []StageFunc, entryType string) {
+	sort.Slice(sfs, func(i int, j int) bool {
+		a := sfs[i]
+		b := sfs[j]
 
-	sort.Sort(s)
+		inta, _ := a.Stage.IntVal()
+		intb, _ := b.Stage.IntVal()
+
+		// 1: Sort by stage number.
+		if inta < intb {
+			return true
+		} else if intb < inta {
+			return false
+		}
+
+		// 2: Sort by entry name.
+		switch strings.Compare(a.Name, b.Name) {
+		case -1:
+			return true
+		case 1:
+			return false
+		}
+
+		// Same stage and function name?
+		log.Warnf("Warning: Identical %s entries detected: %s",
+			entryType, a.Name)
+
+		return true
+	})
 }
 
 func (f *StageFunc) ReturnTypeString() string {

--- a/util/util.go
+++ b/util/util.go
@@ -405,12 +405,18 @@ func ShellInteractiveCommand(cmdStr []string, env []string, flagBlock bool) erro
 	}
 
 	// Release and exit
-	_, err = proc.Wait()
+	state, err := proc.Wait()
+	signal.Stop(c)
+
 	if err != nil {
-		signal.Stop(c)
 		return NewNewtError(err.Error())
 	}
-	signal.Stop(c)
+	if state.ExitCode() != 0 {
+		return FmtNewtError(
+			"command %v exited with nonzero status %d",
+			cmdStr, state.ExitCode())
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds the ability to run custom commands at build time.

A package specifies custom commands in its `pkg.yml` file.  There are three types of commands:
1. pre_build_cmds (run before the build)
2. pre_link_cmds (run after compilation, before linking)
3. post_build_cmds (run after the build)

### EXAMPLE

Example (apps/blinky/pkg.yml):
```
pkg.pre_build_cmds:
    scripts/pre_build1.sh: 100
    scripts/pre_build2.sh: 200

pkg.pre_link_cmds:
    scripts/pre_link.sh: 500

pkg.post_build_cmds:
    scripts/post_build.sh: 100
```

For each command, the string on the left specifies the command to run.  The number on the right indicates the command's relative ordering.

When newt builds this example, it performs the following sequence:

* scripts/pre_build1.sh
* scripts/pre_build2.sh
* [compile]
* scripts/pre_link.sh
* [link]
* scripts/post_build.sh

If other packages specify custom commands, those commands would also be executed during the above sequence.  For example, if another package specifies a pre command with an ordering of 150, that command would run immediately after `pre_build1.sh`.  In the case of a tie, the commands are run in lexicographic order.

All commands are run from the project's base directory.  In the above example, the `scripts` directory is a sibling of `targets`.

### CUSTOM BUILD INPUTS

A custom pre-build or pre-link command can produce files that get fed into the current build.

*Pre-build* commands can generate any of the following:

1. `.c` files for newt to compile.
2. `.a` files for newt to link.
3. `.h` files that any package can include.

*Pre-link* commands can only generate .a files.

`.c` and `.a` files should be written to `$MYNEWT_USER_SRC_DIR` (or any subdirectory within).

`.h` files should be written to `$MYNEWT_USER_INCLUDE_DIR`.  The directory structure used here is directly reflected by the includer.  E.g., if a script writes to:
```
$MYNEWT_USER_INCLUDE_DIR/foo/bar.h
```

then a source file can include this header with:
```
#include "foo/bar.h"
```

### DETAILS

#### 1. Environment variables

In addition to the usual environment variables defined for debug and download scripts, newt defines the following env vars for custom commands:

| Environment variable    | Description                                                                 | Notes                         |
|-------------------------|-----------------------------------------------------------------------------|-------------------------------|
| MYNEWT_APP_BIN_DIR      | The directory where the current target's binary gets written.               |                               |
| MYNEWT_PKG_BIN_ARCHIVE  | The path to the current package's `.a` file.                                |                               |
| MYNEWT_PKG_BIN_DIR      | The directory where the current package's `.o` and `.a` files get written.  |                               |
| MYNEWT_PKG_NAME         | The full name of the current package.                                       |                               |
| MYNEWT_USER_INCLUDE_DIR | Path where globally-accessible headers get written.                         | Pre-build only.               |
| MYNEWT_USER_SRC_DIR     | Path where build inputs get written.                                        | Pre-build and pre-link only.  |
| MYNEWT_USER_WORK_DIR    | Shared temp directory; used for communication between commands.             |                               |

These environment variables are defined for each process that a custom command runs in.  They are *not* defined in the newt process itself.  So, the following snippet will not produce the expected output:

BAD Example (apps/blinky/pkg.yml):
```
pkg.pre_cmds:
    'echo $MYNEWT_USER_SRC_DIR': 100
```

You can execute `sh` here instead if you need access to the environment variables, but it is probably saner to just use a script.

#### 2. Detect changes in custom build inputs

To avoid unnecessary rebuilds, newt detects if custom build inputs have changed since the previous build.  If none of the inputs have changed, then they do not get rebuilt.  If any of them of them have changed, they all get rebuilt.

The `$MYNEWT_USER_[...]` directories are actually temp directories.  After the pre-build commands have run, newt compares the contents of the temp directory with those of the actual user directory.  If any differences are detected, newt replaces the user directory with the temp directory, triggering a rebuild of its contents.  The same procedure is used for pre-link commands.

#### 3. Paths

Custom build inputs get written to the following directories:

* bin/targets/\<target\>/user/pre_build/src
* bin/targets/\<target\>/user/pre_build/include
* bin/targets/\<target\>/user/pre_link/src

Custom commands should not write to these directories.  They should use the `$MYNEWT_USER_[...]` environment variables instead.
