### PR TITLE
Add support for hardware encryption features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
-	github.com/apache/mynewt-artifact v0.0.5
+	github.com/apache/mynewt-artifact v0.0.8
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,10 @@ github.com/apache/mynewt-artifact v0.0.3 h1:760wpGruGSOPjslEo0fgs9PYJ58IAvyjuJqn
 github.com/apache/mynewt-artifact v0.0.3/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/apache/mynewt-artifact v0.0.5 h1:MfKbb7wILRUr/Q4UA4AxTkKVDNikyGwzcy2ZXmoS5XI=
 github.com/apache/mynewt-artifact v0.0.5/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.6 h1:VvIdyo61Im7bvE5EGxByM6NzTaKkoqGQL3t17vyzjfQ=
+github.com/apache/mynewt-artifact v0.0.6/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.8 h1:as5qSDTT5httEM1IclQM4XgoF9Wn/lTqeoJxV/PvZFw=
+github.com/apache/mynewt-artifact v0.0.8/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -36,6 +36,9 @@ import (
 var useV1 bool
 var useV2 bool
 var encKeyFilename string
+var encKeyIndex int
+var hdrPad int
+var imagePad int
 
 // @return                      keys, key ID, error
 func parseKeyArgs(args []string) ([]sec.PrivSignKey, uint8, error) {
@@ -131,9 +134,11 @@ func createImageRunCmd(cmd *cobra.Command, args []string) {
 	}
 
 	if useV1 {
-		err = imgprod.ProduceAllV1(b, ver, keys, encKeyFilename)
+		err = imgprod.ProduceAllV1(b, ver, keys, encKeyFilename, encKeyIndex,
+			hdrPad, imagePad)
 	} else {
-		err = imgprod.ProduceAll(b, ver, keys, encKeyFilename)
+		err = imgprod.ProduceAll(b, ver, keys, encKeyFilename, encKeyIndex,
+			hdrPad, imagePad)
 	}
 	if err != nil {
 		NewtUsage(nil, err)
@@ -164,6 +169,8 @@ func AddImageCommands(cmd *cobra.Command) {
 	createImageHelpEx += "  newt create-image my_target1 1.3.0.3 private.pem\n"
 	createImageHelpEx +=
 		"  newt create-image -2 my_target1 1.3.0.3 private-1.pem private-2.pem\n"
+	createImageHelpEx += "  newt create-image my_target1 1.3.0.3 -H 3 -e " +
+		"aes_key\n\n"
 
 	createImageCmd := &cobra.Command{
 		Use: "create-image <target-name> <version> [signing-key-1] " +
@@ -186,7 +193,13 @@ func AddImageCommands(cmd *cobra.Command) {
 	createImageCmd.PersistentFlags().BoolVarP(&useV2,
 		"2", "2", false, "Use new image header format (default)")
 	createImageCmd.PersistentFlags().StringVarP(&encKeyFilename,
-		"encrypt", "e", "", "Encrypt image using this public key")
+		"encrypt", "e", "", "Encrypt image using this key")
+	createImageCmd.PersistentFlags().IntVarP(&encKeyIndex,
+		"hw-stored-key", "H", -1, "Hardware stored key index")
+	createImageCmd.PersistentFlags().IntVarP(&hdrPad,
+		"pad-header", "p", 0, "Pad header to this length")
+	createImageCmd.PersistentFlags().IntVarP(&imagePad,
+		"pad-image", "i", 0, "Pad image to this length")
 
 	cmd.AddCommand(createImageCmd)
 	AddTabCompleteFn(createImageCmd, targetList)

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -105,9 +105,9 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 			}
 
 			if useV1 {
-				err = imgprod.ProduceAllV1(b, ver, keys, "")
+				err = imgprod.ProduceAllV1(b, ver, keys, "", -1, -1, -1)
 			} else {
-				err = imgprod.ProduceAll(b, ver, keys, "")
+				err = imgprod.ProduceAll(b, ver, keys, "", -1, -1, -1)
 			}
 			if err != nil {
 				NewtUsage(nil, err)

--- a/newt/imgprod/v1.go
+++ b/newt/imgprod/v1.go
@@ -50,6 +50,7 @@ func produceLoaderV1(opts ImageProdOpts) (ProducedImageV1, error) {
 	igo := image.ImageCreateOpts{
 		SrcBinFilename:    opts.LoaderSrcFilename,
 		SrcEncKeyFilename: opts.EncKeyFilename,
+		SrcEncKeyIndex:    opts.EncKeyIndex,
 		Version:           opts.Version,
 		SigKeys:           opts.SigKeys,
 	}
@@ -101,6 +102,7 @@ func produceAppV1(opts ImageProdOpts,
 	igo := image.ImageCreateOpts{
 		SrcBinFilename:    opts.AppSrcFilename,
 		SrcEncKeyFilename: opts.EncKeyFilename,
+		SrcEncKeyIndex:    opts.EncKeyIndex,
 		Version:           opts.Version,
 		SigKeys:           opts.SigKeys,
 		LoaderHash:        loaderHash,
@@ -206,9 +208,11 @@ func ProduceImagesV1(opts ImageProdOpts) (ProducedImageSetV1, error) {
 }
 
 func ProduceAllV1(t *builder.TargetBuilder, ver image.ImageVersion,
-	sigKeys []sec.PrivSignKey, encKeyFilename string) error {
+	sigKeys []sec.PrivSignKey, encKeyFilename string, encKeyIndex int,
+	hdrPad int, imagePad int) error {
 
-	popts, err := OptsFromTgtBldr(t, ver, sigKeys, encKeyFilename)
+	popts, err := OptsFromTgtBldr(t, ver, sigKeys, encKeyFilename, encKeyIndex,
+		hdrPad, imagePad)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch adds a number of features to support the use of hardware
stored encryption keys.  Specifically, options to denote header padding,
image padding, hw key index, and AES-256-CTR encryption were added.

Images created using the hw encryption keys will result in two additional
TLV types being appended to the image.  The first is a TLV that is used to
store the nonce used for the AES-256-CTR.  The second is a TLV that contains
the hw key index being used to decrypt the image.

Signed-off-by: Andy Gross <andy.gross@juul.com>