### PR TITLE
Fix `newt run <test-pkg>`

### DIFF
--- a/newt/builder/buildutil.go
+++ b/newt/builder/buildutil.go
@@ -140,13 +140,19 @@ func logDepInfo(res *resolve.Resolution) {
 //     * bin/targets/my_blinky_sim/app
 //     * bin/targets/splitty-nrf52dk/loader
 func (b *Builder) binBasePath() (string, error) {
-	if b.appPkg == nil {
-		return "", util.NewNewtError("app package not specified")
+	var rawPath string
+
+	if b.appPkg != nil {
+		rawPath = b.AppBinBasePath()
+	} else if b.testPkg != nil {
+		rawPath = b.TestExePath()
+	} else {
+		return "", util.NewNewtError("no app or test package specified")
 	}
 
 	// Convert the binary path from absolute to relative.  This is required for
 	// Windows compatibility.
-	return util.TryRelPath(b.AppBinBasePath()), nil
+	return util.TryRelPath(rawPath), nil
 }
 
 // BasicEnvVars calculates the basic set of environment variables passed to all

--- a/newt/builder/load.go
+++ b/newt/builder/load.go
@@ -227,6 +227,9 @@ func (b *Builder) debugBin(binPath string, extraJtagCmd string, reset bool,
 		env["NO_GDB"] = "1"
 	}
 
+	// The debug script appends ".elf" to the basename.
+	env["BIN_BASENAME"] = strings.TrimSuffix(env["BIN_BASENAME"], ".elf")
+
 	os.Chdir(project.GetProject().Path())
 
 	RunOptionalCheck(bspPkg.OptChkScript, env)


### PR DESCRIPTION
It is supposed to be possible to run a selftest in gdb with:
```
newt run <test-pkg>
```
This was failing with the following error:
```
Error: app package not specified
```