### PR TITLE
mfg: Support the "extra_manifest" field per-target and per-raw

### DIFF
--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -42,11 +42,12 @@ import (
 )
 
 type MfgBuildTarget struct {
-	Target  *target.Target
-	Area    flash.FlashArea
-	Offset  int
-	IsBoot  bool
-	BinPath string
+	Target        *target.Target
+	Area          flash.FlashArea
+	Offset        int
+	IsBoot        bool
+	BinPath       string
+	ExtraManifest map[string]interface{}
 }
 
 type MfgBuildRaw struct {
@@ -222,11 +223,12 @@ func newMfgBuildTarget(dt DecodedTarget,
 	isBoot := parse.ValueIsTrue(man.Syscfg["BOOT_LOADER"])
 
 	return MfgBuildTarget{
-		Target:  t,
-		Area:    area,
-		Offset:  dt.Offset,
-		IsBoot:  isBoot,
-		BinPath: targetSrcBinPath(t, isBoot),
+		Target:        t,
+		Area:          area,
+		Offset:        dt.Offset,
+		IsBoot:        isBoot,
+		BinPath:       targetSrcBinPath(t, isBoot),
+		ExtraManifest: dt.ExtraManifest,
 	}, nil
 }
 

--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -51,9 +52,10 @@ type MfgBuildTarget struct {
 }
 
 type MfgBuildRaw struct {
-	Filename string
-	Offset   int
-	Area     flash.FlashArea
+	Filename      string
+	Offset        int
+	Area          flash.FlashArea
+	ExtraManifest map[string]interface{}
 }
 
 type MfgBuildMetaMmr struct {
@@ -246,9 +248,10 @@ func newMfgBuildRaw(dr DecodedRaw,
 	}
 
 	return MfgBuildRaw{
-		Filename: filename,
-		Offset:   dr.Offset,
-		Area:     area,
+		Filename:      path.Clean(filename),
+		Offset:        dr.Offset,
+		Area:          area,
+		ExtraManifest: dr.ExtraManifest,
 	}, nil
 }
 

--- a/newt/mfg/decode.go
+++ b/newt/mfg/decode.go
@@ -40,9 +40,10 @@ type DecodedTarget struct {
 }
 
 type DecodedRaw struct {
-	Filename string
-	Area     string
-	Offset   int
+	Filename      string
+	Area          string
+	Offset        int
+	ExtraManifest map[string]interface{}
 }
 
 type DecodedMmrRef struct {
@@ -226,6 +227,13 @@ func decodeRaw(yamlRaw interface{}, entryIdx int) (DecodedRaw, error) {
 			"mfg raw entry missing required field \"filename\"")
 	}
 	dr.Filename = cast.ToString(filenameVal)
+
+	extra, err := decodeExtra(kv, "extra_manifest")
+	if err != nil {
+		return dr, util.FmtNewtError(
+			"in raw entry %d: %s", entryIdx, err.Error())
+	}
+	dr.ExtraManifest = extra
 
 	return dr, nil
 }

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -50,12 +50,13 @@ type CpEntry struct {
 }
 
 type MfgEmitTarget struct {
-	Name         string
-	Offset       int
-	IsBoot       bool
-	BinPath      string
-	ElfPath      string
-	ManifestPath string
+	Name          string
+	Offset        int
+	IsBoot        bool
+	BinPath       string
+	ElfPath       string
+	ManifestPath  string
+	ExtraManifest map[string]interface{}
 }
 
 type MfgEmitRaw struct {
@@ -121,6 +122,7 @@ func newMfgEmitTarget(bt MfgBuildTarget) (MfgEmitTarget, error) {
 		ElfPath: targetSrcElfPath(bt.Target),
 		ManifestPath: builder.ManifestPath(bt.Target.Name(),
 			builder.BUILD_NAME_APP, bt.Target.App().Name()),
+		ExtraManifest: bt.ExtraManifest,
 	}, nil
 }
 
@@ -367,6 +369,7 @@ func (me *MfgEmitter) emitManifest() ([]byte, error) {
 			Name:         t.Name,
 			ManifestPath: MfgTargetManifestPath(i),
 			Offset:       t.Offset,
+			Extra:        t.ExtraManifest,
 		}
 
 		if t.IsBoot {

--- a/newt/mfg/paths.go
+++ b/newt/mfg/paths.go
@@ -49,6 +49,10 @@ func MfgTargetDir(targetNum int) string {
 	return fmt.Sprintf("targets/%d", targetNum)
 }
 
+func MfgRawDir(rawNum int) string {
+	return fmt.Sprintf("raws/%d", rawNum)
+}
+
 func MfgTargetBinPath(targetNum int) string {
 	return fmt.Sprintf("%s/binary.bin", MfgTargetDir(targetNum))
 }
@@ -67,4 +71,8 @@ func MfgTargetElfPath(targetNum int) string {
 
 func MfgTargetManifestPath(targetNum int) string {
 	return fmt.Sprintf("%s/manifest.json", MfgTargetDir(targetNum))
+}
+
+func MfgRawBinPath(rawNum int) string {
+	return fmt.Sprintf("%s/raw.bin", MfgRawDir(rawNum))
 }


### PR DESCRIPTION
This new field allows an mfgimage definition to specify an "extra_manifest" map for each embedded target or embedded raw.  This map is passed through unchanged to the resulting mfg manifest JSON file with the name "extra".  This field is useful if the user needs to convey additional information to some system that knows how to parse a manufacturing manifest file.

For example, the following `mfg.yml` snippet:

```
    mfg.targets:
        -
            name: 'targets/blinky_dev'
            area: FLASH_AREA_IMAGE_0
            offset: 0
            extra_manifest:
                map:
                    int1: 5
                    int2: 100
                    str: "abc"
                sequence:
                    - 8
                    - 9
                    - 10
```

yields the following `manifest.json` snippet:

```
    "targets": [
      {
        "name": "targets/blinky_dev",
        "offset": 49152,
        "image_path": "targets/0/image.img",
        "hex_path": "targets/0/image.hex",
        "manifest_path": "targets/0/manifest.json",
        "extra": {
          "map": {
            "int1": 5,
            "int2": 100,
            "str": "abc"
          },
          "sequence": [
            8,
            9,
            10
          ]
        }
      }
    ],
```

The above example only consists of a target, but the same could be done with the `mfg.raw` item.