### PR TITLE
repo: print a detailed error when version not found

### DIFF
--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -435,8 +435,8 @@ func parseRepoDepMap(depName string,
 	for commit, verReqsStr := range versMap {
 		verReqs, err := newtutil.ParseRepoVersionReqs(verReqsStr)
 		if err != nil {
-			return nil, util.FmtNewtError("invalid version string: %s",
-				verReqsStr)
+			return nil, util.FmtNewtError("invalid version string: %s: %s",
+				verReqsStr, err.Error())
 		}
 
 		result[commit] = &RepoDependency{


### PR DESCRIPTION
Print a detailed error message for better debugging
when version specified is not found.

Example:
```
       /home/naveen/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000d4500, 0x811aff, 0x7, 0x2)
        /home/naveen/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fc
github.com/spf13/cobra.(*Command).Execute(...)
        /home/naveen/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /tmp/mynewt.4s2bNH9guR/src/mynewt.apache.org/newt/newt/newt.go:183 +0x18c
goroutine 19 [syscall]:
os/signal.signal_recv(0x0)
        /usr/local/go/src/runtime/sigqueue.go:139 +0x9c
os/signal.loop()
        /usr/local/go/src/os/signal/signal_unix.go:23 +0x22
created by os/signal.init.0
        /usr/local/go/src/os/signal/signal_unix.go:29 +0x41
Error: Error while parsing 'repo.deps' for repo "juul-device-platform", dependency "apache-mynewt-core": invalid version string: 348cb613a1229482b6fdc1f12d0ab42df43ba56f: Invalid version string: "348cb613a1229482b6fdc1f12d0ab42df43ba56f"; must be fixed (X.X.X) or floating (X[.X]-stability)
```
Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>