### PR TITLE
Use `util.MoveDir()` instead of `os.Rename()` 

### DIFF
--- a/newt/builder/extcmd.go
+++ b/newt/builder/extcmd.go
@@ -28,8 +28,8 @@ func replaceArtifactsIfChanged(oldDir string, newDir string) error {
 
 	log.Debugf("changes detected; replacing %s with %s", oldDir, newDir)
 	os.RemoveAll(oldDir)
-	if err := os.Rename(newDir, oldDir); err != nil {
-		return util.ChildNewtError(err)
+	if err := util.MoveDir(newDir, oldDir); err != nil {
+		return err
 	}
 
 	return nil

--- a/newt/project/pkgwriter.go
+++ b/newt/project/pkgwriter.go
@@ -201,8 +201,8 @@ func (pw *PackageWriter) fixupPkg() error {
 			if err := os.MkdirAll(filepath.Dir(d2), os.ModePerm); err != nil {
 				return util.ChildNewtError(err)
 			}
-			if err := os.Rename(d1, d2); err != nil {
-				return util.ChildNewtError(err)
+			if err := util.MoveDir(d1, d2); err != nil {
+				return err
 			}
 		}
 	}
@@ -224,8 +224,8 @@ func (pw *PackageWriter) fixupPkg() error {
 	for _, f1 := range files {
 		f2 := replaceText(f1, table)
 		if f2 != f1 {
-			if err := os.Rename(f1, f2); err != nil {
-				return util.ChildNewtError(err)
+			if err := util.MoveDir(f1, f2); err != nil {
+				return err
 			}
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -552,6 +552,13 @@ func CopyDir(srcDirStr, dstDirStr string) error {
 }
 
 func MoveFile(srcFile string, destFile string) error {
+	// First, attempt a rename.  This will succeed if the source and
+	// destination are on the same disk.
+	if err := os.Rename(srcFile, destFile); err == nil {
+		return nil
+	}
+
+	// Otherwise, copy the file and delete the old path.
 	if err := CopyFile(srcFile, destFile); err != nil {
 		return err
 	}
@@ -564,6 +571,13 @@ func MoveFile(srcFile string, destFile string) error {
 }
 
 func MoveDir(srcDir string, destDir string) error {
+	// First, attempt a rename.  This will succeed if the source and
+	// destination are on the same disk.
+	if err := os.Rename(srcDir, destDir); err == nil {
+		return nil
+	}
+
+	// Otherwise, copy the directory and delete the old path.
 	if err := CopyDir(srcDir, destDir); err != nil {
 		return err
 	}


### PR DESCRIPTION
`os.Rename()` fails if the source and destination paths reside on different disks.  The `util.MoveDir()` function handles both cases (same disk and different disks).

Before this PR, a cross-disk rename might cause the newt command to fail with an error like this:

```Error: rename /tmp/mynewt-user-pre-link391870512/src /home/me/repo/bin/targets/my_blinky_sim/user/pre_link/src: invalid cross-device link```