### PR TITLE
Don't emit spurious YCfg parse warnings

### DIFF
--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -123,7 +123,10 @@ func expandFlags(flags []string) {
 // returned.
 func (bpkg *BuildPackage) BuildProfile(b *Builder) string {
 	settings := b.cfg.AllSettingsForLpkg(bpkg.rpkg.Lpkg)
-	return bpkg.rpkg.Lpkg.PkgY.GetValString("pkg.build_profile", settings)
+
+	profile, _ := bpkg.rpkg.Lpkg.PkgY.GetValString("pkg.build_profile", settings)
+
+	return profile
 }
 
 func (bpkg *BuildPackage) CompilerInfo(
@@ -140,16 +143,16 @@ func (bpkg *BuildPackage) CompilerInfo(
 
 	// Read each set of flags and expand repo designators ("@<repo-name>") into
 	// paths.
-	ci.Cflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cflags", settings)
+	ci.Cflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cflags", settings)
 	expandFlags(ci.Cflags)
 
-	ci.CXXflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cxxflags", settings)
+	ci.CXXflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cxxflags", settings)
 	expandFlags(ci.CXXflags)
 
-	ci.Lflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.lflags", settings)
+	ci.Lflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.lflags", settings)
 	expandFlags(ci.Lflags)
 
-	ci.Aflags = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.aflags", settings)
+	ci.Aflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.aflags", settings)
 	expandFlags(ci.Aflags)
 
 	// Package-specific injected settings get specified as C flags on the
@@ -159,7 +162,10 @@ func (bpkg *BuildPackage) CompilerInfo(
 	}
 
 	ci.IgnoreFiles = []*regexp.Regexp{}
-	ignPats := bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.ign_files", settings)
+
+	ignPats, _ := bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+		"pkg.ign_files", settings)
+
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
 		if err != nil {
@@ -170,7 +176,10 @@ func (bpkg *BuildPackage) CompilerInfo(
 	}
 
 	ci.IgnoreDirs = []*regexp.Regexp{}
-	ignPats = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.ign_dirs", settings)
+
+	ignPats, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+		"pkg.ign_dirs", settings)
+
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
 		if err != nil {
@@ -180,7 +189,7 @@ func (bpkg *BuildPackage) CompilerInfo(
 		ci.IgnoreDirs = append(ci.IgnoreDirs, re)
 	}
 
-	bpkg.SourceDirectories = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+	bpkg.SourceDirectories, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
 		"pkg.src_dirs", settings)
 
 	includePaths, err := bpkg.recursiveIncludePaths(b)

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -124,7 +124,8 @@ func expandFlags(flags []string) {
 func (bpkg *BuildPackage) BuildProfile(b *Builder) string {
 	settings := b.cfg.AllSettingsForLpkg(bpkg.rpkg.Lpkg)
 
-	profile, _ := bpkg.rpkg.Lpkg.PkgY.GetValString("pkg.build_profile", settings)
+	profile, err := bpkg.rpkg.Lpkg.PkgY.GetValString("pkg.build_profile", settings)
+	util.OneTimeWarningError(err)
 
 	return profile
 }
@@ -141,18 +142,24 @@ func (bpkg *BuildPackage) CompilerInfo(
 	ci := toolchain.NewCompilerInfo()
 	settings := b.cfg.AllSettingsForLpkg(bpkg.rpkg.Lpkg)
 
+	var err error
+
 	// Read each set of flags and expand repo designators ("@<repo-name>") into
 	// paths.
-	ci.Cflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cflags", settings)
+	ci.Cflags, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cflags", settings)
+	util.OneTimeWarningError(err)
 	expandFlags(ci.Cflags)
 
-	ci.CXXflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cxxflags", settings)
+	ci.CXXflags, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.cxxflags", settings)
+	util.OneTimeWarningError(err)
 	expandFlags(ci.CXXflags)
 
-	ci.Lflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.lflags", settings)
+	ci.Lflags, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.lflags", settings)
+	util.OneTimeWarningError(err)
 	expandFlags(ci.Lflags)
 
-	ci.Aflags, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.aflags", settings)
+	ci.Aflags, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice("pkg.aflags", settings)
+	util.OneTimeWarningError(err)
 	expandFlags(ci.Aflags)
 
 	// Package-specific injected settings get specified as C flags on the
@@ -163,8 +170,9 @@ func (bpkg *BuildPackage) CompilerInfo(
 
 	ci.IgnoreFiles = []*regexp.Regexp{}
 
-	ignPats, _ := bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+	ignPats, err := bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
 		"pkg.ign_files", settings)
+	util.OneTimeWarningError(err)
 
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
@@ -177,8 +185,9 @@ func (bpkg *BuildPackage) CompilerInfo(
 
 	ci.IgnoreDirs = []*regexp.Regexp{}
 
-	ignPats, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+	ignPats, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
 		"pkg.ign_dirs", settings)
+	util.OneTimeWarningError(err)
 
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
@@ -189,8 +198,9 @@ func (bpkg *BuildPackage) CompilerInfo(
 		ci.IgnoreDirs = append(ci.IgnoreDirs, re)
 	}
 
-	bpkg.SourceDirectories, _ = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+	bpkg.SourceDirectories, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
 		"pkg.src_dirs", settings)
+	util.OneTimeWarningError(err)
 
 	includePaths, err := bpkg.recursiveIncludePaths(b)
 	if err != nil {

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -79,7 +79,8 @@ func targetContainsUserFiles(t *target.Target) (bool, error) {
 }
 
 func pkgVarSliceString(pack *pkg.LocalPackage, key string) string {
-	vals := pack.PkgY.GetValStringSlice(key, nil)
+	vals, _ := pack.PkgY.GetValStringSlice(key, nil)
+
 	sort.Strings(vals)
 	var buffer bytes.Buffer
 	for _, v := range vals {
@@ -92,7 +93,7 @@ func pkgVarSliceString(pack *pkg.LocalPackage, key string) string {
 //Process amend command for syscfg target variable
 func amendSysCfg(value string, t *target.Target) error {
 	// Get the current syscfg.vals name-value pairs
-	sysVals := t.Package().SyscfgY.GetValStringMapString("syscfg.vals", nil)
+	sysVals, _ := t.Package().SyscfgY.GetValStringMapString("syscfg.vals", nil)
 
 	// Convert the input syscfg into name-value pairs
 	amendSysVals, err := syscfg.KeyValueFromStr(value)
@@ -125,7 +126,9 @@ func amendSysCfg(value string, t *target.Target) error {
 //Process amend command for aflags, cflags, cxxflags, and lflags target variables.
 func amendBuildFlags(kv []string, t *target.Target) error {
 	pkgVar := "pkg." + kv[0]
-	curFlags := t.Package().PkgY.GetValStringSlice(pkgVar, nil)
+
+	curFlags, _ := t.Package().PkgY.GetValStringSlice(pkgVar, nil)
+
 	amendFlags := strings.Fields(kv[1])
 
 	newFlags := []string{}
@@ -217,8 +220,10 @@ func targetShowCmd(cmd *cobra.Command, args []string) {
 		}
 
 		// A few variables come from the base package rather than the target.
-		kvPairs["syscfg"] = syscfg.KeyValueToStr(
-			target.Package().SyscfgY.GetValStringMapString("syscfg.vals", nil))
+		scfg, _ := target.Package().SyscfgY.GetValStringMapString(
+			"syscfg.vals", nil)
+		kvPairs["syscfg"] = syscfg.KeyValueToStr(scfg)
+
 		kvPairs["cflags"] = pkgVarSliceString(target.Package(), "pkg.cflags")
 		kvPairs["cxxflags"] = pkgVarSliceString(target.Package(), "pkg.cxxflags")
 		kvPairs["lflags"] = pkgVarSliceString(target.Package(), "pkg.lflags")

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -79,7 +79,8 @@ func targetContainsUserFiles(t *target.Target) (bool, error) {
 }
 
 func pkgVarSliceString(pack *pkg.LocalPackage, key string) string {
-	vals, _ := pack.PkgY.GetValStringSlice(key, nil)
+	vals, err := pack.PkgY.GetValStringSlice(key, nil)
+	util.OneTimeWarningError(err)
 
 	sort.Strings(vals)
 	var buffer bytes.Buffer
@@ -93,7 +94,8 @@ func pkgVarSliceString(pack *pkg.LocalPackage, key string) string {
 //Process amend command for syscfg target variable
 func amendSysCfg(value string, t *target.Target) error {
 	// Get the current syscfg.vals name-value pairs
-	sysVals, _ := t.Package().SyscfgY.GetValStringMapString("syscfg.vals", nil)
+	sysVals, err := t.Package().SyscfgY.GetValStringMapString("syscfg.vals", nil)
+	util.OneTimeWarningError(err)
 
 	// Convert the input syscfg into name-value pairs
 	amendSysVals, err := syscfg.KeyValueFromStr(value)
@@ -127,7 +129,8 @@ func amendSysCfg(value string, t *target.Target) error {
 func amendBuildFlags(kv []string, t *target.Target) error {
 	pkgVar := "pkg." + kv[0]
 
-	curFlags, _ := t.Package().PkgY.GetValStringSlice(pkgVar, nil)
+	curFlags, err := t.Package().PkgY.GetValStringSlice(pkgVar, nil)
+	util.OneTimeWarningError(err)
 
 	amendFlags := strings.Fields(kv[1])
 
@@ -220,8 +223,9 @@ func targetShowCmd(cmd *cobra.Command, args []string) {
 		}
 
 		// A few variables come from the base package rather than the target.
-		scfg, _ := target.Package().SyscfgY.GetValStringMapString(
+		scfg, err := target.Package().SyscfgY.GetValStringMapString(
 			"syscfg.vals", nil)
+		util.OneTimeWarningError(err)
 		kvPairs["syscfg"] = syscfg.KeyValueToStr(scfg)
 
 		kvPairs["cflags"] = pkgVarSliceString(target.Package(), "pkg.cflags")

--- a/newt/cli/vars.go
+++ b/newt/cli/vars.go
@@ -58,7 +58,7 @@ func settingValues(settingName string) ([]string, error) {
 
 	packs := project.GetProject().PackagesOfType(-1)
 	for _, pack := range packs {
-		settings :=
+		settings, _ :=
 			pack.(*pkg.LocalPackage).PkgY.GetValStringSlice(settingName, nil)
 
 		for _, setting := range settings {

--- a/newt/cli/vars.go
+++ b/newt/cli/vars.go
@@ -58,8 +58,9 @@ func settingValues(settingName string) ([]string, error) {
 
 	packs := project.GetProject().PackagesOfType(-1)
 	for _, pack := range packs {
-		settings, _ :=
+		settings, err :=
 			pack.(*pkg.LocalPackage).PkgY.GetValStringSlice(settingName, nil)
+		util.OneTimeWarningError(err)
 
 		for _, setting := range settings {
 			settingMap[setting] = struct{}{}

--- a/newt/compat/compat.go
+++ b/newt/compat/compat.go
@@ -106,7 +106,7 @@ func ParseNcTable(strMap map[string]string) (NewtCompatTable, error) {
 
 func ReadNcMap(yc ycfg.YCfg) (NewtCompatMap, error) {
 	mp := NewtCompatMap{}
-	ncMap := yc.GetValStringMap("repo.newt_compatibility", nil)
+	ncMap, _ := yc.GetValStringMap("repo.newt_compatibility", nil)
 
 	for k, v := range ncMap {
 		repoVer, err := newtutil.ParseVersion(k)

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -1055,7 +1055,8 @@ func LoadDownloader(repoName string, repoVars map[string]string) (
 		// Alternatively, the user can put security material in
 		// $HOME/.newt/repos.yml.
 		newtrc := settings.Newtrc()
-		privRepo, _ := newtrc.GetValStringMapString("repository."+repoName, nil)
+		privRepo, err := newtrc.GetValStringMapString("repository."+repoName, nil)
+		util.OneTimeWarningError(err)
 		if privRepo != nil {
 			if gd.Login == "" {
 				gd.Login = privRepo["login"]

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -1055,7 +1055,7 @@ func LoadDownloader(repoName string, repoVars map[string]string) (
 		// Alternatively, the user can put security material in
 		// $HOME/.newt/repos.yml.
 		newtrc := settings.Newtrc()
-		privRepo := newtrc.GetValStringMapString("repository."+repoName, nil)
+		privRepo, _ := newtrc.GetValStringMapString("repository."+repoName, nil)
 		if privRepo != nil {
 			if gd.Login == "" {
 				gd.Login = privRepo["login"]

--- a/newt/logcfg/logcfg.go
+++ b/newt/logcfg/logcfg.go
@@ -157,7 +157,8 @@ func parseOneLog(name string, lpkg *pkg.LocalPackage, logMapItf interface{},
 // are read from the `syscfg.logs` map in the package's `syscfg.yml` file.
 func (lcfg *LCfg) readOnePkg(lpkg *pkg.LocalPackage, cfg *syscfg.Cfg) {
 	lsettings := cfg.AllSettingsForLpkg(lpkg)
-	logMaps := lpkg.SyscfgY.GetValStringMap("syscfg.logs", lsettings)
+	logMaps, _ := lpkg.SyscfgY.GetValStringMap("syscfg.logs", lsettings)
+
 	for name, logMapItf := range logMaps {
 		cl, err := parseOneLog(name, lpkg, logMapItf, cfg)
 		if err != nil {

--- a/newt/logcfg/logcfg.go
+++ b/newt/logcfg/logcfg.go
@@ -157,7 +157,8 @@ func parseOneLog(name string, lpkg *pkg.LocalPackage, logMapItf interface{},
 // are read from the `syscfg.logs` map in the package's `syscfg.yml` file.
 func (lcfg *LCfg) readOnePkg(lpkg *pkg.LocalPackage, cfg *syscfg.Cfg) {
 	lsettings := cfg.AllSettingsForLpkg(lpkg)
-	logMaps, _ := lpkg.SyscfgY.GetValStringMap("syscfg.logs", lsettings)
+	logMaps, err := lpkg.SyscfgY.GetValStringMap("syscfg.logs", lsettings)
+	util.OneTimeWarningError(err)
 
 	for name, logMapItf := range logMaps {
 		cl, err := parseOneLog(name, lpkg, logMapItf, cfg)

--- a/newt/manifest/manifest.go
+++ b/newt/manifest/manifest.go
@@ -303,8 +303,9 @@ func CreateManifest(opts ManifestCreateOpts) (manifest.Manifest, error) {
 	for _, k := range keys {
 		m.TgtVars = append(m.TgtVars, k+"="+vars[k])
 	}
-	syscfgKV, _ := t.GetTarget().Package().SyscfgY.GetValStringMapString(
+	syscfgKV, err := t.GetTarget().Package().SyscfgY.GetValStringMapString(
 		"syscfg.vals", nil)
+	util.OneTimeWarningError(err)
 
 	if len(syscfgKV) > 0 {
 		tgtSyscfg := fmt.Sprintf("target.syscfg=%s",

--- a/newt/manifest/manifest.go
+++ b/newt/manifest/manifest.go
@@ -303,8 +303,9 @@ func CreateManifest(opts ManifestCreateOpts) (manifest.Manifest, error) {
 	for _, k := range keys {
 		m.TgtVars = append(m.TgtVars, k+"="+vars[k])
 	}
-	syscfgKV := t.GetTarget().Package().SyscfgY.GetValStringMapString(
+	syscfgKV, _ := t.GetTarget().Package().SyscfgY.GetValStringMapString(
 		"syscfg.vals", nil)
+
 	if len(syscfgKV) > 0 {
 		tgtSyscfg := fmt.Sprintf("target.syscfg=%s",
 			syscfg.KeyValueToStr(syscfgKV))

--- a/newt/mfg/decode.go
+++ b/newt/mfg/decode.go
@@ -326,7 +326,8 @@ func decodeMeta(
 func decodeMfg(yc ycfg.YCfg) (DecodedMfg, error) {
 	dm := DecodedMfg{}
 
-	yamlTargets := yc.GetValSlice("mfg.targets", nil)
+	yamlTargets, _ := yc.GetValSlice("mfg.targets", nil)
+
 	if yamlTargets != nil {
 		for _, yamlTarget := range yamlTargets {
 			t, err := decodeTarget(yamlTarget)
@@ -338,14 +339,15 @@ func decodeMfg(yc ycfg.YCfg) (DecodedMfg, error) {
 		}
 	}
 
-	dm.Bsp = yc.GetValString("mfg.bsp", nil)
+	dm.Bsp, _ = yc.GetValString("mfg.bsp", nil)
 
 	if len(dm.Targets) == 0 && dm.Bsp == "" {
 		return dm, util.FmtNewtError(
 			"\"mfg.bsp\" field required for mfg images without any targets")
 	}
 
-	itf := yc.GetValSlice("mfg.raw", nil)
+	itf, _ := yc.GetValSlice("mfg.raw", nil)
+
 	slice := cast.ToSlice(itf)
 	if slice != nil {
 		for i, yamlRaw := range slice {
@@ -358,7 +360,8 @@ func decodeMfg(yc ycfg.YCfg) (DecodedMfg, error) {
 		}
 	}
 
-	yamlMeta := yc.GetValStringMap("mfg.meta", nil)
+	yamlMeta, _ := yc.GetValStringMap("mfg.meta", nil)
+
 	if yamlMeta != nil {
 		meta, err := decodeMeta(yamlMeta)
 		if err != nil {

--- a/newt/mfg/decode.go
+++ b/newt/mfg/decode.go
@@ -326,7 +326,8 @@ func decodeMeta(
 func decodeMfg(yc ycfg.YCfg) (DecodedMfg, error) {
 	dm := DecodedMfg{}
 
-	yamlTargets, _ := yc.GetValSlice("mfg.targets", nil)
+	yamlTargets, err := yc.GetValSlice("mfg.targets", nil)
+	util.OneTimeWarningError(err)
 
 	if yamlTargets != nil {
 		for _, yamlTarget := range yamlTargets {
@@ -339,14 +340,16 @@ func decodeMfg(yc ycfg.YCfg) (DecodedMfg, error) {
 		}
 	}
 
-	dm.Bsp, _ = yc.GetValString("mfg.bsp", nil)
+	dm.Bsp, err = yc.GetValString("mfg.bsp", nil)
+	util.OneTimeWarningError(err)
 
 	if len(dm.Targets) == 0 && dm.Bsp == "" {
 		return dm, util.FmtNewtError(
 			"\"mfg.bsp\" field required for mfg images without any targets")
 	}
 
-	itf, _ := yc.GetValSlice("mfg.raw", nil)
+	itf, err := yc.GetValSlice("mfg.raw", nil)
+	util.OneTimeWarningError(err)
 
 	slice := cast.ToSlice(itf)
 	if slice != nil {
@@ -360,7 +363,8 @@ func decodeMfg(yc ycfg.YCfg) (DecodedMfg, error) {
 		}
 	}
 
-	yamlMeta, _ := yc.GetValStringMap("mfg.meta", nil)
+	yamlMeta, err := yc.GetValStringMap("mfg.meta", nil)
+	util.OneTimeWarningError(err)
 
 	if yamlMeta != nil {
 		meta, err := decodeMeta(yamlMeta)

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -57,7 +57,8 @@ func (bsp *BspPackage) resolvePathSetting(
 
 	proj := interfaces.GetProject()
 
-	val, _ := bsp.BspV.GetValString(key, settings)
+	val, err := bsp.BspV.GetValString(key, settings)
+	util.OneTimeWarningError(err)
 	if val == "" {
 		return "", nil
 	}
@@ -78,7 +79,8 @@ func (bsp *BspPackage) resolveLinkerScriptSetting(
 	paths := []string{}
 
 	// Assume config file specifies a list of scripts.
-	vals, _ := bsp.BspV.GetValStringSlice(key, settings)
+	vals, err := bsp.BspV.GetValStringSlice(key, settings)
+	util.OneTimeWarningError(err)
 	if vals == nil {
 		// Couldn't read a list of scripts; try to interpret setting as a
 		// single script.
@@ -125,12 +127,17 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 	}
 	bsp.AddCfgFilename(bsp.BspYamlPath())
 
-	bsp.CompilerName, _ = bsp.BspV.GetValString("bsp.compiler", settings)
-	bsp.Arch, _ = bsp.BspV.GetValString("bsp.arch", settings)
+	bsp.CompilerName, err = bsp.BspV.GetValString("bsp.compiler", settings)
+	util.OneTimeWarningError(err)
 
-	bsp.ImageOffset, _ = bsp.BspV.GetValInt("bsp.image_offset", settings)
+	bsp.Arch, err = bsp.BspV.GetValString("bsp.arch", settings)
+	util.OneTimeWarningError(err)
 
-	bsp.ImagePad, _ = bsp.BspV.GetValInt("bsp.image_pad", settings)
+	bsp.ImageOffset, err = bsp.BspV.GetValInt("bsp.image_offset", settings)
+	util.OneTimeWarningError(err)
+
+	bsp.ImagePad, err = bsp.BspV.GetValInt("bsp.image_pad", settings)
+	util.OneTimeWarningError(err)
 
 	bsp.LinkerScripts, err = bsp.resolveLinkerScriptSetting(
 		settings, "bsp.linkerscript")
@@ -167,7 +174,8 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 			"(bsp.arch)")
 	}
 
-	ymlFlashMap, _ := bsp.BspV.GetValStringMap("bsp.flash_map", settings)
+	ymlFlashMap, err := bsp.BspV.GetValStringMap("bsp.flash_map", settings)
+	util.OneTimeWarningError(err)
 	if ymlFlashMap == nil {
 		return util.NewNewtError("BSP does not specify a flash map " +
 			"(bsp.flash_map)")

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -57,7 +57,7 @@ func (bsp *BspPackage) resolvePathSetting(
 
 	proj := interfaces.GetProject()
 
-	val := bsp.BspV.GetValString(key, settings)
+	val, _ := bsp.BspV.GetValString(key, settings)
 	if val == "" {
 		return "", nil
 	}
@@ -78,7 +78,7 @@ func (bsp *BspPackage) resolveLinkerScriptSetting(
 	paths := []string{}
 
 	// Assume config file specifies a list of scripts.
-	vals := bsp.BspV.GetValStringSlice(key, settings)
+	vals, _ := bsp.BspV.GetValStringSlice(key, settings)
 	if vals == nil {
 		// Couldn't read a list of scripts; try to interpret setting as a
 		// single script.
@@ -125,12 +125,12 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 	}
 	bsp.AddCfgFilename(bsp.BspYamlPath())
 
-	bsp.CompilerName = bsp.BspV.GetValString("bsp.compiler", settings)
-	bsp.Arch = bsp.BspV.GetValString("bsp.arch", settings)
+	bsp.CompilerName, _ = bsp.BspV.GetValString("bsp.compiler", settings)
+	bsp.Arch, _ = bsp.BspV.GetValString("bsp.arch", settings)
 
-	bsp.ImageOffset = bsp.BspV.GetValInt("bsp.image_offset", settings)
+	bsp.ImageOffset, _ = bsp.BspV.GetValInt("bsp.image_offset", settings)
 
-	bsp.ImagePad = bsp.BspV.GetValInt("bsp.image_pad", settings)
+	bsp.ImagePad, _ = bsp.BspV.GetValInt("bsp.image_pad", settings)
 
 	bsp.LinkerScripts, err = bsp.resolveLinkerScriptSetting(
 		settings, "bsp.linkerscript")
@@ -167,7 +167,7 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 			"(bsp.arch)")
 	}
 
-	ymlFlashMap := bsp.BspV.GetValStringMap("bsp.flash_map", settings)
+	ymlFlashMap, _ := bsp.BspV.GetValStringMap("bsp.flash_map", settings)
 	if ymlFlashMap == nil {
 		return util.NewNewtError("BSP does not specify a flash map " +
 			"(bsp.flash_map)")

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -200,10 +200,10 @@ func (pkg *LocalPackage) AddCfgFilename(cfgFilename string) {
 func (pkg *LocalPackage) readDesc(yc ycfg.YCfg) (*PackageDesc, error) {
 	pdesc := &PackageDesc{}
 
-	pdesc.Author = yc.GetValString("pkg.author", nil)
-	pdesc.Homepage = yc.GetValString("pkg.homepage", nil)
-	pdesc.Description = yc.GetValString("pkg.description", nil)
-	pdesc.Keywords = yc.GetValStringSlice("pkg.keywords", nil)
+	pdesc.Author, _ = yc.GetValString("pkg.author", nil)
+	pdesc.Homepage, _ = yc.GetValString("pkg.homepage", nil)
+	pdesc.Description, _ = yc.GetValString("pkg.description", nil)
+	pdesc.Keywords, _ = yc.GetValStringSlice("pkg.keywords", nil)
 
 	return pdesc, nil
 }
@@ -211,7 +211,8 @@ func (pkg *LocalPackage) readDesc(yc ycfg.YCfg) (*PackageDesc, error) {
 func (pkg *LocalPackage) sequenceString(key string) string {
 	var buffer bytes.Buffer
 
-	for _, f := range pkg.PkgY.GetValStringSlice(key, nil) {
+	vals, _ := pkg.PkgY.GetValStringSlice(key, nil)
+	for _, f := range vals {
 		buffer.WriteString("    - " + yaml.EscapeString(f) + "\n")
 	}
 
@@ -299,7 +300,7 @@ func (pkg *LocalPackage) Load() error {
 	pkg.AddCfgFilename(pkg.PkgYamlPath())
 
 	// Set package name from the package
-	pkg.name = pkg.PkgY.GetValString("pkg.name", nil)
+	pkg.name, _ = pkg.PkgY.GetValString("pkg.name", nil)
 	if pkg.name == "" {
 		return util.FmtNewtError(
 			"Package \"%s\" missing \"pkg.name\" field in its `pkg.yml` file",
@@ -312,7 +313,7 @@ func (pkg *LocalPackage) Load() error {
 				"`pkg.yml` file (pkg.name=%s)", pkg.basePath, pkg.name)
 	}
 
-	typeString := pkg.PkgY.GetValString("pkg.type", nil)
+	typeString, _ := pkg.PkgY.GetValString("pkg.type", nil)
 	pkg.packageType = PACKAGE_TYPE_LIB
 	if len(typeString) > 0 {
 		found := false
@@ -332,7 +333,7 @@ func (pkg *LocalPackage) Load() error {
 	}
 
 	if pkg.packageType == PACKAGE_TYPE_TRANSIENT {
-		n := pkg.PkgY.GetValString("pkg.link", nil)
+		n, _ := pkg.PkgY.GetValString("pkg.link", nil)
 		if len(n) == 0 {
 			return util.FmtNewtError(
 				"Transient package \"%s\" does not specify target "+
@@ -366,7 +367,8 @@ func (pkg *LocalPackage) Load() error {
 func (pkg *LocalPackage) InitFuncs(
 	settings map[string]string) map[string]string {
 
-	return pkg.PkgY.GetValStringMapString("pkg.init", settings)
+	vals, _ := pkg.PkgY.GetValStringMapString("pkg.init", settings)
+	return vals
 }
 
 // DownFuncs retrieves the package's shutdown functions.  The returned map has:
@@ -374,25 +376,29 @@ func (pkg *LocalPackage) InitFuncs(
 func (pkg *LocalPackage) DownFuncs(
 	settings map[string]string) map[string]string {
 
-	return pkg.PkgY.GetValStringMapString("pkg.down", settings)
+	vals, _ := pkg.PkgY.GetValStringMapString("pkg.down", settings)
+	return vals
 }
 
 func (pkg *LocalPackage) PreBuildCmds(
 	settings map[string]string) map[string]string {
 
-	return pkg.PkgY.GetValStringMapString("pkg.pre_build_cmds", settings)
+	vals, _ := pkg.PkgY.GetValStringMapString("pkg.pre_build_cmds", settings)
+	return vals
 }
 
 func (pkg *LocalPackage) PreLinkCmds(
 	settings map[string]string) map[string]string {
 
-	return pkg.PkgY.GetValStringMapString("pkg.pre_link_cmds", settings)
+	vals, _ := pkg.PkgY.GetValStringMapString("pkg.pre_link_cmds", settings)
+	return vals
 }
 
 func (pkg *LocalPackage) PostLinkCmds(
 	settings map[string]string) map[string]string {
 
-	return pkg.PkgY.GetValStringMapString("pkg.post_link_cmds", settings)
+	vals, _ := pkg.PkgY.GetValStringMapString("pkg.post_link_cmds", settings)
+	return vals
 }
 
 func (pkg *LocalPackage) InjectedSettings() map[string]string {

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -200,10 +200,19 @@ func (pkg *LocalPackage) AddCfgFilename(cfgFilename string) {
 func (pkg *LocalPackage) readDesc(yc ycfg.YCfg) (*PackageDesc, error) {
 	pdesc := &PackageDesc{}
 
-	pdesc.Author, _ = yc.GetValString("pkg.author", nil)
-	pdesc.Homepage, _ = yc.GetValString("pkg.homepage", nil)
-	pdesc.Description, _ = yc.GetValString("pkg.description", nil)
-	pdesc.Keywords, _ = yc.GetValStringSlice("pkg.keywords", nil)
+	var err error
+
+	pdesc.Author, err = yc.GetValString("pkg.author", nil)
+	util.OneTimeWarningError(err)
+
+	pdesc.Homepage, err = yc.GetValString("pkg.homepage", nil)
+	util.OneTimeWarningError(err)
+
+	pdesc.Description, err = yc.GetValString("pkg.description", nil)
+	util.OneTimeWarningError(err)
+
+	pdesc.Keywords, err = yc.GetValStringSlice("pkg.keywords", nil)
+	util.OneTimeWarningError(err)
 
 	return pdesc, nil
 }
@@ -211,7 +220,8 @@ func (pkg *LocalPackage) readDesc(yc ycfg.YCfg) (*PackageDesc, error) {
 func (pkg *LocalPackage) sequenceString(key string) string {
 	var buffer bytes.Buffer
 
-	vals, _ := pkg.PkgY.GetValStringSlice(key, nil)
+	vals, err := pkg.PkgY.GetValStringSlice(key, nil)
+	util.OneTimeWarningError(err)
 	for _, f := range vals {
 		buffer.WriteString("    - " + yaml.EscapeString(f) + "\n")
 	}
@@ -300,7 +310,8 @@ func (pkg *LocalPackage) Load() error {
 	pkg.AddCfgFilename(pkg.PkgYamlPath())
 
 	// Set package name from the package
-	pkg.name, _ = pkg.PkgY.GetValString("pkg.name", nil)
+	pkg.name, err = pkg.PkgY.GetValString("pkg.name", nil)
+	util.OneTimeWarningError(err)
 	if pkg.name == "" {
 		return util.FmtNewtError(
 			"Package \"%s\" missing \"pkg.name\" field in its `pkg.yml` file",
@@ -313,7 +324,8 @@ func (pkg *LocalPackage) Load() error {
 				"`pkg.yml` file (pkg.name=%s)", pkg.basePath, pkg.name)
 	}
 
-	typeString, _ := pkg.PkgY.GetValString("pkg.type", nil)
+	typeString, err := pkg.PkgY.GetValString("pkg.type", nil)
+	util.OneTimeWarningError(err)
 	pkg.packageType = PACKAGE_TYPE_LIB
 	if len(typeString) > 0 {
 		found := false
@@ -333,7 +345,8 @@ func (pkg *LocalPackage) Load() error {
 	}
 
 	if pkg.packageType == PACKAGE_TYPE_TRANSIENT {
-		n, _ := pkg.PkgY.GetValString("pkg.link", nil)
+		n, err := pkg.PkgY.GetValString("pkg.link", nil)
+		util.OneTimeWarningError(err)
 		if len(n) == 0 {
 			return util.FmtNewtError(
 				"Transient package \"%s\" does not specify target "+
@@ -367,7 +380,8 @@ func (pkg *LocalPackage) Load() error {
 func (pkg *LocalPackage) InitFuncs(
 	settings map[string]string) map[string]string {
 
-	vals, _ := pkg.PkgY.GetValStringMapString("pkg.init", settings)
+	vals, err := pkg.PkgY.GetValStringMapString("pkg.init", settings)
+	util.OneTimeWarningError(err)
 	return vals
 }
 
@@ -376,28 +390,32 @@ func (pkg *LocalPackage) InitFuncs(
 func (pkg *LocalPackage) DownFuncs(
 	settings map[string]string) map[string]string {
 
-	vals, _ := pkg.PkgY.GetValStringMapString("pkg.down", settings)
+	vals, err := pkg.PkgY.GetValStringMapString("pkg.down", settings)
+	util.OneTimeWarningError(err)
 	return vals
 }
 
 func (pkg *LocalPackage) PreBuildCmds(
 	settings map[string]string) map[string]string {
 
-	vals, _ := pkg.PkgY.GetValStringMapString("pkg.pre_build_cmds", settings)
+	vals, err := pkg.PkgY.GetValStringMapString("pkg.pre_build_cmds", settings)
+	util.OneTimeWarningError(err)
 	return vals
 }
 
 func (pkg *LocalPackage) PreLinkCmds(
 	settings map[string]string) map[string]string {
 
-	vals, _ := pkg.PkgY.GetValStringMapString("pkg.pre_link_cmds", settings)
+	vals, err := pkg.PkgY.GetValStringMapString("pkg.pre_link_cmds", settings)
+	util.OneTimeWarningError(err)
 	return vals
 }
 
 func (pkg *LocalPackage) PostLinkCmds(
 	settings map[string]string) map[string]string {
 
-	vals, _ := pkg.PkgY.GetValStringMapString("pkg.post_link_cmds", settings)
+	vals, err := pkg.PkgY.GetValStringMapString("pkg.post_link_cmds", settings)
+	util.OneTimeWarningError(err)
 	return vals
 }
 

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -346,7 +346,7 @@ func (proj *Project) loadRepo(name string, fields map[string]string) (
 }
 
 func (proj *Project) checkNewtVer() error {
-	compatSms := proj.yc.GetValStringMapString(
+	compatSms, _ := proj.yc.GetValStringMapString(
 		"project.newt_compatibility", nil)
 
 	// If this project doesn't have a newt compatibility map, just assume there
@@ -517,7 +517,7 @@ func (proj *Project) loadConfig() error {
 	// we need to process it later.
 	proj.yc = yc
 
-	proj.name = yc.GetValString("project.name", nil)
+	proj.name, _ = yc.GetValString("project.name", nil)
 
 	// Local repository always included in initialization
 	r, err := repo.NewLocalRepo(proj.name)
@@ -536,7 +536,8 @@ func (proj *Project) loadConfig() error {
 	for k, _ := range yc.AllSettings() {
 		repoName := strings.TrimPrefix(k, "repository.")
 		if repoName != k {
-			fields := yc.GetValStringMapString(k, nil)
+			fields, _ := yc.GetValStringMapString(k, nil)
+
 			r, err := proj.loadRepo(repoName, fields)
 			if err != nil {
 				// if `repository.yml` does not exist, it is not an error; we
@@ -572,7 +573,7 @@ func (proj *Project) loadConfig() error {
 		return err
 	}
 
-	ignoreDirs := yc.GetValStringSlice("project.ignore_dirs", nil)
+	ignoreDirs, _ := yc.GetValStringSlice("project.ignore_dirs", nil)
 	for _, ignDir := range ignoreDirs {
 		repoName, dirName, err := newtutil.ParsePackageString(ignDir)
 		if err != nil {

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -346,8 +346,9 @@ func (proj *Project) loadRepo(name string, fields map[string]string) (
 }
 
 func (proj *Project) checkNewtVer() error {
-	compatSms, _ := proj.yc.GetValStringMapString(
+	compatSms, err := proj.yc.GetValStringMapString(
 		"project.newt_compatibility", nil)
+	util.OneTimeWarningError(err)
 
 	// If this project doesn't have a newt compatibility map, just assume there
 	// is no incompatibility.
@@ -517,7 +518,8 @@ func (proj *Project) loadConfig() error {
 	// we need to process it later.
 	proj.yc = yc
 
-	proj.name, _ = yc.GetValString("project.name", nil)
+	proj.name, err = yc.GetValString("project.name", nil)
+	util.OneTimeWarningError(err)
 
 	// Local repository always included in initialization
 	r, err := repo.NewLocalRepo(proj.name)
@@ -536,7 +538,8 @@ func (proj *Project) loadConfig() error {
 	for k, _ := range yc.AllSettings() {
 		repoName := strings.TrimPrefix(k, "repository.")
 		if repoName != k {
-			fields, _ := yc.GetValStringMapString(k, nil)
+			fields, err := yc.GetValStringMapString(k, nil)
+			util.OneTimeWarningError(err)
 
 			r, err := proj.loadRepo(repoName, fields)
 			if err != nil {
@@ -573,7 +576,8 @@ func (proj *Project) loadConfig() error {
 		return err
 	}
 
-	ignoreDirs, _ := yc.GetValStringSlice("project.ignore_dirs", nil)
+	ignoreDirs, err := yc.GetValStringSlice("project.ignore_dirs", nil)
+	util.OneTimeWarningError(err)
 	for _, ignDir := range ignoreDirs {
 		repoName, dirName, err := newtutil.ParsePackageString(ignDir)
 		if err != nil {

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -450,7 +450,8 @@ func parseRepoDepMap(depName string,
 }
 
 func (r *Repo) readDepRepos(yc ycfg.YCfg) error {
-	depMap := yc.GetValStringMap("repo.deps", nil)
+	depMap, _ := yc.GetValStringMap("repo.deps", nil)
+
 	for depName, repoMapYml := range depMap {
 		rdm, err := parseRepoDepMap(depName, repoMapYml)
 		if err != nil {
@@ -477,7 +478,8 @@ func (r *Repo) Read() error {
 		return err
 	}
 
-	versMap := yc.GetValStringMapString("repo.versions", nil)
+	versMap, _ := yc.GetValStringMapString("repo.versions", nil)
+
 	for versStr, commit := range versMap {
 		log.Debugf("Printing version %s for remote repo %s", versStr, r.name)
 		vers, err := newtutil.ParseRepoVersion(versStr)

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -450,7 +450,8 @@ func parseRepoDepMap(depName string,
 }
 
 func (r *Repo) readDepRepos(yc ycfg.YCfg) error {
-	depMap, _ := yc.GetValStringMap("repo.deps", nil)
+	depMap, err := yc.GetValStringMap("repo.deps", nil)
+	util.OneTimeWarningError(err)
 
 	for depName, repoMapYml := range depMap {
 		rdm, err := parseRepoDepMap(depName, repoMapYml)
@@ -478,7 +479,8 @@ func (r *Repo) Read() error {
 		return err
 	}
 
-	versMap, _ := yc.GetValStringMapString("repo.versions", nil)
+	versMap, err := yc.GetValStringMapString("repo.versions", nil)
+	util.OneTimeWarningError(err)
 
 	for versStr, commit := range versMap {
 		log.Debugf("Printing version %s for remote repo %s", versStr, r.name)

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -315,7 +315,8 @@ func parseVersionYml(path string) (newtutil.RepoVersion, error) {
 		}
 	}
 
-	verString, _ := yc.GetValString("repo.version", nil)
+	verString, err := yc.GetValString("repo.version", nil)
+	util.OneTimeWarningError(err)
 
 	if verString == "" {
 		return newtutil.RepoVersion{}, versionYmlBad

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -315,7 +315,8 @@ func parseVersionYml(path string) (newtutil.RepoVersion, error) {
 		}
 	}
 
-	verString := yc.GetValString("repo.version", nil)
+	verString, _ := yc.GetValString("repo.version", nil)
+
 	if verString == "" {
 		return newtutil.RepoVersion{}, versionYmlBad
 	}

--- a/newt/resolve/expr.go
+++ b/newt/resolve/expr.go
@@ -30,7 +30,7 @@ func getExprMapStringSlice(
 	yc ycfg.YCfg, key string, settings map[string]string) (
 	map[*parse.Node][]string, error) {
 
-	entries := yc.GetSlice(key, settings)
+	entries, _ := yc.GetSlice(key, settings)
 	if len(entries) == 0 {
 		return nil, nil
 	}

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -39,7 +39,7 @@ const NEWTRC_FILENAME string = "newtrc.yml"
 var newtrc *ycfg.YCfg
 
 func processNewtrc(yc ycfg.YCfg) {
-	s := yc.GetValString("escape_shell", nil)
+	s, _ := yc.GetValString("escape_shell", nil)
 	if s != "" {
 		b, err := strconv.ParseBool(s)
 		if err != nil {

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -538,7 +538,8 @@ func (cfg *Cfg) readDefsOnce(lpkg *pkg.LocalPackage,
 
 	lsettings := cfg.settingsForLpkg(lpkg, settings)
 
-	defs, _ := yc.GetValStringMap("syscfg.defs", lsettings)
+	defs, err := yc.GetValStringMap("syscfg.defs", lsettings)
+	util.OneTimeWarningError(err)
 
 	if defs != nil {
 		for k, v := range defs {
@@ -603,7 +604,8 @@ func (cfg *Cfg) readRestrictions(lpkg *pkg.LocalPackage,
 	yc := lpkg.SyscfgY
 	lsettings := cfg.settingsForLpkg(lpkg, settings)
 
-	restrictionStrings, _ := yc.GetValStringSlice("syscfg.restrictions", lsettings)
+	restrictionStrings, err := yc.GetValStringSlice("syscfg.restrictions", lsettings)
+	util.OneTimeWarningError(err)
 
 	for _, rstring := range restrictionStrings {
 		r, err := readRestriction("", rstring)
@@ -623,7 +625,8 @@ func (cfg *Cfg) readValsOnce(lpkg *pkg.LocalPackage,
 
 	lsettings := cfg.settingsForLpkg(lpkg, settings)
 
-	values, _ := yc.GetValStringMap("syscfg.vals", lsettings)
+	values, err := yc.GetValStringMap("syscfg.vals", lsettings)
+	util.OneTimeWarningError(err)
 
 	for k, v := range values {
 		switch v.(type) {

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -538,7 +538,8 @@ func (cfg *Cfg) readDefsOnce(lpkg *pkg.LocalPackage,
 
 	lsettings := cfg.settingsForLpkg(lpkg, settings)
 
-	defs := yc.GetValStringMap("syscfg.defs", lsettings)
+	defs, _ := yc.GetValStringMap("syscfg.defs", lsettings)
+
 	if defs != nil {
 		for k, v := range defs {
 			vals, ok := v.(map[interface{}]interface{})
@@ -602,7 +603,8 @@ func (cfg *Cfg) readRestrictions(lpkg *pkg.LocalPackage,
 	yc := lpkg.SyscfgY
 	lsettings := cfg.settingsForLpkg(lpkg, settings)
 
-	restrictionStrings := yc.GetValStringSlice("syscfg.restrictions", lsettings)
+	restrictionStrings, _ := yc.GetValStringSlice("syscfg.restrictions", lsettings)
+
 	for _, rstring := range restrictionStrings {
 		r, err := readRestriction("", rstring)
 		if err != nil {
@@ -621,7 +623,8 @@ func (cfg *Cfg) readValsOnce(lpkg *pkg.LocalPackage,
 
 	lsettings := cfg.settingsForLpkg(lpkg, settings)
 
-	values := yc.GetValStringMap("syscfg.vals", lsettings)
+	values, _ := yc.GetValStringMap("syscfg.vals", lsettings)
+
 	for k, v := range values {
 		switch v.(type) {
 		case map[interface{}]interface{}, []interface{}:

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -484,20 +484,20 @@ func readSetting(name string, lpkg *pkg.LocalPackage,
 		for i, choice := range choices {
 			if !cfgChoiceValRe.MatchString(choice) {
 				return entry, util.FmtNewtError(
-					"setting %s has invalid choice defined (%s) - " +
+					"setting %s has invalid choice defined (%s) - "+
 						"only letters, numbers and underscore are allowed", name, choice)
 			}
 
-			if i > 0 && strings.ToLower(choices[i - 1]) == strings.ToLower(choice) {
+			if i > 0 && strings.ToLower(choices[i-1]) == strings.ToLower(choice) {
 				return entry, util.FmtNewtError(
 					"setting %s has duplicated choice defined ('%s' and '%s')",
-					name, choice, choices[i - 1])
+					name, choice, choices[i-1])
 			}
 		}
 
 		r := CfgRestriction{
 			BaseSetting: name,
-			Code: CFG_RESTRICTION_CODE_CHOICE,
+			Code:        CFG_RESTRICTION_CODE_CHOICE,
 		}
 
 		entry.Restrictions = append(entry.Restrictions, r)

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -88,25 +88,27 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 
 	target.TargetY = yc
 
-	target.BspName = yc.GetValString("target.bsp", nil)
-	target.AppName = yc.GetValString("target.app", nil)
-	target.LoaderName = yc.GetValString("target.loader", nil)
+	target.BspName, _ = yc.GetValString("target.bsp", nil)
+	target.AppName, _ = yc.GetValString("target.app", nil)
+	target.LoaderName, _ = yc.GetValString("target.loader", nil)
 
-	target.BuildProfile = yc.GetValString("target.build_profile", nil)
+	target.BuildProfile, _ = yc.GetValString("target.build_profile", nil)
 	if target.BuildProfile == "" {
 		target.BuildProfile = DEFAULT_BUILD_PROFILE
 	}
 
 	target.HeaderSize = DEFAULT_HEADER_SIZE
-	if yc.GetValString("target.header_size", nil) != "" {
-		hs, err := strconv.ParseUint(
-			yc.GetValString("target.header_size", nil), 0, 32)
+
+	hsStr, _ := yc.GetValString("target.header_size", nil)
+	if hsStr != "" {
+		hs, err := strconv.ParseUint(hsStr, 0, 32)
 		if err == nil {
 			target.HeaderSize = uint32(hs)
 		}
 	}
 
-	target.KeyFile = yc.GetValString("target.key_file", nil)
+	target.KeyFile, _ = yc.GetValString("target.key_file", nil)
+
 	if target.KeyFile != "" {
 		proj := interfaces.GetProject()
 		path, err := proj.ResolvePath(proj.Path(), target.KeyFile)
@@ -115,7 +117,7 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 		}
 	}
 
-	target.PkgProfiles = yc.GetValStringMapString(
+	target.PkgProfiles, _ = yc.GetValStringMapString(
 		"target.package_profiles", nil)
 
 	// Note: App not required in the case of unit tests.

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -88,18 +88,26 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 
 	target.TargetY = yc
 
-	target.BspName, _ = yc.GetValString("target.bsp", nil)
-	target.AppName, _ = yc.GetValString("target.app", nil)
-	target.LoaderName, _ = yc.GetValString("target.loader", nil)
+	target.BspName, err = yc.GetValString("target.bsp", nil)
+	util.OneTimeWarningError(err)
 
-	target.BuildProfile, _ = yc.GetValString("target.build_profile", nil)
+	target.AppName, err = yc.GetValString("target.app", nil)
+	util.OneTimeWarningError(err)
+
+	target.LoaderName, err = yc.GetValString("target.loader", nil)
+	util.OneTimeWarningError(err)
+
+	target.BuildProfile, err = yc.GetValString("target.build_profile", nil)
+	util.OneTimeWarningError(err)
+
 	if target.BuildProfile == "" {
 		target.BuildProfile = DEFAULT_BUILD_PROFILE
 	}
 
 	target.HeaderSize = DEFAULT_HEADER_SIZE
 
-	hsStr, _ := yc.GetValString("target.header_size", nil)
+	hsStr, err := yc.GetValString("target.header_size", nil)
+	util.OneTimeWarningError(err)
 	if hsStr != "" {
 		hs, err := strconv.ParseUint(hsStr, 0, 32)
 		if err == nil {
@@ -107,7 +115,8 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 		}
 	}
 
-	target.KeyFile, _ = yc.GetValString("target.key_file", nil)
+	target.KeyFile, err = yc.GetValString("target.key_file", nil)
+	util.OneTimeWarningError(err)
 
 	if target.KeyFile != "" {
 		proj := interfaces.GetProject()
@@ -117,8 +126,9 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 		}
 	}
 
-	target.PkgProfiles, _ = yc.GetValStringMapString(
+	target.PkgProfiles, err = yc.GetValStringMapString(
 		"target.package_profiles", nil)
+	util.OneTimeWarningError(err)
 
 	// Note: App not required in the case of unit tests.
 

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -277,10 +277,12 @@ func NewCompiler(compilerDir string, dstDir string,
 func loadFlags(yc ycfg.YCfg, settings map[string]string, key string) []string {
 	flags := []string{}
 
-	rawFlags := yc.GetValStringSlice(key, settings)
+	rawFlags, _ := yc.GetValStringSlice(key, settings)
+
 	for _, rawFlag := range rawFlags {
 		if strings.HasPrefix(rawFlag, key) {
-			expandedFlags := yc.GetValStringSlice(rawFlag, settings)
+			expandedFlags, _ := yc.GetValStringSlice(rawFlag, settings)
+
 			flags = append(flags, expandedFlags...)
 		} else {
 			flags = append(flags, strings.Trim(rawFlag, "\n"))
@@ -301,23 +303,24 @@ func (c *Compiler) load(compilerDir string, buildProfile string) error {
 		strings.ToUpper(runtime.GOOS): "1",
 	}
 
-	c.ccPath = yc.GetValString("compiler.path.cc", settings)
-	c.cppPath = yc.GetValString("compiler.path.cpp", settings)
-	c.asPath = yc.GetValString("compiler.path.as", settings)
-	c.arPath = yc.GetValString("compiler.path.archive", settings)
-	c.odPath = yc.GetValString("compiler.path.objdump", settings)
-	c.osPath = yc.GetValString("compiler.path.objsize", settings)
-	c.ocPath = yc.GetValString("compiler.path.objcopy", settings)
+	c.ccPath, _ = yc.GetValString("compiler.path.cc", settings)
+	c.cppPath, _ = yc.GetValString("compiler.path.cpp", settings)
+	c.asPath, _ = yc.GetValString("compiler.path.as", settings)
+	c.arPath, _ = yc.GetValString("compiler.path.archive", settings)
+	c.odPath, _ = yc.GetValString("compiler.path.objdump", settings)
+	c.osPath, _ = yc.GetValString("compiler.path.objsize", settings)
+	c.ocPath, _ = yc.GetValString("compiler.path.objcopy", settings)
 
 	c.lclInfo.Cflags = loadFlags(yc, settings, "compiler.flags")
 	c.lclInfo.CXXflags = loadFlags(yc, settings, "compiler.cxx.flags")
 	c.lclInfo.Lflags = loadFlags(yc, settings, "compiler.ld.flags")
 	c.lclInfo.Aflags = loadFlags(yc, settings, "compiler.as.flags")
 
-	c.ldResolveCircularDeps = yc.GetValBool(
+	c.ldResolveCircularDeps, _ = yc.GetValBool(
 		"compiler.ld.resolve_circular_deps", settings)
-	c.ldMapFile = yc.GetValBool("compiler.ld.mapfile", settings)
-	c.ldBinFile = yc.GetValBoolDflt("compiler.ld.binfile", settings, true)
+
+	c.ldMapFile, _ = yc.GetValBool("compiler.ld.mapfile", settings)
+	c.ldBinFile, _ = yc.GetValBoolDflt("compiler.ld.binfile", settings, true)
 
 	if len(c.lclInfo.Cflags) == 0 {
 		// Assume no Cflags implies an unsupported build profile.

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -277,11 +277,13 @@ func NewCompiler(compilerDir string, dstDir string,
 func loadFlags(yc ycfg.YCfg, settings map[string]string, key string) []string {
 	flags := []string{}
 
-	rawFlags, _ := yc.GetValStringSlice(key, settings)
+	rawFlags, err := yc.GetValStringSlice(key, settings)
+	util.OneTimeWarningError(err)
 
 	for _, rawFlag := range rawFlags {
 		if strings.HasPrefix(rawFlag, key) {
-			expandedFlags, _ := yc.GetValStringSlice(rawFlag, settings)
+			expandedFlags, err := yc.GetValStringSlice(rawFlag, settings)
+			util.OneTimeWarningError(err)
 
 			flags = append(flags, expandedFlags...)
 		} else {
@@ -303,24 +305,41 @@ func (c *Compiler) load(compilerDir string, buildProfile string) error {
 		strings.ToUpper(runtime.GOOS): "1",
 	}
 
-	c.ccPath, _ = yc.GetValString("compiler.path.cc", settings)
-	c.cppPath, _ = yc.GetValString("compiler.path.cpp", settings)
-	c.asPath, _ = yc.GetValString("compiler.path.as", settings)
-	c.arPath, _ = yc.GetValString("compiler.path.archive", settings)
-	c.odPath, _ = yc.GetValString("compiler.path.objdump", settings)
-	c.osPath, _ = yc.GetValString("compiler.path.objsize", settings)
-	c.ocPath, _ = yc.GetValString("compiler.path.objcopy", settings)
+	c.ccPath, err = yc.GetValString("compiler.path.cc", settings)
+	util.OneTimeWarningError(err)
+
+	c.cppPath, err = yc.GetValString("compiler.path.cpp", settings)
+	util.OneTimeWarningError(err)
+
+	c.asPath, err = yc.GetValString("compiler.path.as", settings)
+	util.OneTimeWarningError(err)
+
+	c.arPath, err = yc.GetValString("compiler.path.archive", settings)
+	util.OneTimeWarningError(err)
+
+	c.odPath, err = yc.GetValString("compiler.path.objdump", settings)
+	util.OneTimeWarningError(err)
+
+	c.osPath, err = yc.GetValString("compiler.path.objsize", settings)
+	util.OneTimeWarningError(err)
+
+	c.ocPath, err = yc.GetValString("compiler.path.objcopy", settings)
+	util.OneTimeWarningError(err)
 
 	c.lclInfo.Cflags = loadFlags(yc, settings, "compiler.flags")
 	c.lclInfo.CXXflags = loadFlags(yc, settings, "compiler.cxx.flags")
 	c.lclInfo.Lflags = loadFlags(yc, settings, "compiler.ld.flags")
 	c.lclInfo.Aflags = loadFlags(yc, settings, "compiler.as.flags")
 
-	c.ldResolveCircularDeps, _ = yc.GetValBool(
+	c.ldResolveCircularDeps, err = yc.GetValBool(
 		"compiler.ld.resolve_circular_deps", settings)
+	util.OneTimeWarningError(err)
 
-	c.ldMapFile, _ = yc.GetValBool("compiler.ld.mapfile", settings)
-	c.ldBinFile, _ = yc.GetValBoolDflt("compiler.ld.binfile", settings, true)
+	c.ldMapFile, err = yc.GetValBool("compiler.ld.mapfile", settings)
+	util.OneTimeWarningError(err)
+
+	c.ldBinFile, err = yc.GetValBoolDflt("compiler.ld.binfile", settings, true)
+	util.OneTimeWarningError(err)
 
 	if len(c.lclInfo.Cflags) == 0 {
 		// Assume no Cflags implies an unsupported build profile.

--- a/util/util.go
+++ b/util/util.go
@@ -854,6 +854,14 @@ func OneTimeWarning(text string, args ...interface{}) {
 	}
 }
 
+// OneTimeWarningError displays the text of the specified error as a warning if
+// it has not been displayed yet.  No-op if nil is passed in.
+func OneTimeWarningError(err error) {
+	if err != nil {
+		OneTimeWarning("%s", err.Error())
+	}
+}
+
 func MarshalJSONStringer(sr fmt.Stringer) ([]byte, error) {
 	s := sr.String()
 	j, err := json.Marshal(s)


### PR DESCRIPTION
### Background

When newt processes a YAML file, it converts it into a tree form called a YCfg.  For example, this YAML excerpt:

```
OS_MAIN_STACK_SIZE: 100
OS_MAIN_STACK_SIZE.'BLE_MAX_CONNECTIONS > 3': 200
OS_MAIN_STACK_SIZE.SHELL_TASK: 300
```

Is represented as the following tree:

```
                     [OS_MAIN_STACK_SIZE (100)]
                    /                          \
      [BLE_MAX_CONNECTIONS > 3 (200)]      [SHELL_TASK (300)]
```

This YCfg object contains three nodes.  Some of these nodes may be "inactive" in the sense that a required setting is not enabled (e.g., if `SHELL_TASK` is disabled then the rightmost node is inactive).  We don't know which nodes are inactive because we don't have a list of enabled settings when the YCfg is created.

We only know which nodes are active when someone retrieves a value from the tree with a "Get" function.  All the Get functions take a `settings` map parameter which allows the tree to be properly interpreted.  With the list of settings available, the Get functions can identify problems in the tree.  For example, if `BLE_MAX_CONNECTIONS` is configured with a value of "foo", then the expression

```
BLE_MAX_CONNECTIONS > 3
```

cannot be evaluated.  When the Get functions spot a problem like this, they print a warning to the console and ignore the problematic node.

(Perhaps we should convert the YCfg to another "more processed" form after we have calculated the list of settings.  That way we wouldn't need to do any processing in the Get functions.  But that is probably a bigger discussion for another time.)

### Problem

It's a little odd to be doing so much evaluation in a Get function, but this design has worked for the most part.  However, a problem arises when a condition involving a numeric comparison is applied to `pkg.deps`.  For example (from `sys/log/full/pkg.yml`):

```
pkg.deps.'LOG_CONSOLE && LOG_VERSION > 2':
```

This is a problem because newt retrieves `pkg.deps` from each package before it has done syscfg resolution.  The issue is that we can't know what syscfg is until we know the full list of packages included in the build (since each package defines and overrides settings).  We also can't know the full list of packages until we know what syscfg is, since some dependencies are conditional on syscfg settings (as in the example above).  So newt has to repeat a few steps in the process until everything has been fully resolved.  But because newt doesn't know the syscfg definition the first time it encounters the above `pkg.deps` specifier, the `LOG_VERSION` setting is not defined.  The comparison of an undefined setting agains `2` fails and newt prints a warning.  This warning is wrong; `LOG_VERSION` is a valid setting with a numeric value, newt just doesn't know that yet.


### Solution

The solution is to:

1. Remove the warning-printing code from the YCfg Get functions.
2. Change the YCfg Get functions so that they return the parse warnings as an `error` object.

Most code that retrieves values from YCfgs just takes the returned error and prints a warning.  In these cases there is no change in behavior.

During dependency resolution however, any returned errors do not get printed to the screen.  Instead, these warnings are retained for later use.  The previous cycle's warnings are cleared each time a new cycle starts.  After resolution has completed, the retained warnings are printed.  In this way, none of the printed warnings are spurious because they were reported during the final iteration.

### Simple Test

1. Build a target that depends on `sys/log/full`. Ensure no warning is displayed.
2. Modify `sys/log/full/pkg.yml` as follows:
```
@@ -46 +46 @@ pkg.deps.LOG_CLI:
-pkg.deps.'LOG_CONSOLE && LOG_VERSION > 2':
+pkg.deps.'LOG_CONSOLE && LOG_VERSIONx > 2':
```
(i.e., change `LOG_VERSION` to `LOG_VERSIONx`

3. Rebuild the target.  Ensure you see a warning like this one:
```
WARNING: /Users/ccollins/repos/juul-platform/repos/apache-mynewt-core/sys/log/full/pkg.yml: cannot apply > to `LOG_VERSIONx`; operand not a number
```