### PR TITLE
Provide method for BSP to override image offset and padding

### DIFF
--- a/newt/imgprod/imgprod.go
+++ b/newt/imgprod/imgprod.go
@@ -277,6 +277,15 @@ func OptsFromTgtBldr(b *builder.TargetBuilder, ver image.ImageVersion,
 	img0Area := b.BspPkg().FlashMap.Areas[flash.FLASH_AREA_NAME_IMAGE_0]
 	baseAddr := img0Area.Offset
 
+	// If there is not a cmd line override, use the BSP values
+	// for header pad and image pad
+	if hdrPad <= 0 {
+		hdrPad = b.BspPkg().ImageOffset
+	}
+	if imagePad <= 0 {
+		imagePad = b.BspPkg().ImagePad
+	}
+
 	opts := ImageProdOpts{
 		AppSrcFilename: b.AppBuilder.AppBinPath(),
 		AppDstFilename: b.AppBuilder.AppImgPath(),

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -42,6 +42,8 @@ type BspPackage struct {
 	DownloadScript     string
 	DebugScript        string
 	OptChkScript       string
+	ImageOffset        int
+	ImagePad           int
 	FlashMap           flashmap.FlashMap
 	BspV               ycfg.YCfg
 }
@@ -125,6 +127,10 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 
 	bsp.CompilerName = bsp.BspV.GetValString("bsp.compiler", settings)
 	bsp.Arch = bsp.BspV.GetValString("bsp.arch", settings)
+
+	bsp.ImageOffset = bsp.BspV.GetValInt("bsp.image_offset", settings)
+
+	bsp.ImagePad = bsp.BspV.GetValInt("bsp.image_pad", settings)
 
 	bsp.LinkerScripts, err = bsp.resolveLinkerScriptSetting(
 		settings, "bsp.linkerscript")


### PR DESCRIPTION
This patch adds the capability to set the image header offset
and image padding values via the BSP file.  Command line settings
override the BSP settings.

Signed-off-by: Andy Gross <andy.gross@juul.com>