### PR TITLE
Add size to raw entries in mfg manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
-	github.com/apache/mynewt-artifact v0.0.8
+	github.com/apache/mynewt-artifact v0.0.9
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/apache/mynewt-artifact v0.0.6 h1:VvIdyo61Im7bvE5EGxByM6NzTaKkoqGQL3t1
 github.com/apache/mynewt-artifact v0.0.6/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/apache/mynewt-artifact v0.0.8 h1:as5qSDTT5httEM1IclQM4XgoF9Wn/lTqeoJxV/PvZFw=
 github.com/apache/mynewt-artifact v0.0.8/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.9 h1:Pv/nAD50Zvom6YJ5gzQG7M4jsItPA3txSV/5eelt3Cc=
+github.com/apache/mynewt-artifact v0.0.9/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -24,11 +24,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/apache/mynewt-artifact/errors"
 	"github.com/apache/mynewt-artifact/flash"
 	"github.com/apache/mynewt-artifact/image"
 	"github.com/apache/mynewt-artifact/manifest"
@@ -54,6 +56,7 @@ type MfgBuildTarget struct {
 type MfgBuildRaw struct {
 	Filename      string
 	Offset        int
+	Size          int
 	Area          flash.FlashArea
 	ExtraManifest map[string]interface{}
 }
@@ -247,9 +250,16 @@ func newMfgBuildRaw(dr DecodedRaw,
 		return MfgBuildRaw{}, err
 	}
 
+	st, err := os.Stat(filename)
+	if err != nil {
+		return MfgBuildRaw{}, errors.Wrapf(err,
+			"failed to determine size of file \"%s\"", filename)
+	}
+
 	return MfgBuildRaw{
 		Filename:      path.Clean(filename),
 		Offset:        dr.Offset,
+		Size:          int(st.Size()),
 		Area:          area,
 		ExtraManifest: dr.ExtraManifest,
 	}, nil

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -313,7 +313,7 @@ func (me *MfgEmitter) createSigs() ([]manifest.MfgManifestSig, error) {
 
 		sigs = append(sigs, manifest.MfgManifestSig{
 			Key: hex.EncodeToString(keyHash),
-			Sig: hex.EncodeToString(sig),
+			Sig: hex.EncodeToString(sig.Data),
 		})
 	}
 

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -63,6 +63,7 @@ type MfgEmitTarget struct {
 type MfgEmitRaw struct {
 	Filename      string
 	Offset        int
+	Size          int
 	ExtraManifest map[string]interface{}
 }
 
@@ -132,6 +133,7 @@ func newMfgEmitRaw(br MfgBuildRaw) MfgEmitRaw {
 	return MfgEmitRaw{
 		Filename:      br.Filename,
 		Offset:        br.Area.Offset + br.Offset,
+		Size:          br.Size,
 		ExtraManifest: br.ExtraManifest,
 	}
 }
@@ -391,6 +393,7 @@ func (me *MfgEmitter) emitManifest() ([]byte, error) {
 		mmr := manifest.MfgManifestRaw{
 			Filename: strings.TrimPrefix(r.Filename, basePath+"/"),
 			Offset:   r.Offset,
+			Size:     r.Size,
 			BinPath:  MfgRawBinPath(i),
 			Extra:    r.ExtraManifest,
 		}


### PR DESCRIPTION
The `size` field indicates the amount of flash occupied by the raw entry.