### PR TITLE
mfg: Copy user-specified files to raw output directory

### DIFF
--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -58,6 +58,7 @@ type MfgBuildRaw struct {
 	Offset        int
 	Size          int
 	Area          flash.FlashArea
+	ExtraFiles    []string
 	ExtraManifest map[string]interface{}
 }
 
@@ -240,9 +241,19 @@ func newMfgBuildTarget(dt DecodedTarget,
 func newMfgBuildRaw(dr DecodedRaw,
 	fm flashmap.FlashMap, basePath string) (MfgBuildRaw, error) {
 
-	filename := dr.Filename
-	if !strings.HasPrefix(filename, "/") {
-		filename = basePath + "/" + filename
+	pathToBase := func(s string) string {
+		if !strings.HasPrefix(s, "/") {
+			s = basePath + "/" + s
+		}
+
+		return filepath.Clean(s)
+	}
+
+	filename := pathToBase(dr.Filename)
+
+	var extraFiles []string
+	for _, ef := range dr.ExtraFiles {
+		extraFiles = append(extraFiles, pathToBase(ef))
 	}
 
 	area, err := lookUpArea(fm, dr.Area)
@@ -261,6 +272,7 @@ func newMfgBuildRaw(dr DecodedRaw,
 		Offset:        dr.Offset,
 		Size:          int(st.Size()),
 		Area:          area,
+		ExtraFiles:    extraFiles,
 		ExtraManifest: dr.ExtraManifest,
 	}, nil
 }

--- a/newt/mfg/decode.go
+++ b/newt/mfg/decode.go
@@ -43,6 +43,7 @@ type DecodedRaw struct {
 	Filename      string
 	Area          string
 	Offset        int
+	ExtraFiles    []string
 	ExtraManifest map[string]interface{}
 }
 
@@ -227,6 +228,16 @@ func decodeRaw(yamlRaw interface{}, entryIdx int) (DecodedRaw, error) {
 			"mfg raw entry missing required field \"filename\"")
 	}
 	dr.Filename = cast.ToString(filenameVal)
+
+	if itf, ok := kv["extra_files"]; ok {
+		extraFiles, err := cast.ToStringSliceE(itf)
+		if err != nil {
+			return dr, util.FmtNewtError(
+				"mfg raw entry contains invalid \"extra_files\" field: "+
+					"have=%T want=[]string", itf)
+		}
+		dr.ExtraFiles = extraFiles
+	}
 
 	extra, err := decodeExtra(kv, "extra_manifest")
 	if err != nil {

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -64,6 +64,7 @@ type MfgEmitRaw struct {
 	Filename      string
 	Offset        int
 	Size          int
+	ExtraFiles    []string
 	ExtraManifest map[string]interface{}
 }
 
@@ -134,6 +135,7 @@ func newMfgEmitRaw(br MfgBuildRaw) MfgEmitRaw {
 		Filename:      br.Filename,
 		Offset:        br.Area.Offset + br.Offset,
 		Size:          br.Size,
+		ExtraFiles:    br.ExtraFiles,
 		ExtraManifest: br.ExtraManifest,
 	}
 }
@@ -250,12 +252,25 @@ func (me *MfgEmitter) calcCpEntriesTarget(mt MfgEmitTarget, idx int) []CpEntry {
 }
 
 func (me *MfgEmitter) calcCpEntriesRaw(mr MfgEmitRaw, idx int) []CpEntry {
-	entry := CpEntry{
-		From: mr.Filename,
-		To:   MfgRawBinPath(me.Name, idx),
+	var entries []CpEntry
+
+	// Include `.bin` file.
+	entries = append(entries,
+		CpEntry{
+			From: mr.Filename,
+			To:   MfgRawBinPath(me.Name, idx),
+		})
+
+	// Include each extra file.
+	for _, ef := range mr.ExtraFiles {
+		entries = append(entries, CpEntry{
+			From: ef,
+			To: MfgRawDir(me.Name, idx) + "/" +
+				filepath.Base(ef),
+		})
 	}
 
-	return []CpEntry{entry}
+	return entries
 }
 
 // Calculates the necessary file copy operations for emitting an mfg image.


### PR DESCRIPTION
In a `mfg.yml` file, a "raw" section can specify a list of files in
under `extra_files`.  At mfg-build time, the listed files get copied
into the raw's binary directory.  This might be useful if some external
system requires additional information to interpret the raw sections in
an mfgimage.

For example:
```
    mfg.raw:
        name: '../../bin/myraw.bin'
        offset: 0
        area: FLASH_AREA_BOOTLOADER
        extra_files:
            - '../../bin/readme.txt'
            - '../../bin/manifest.json'
```

All paths are relative to the mfg package.
```
    $ newt mfg create mymfg 1.2.3
    [...]
    Generated the following files:
        /home/me/mynewt/bin/mfgs/mymfg/manifest.json
        /home/me/mynewt/bin/mfgs/mymfg/mfgimg.bin
        /home/me/mynewt/bin/mfgs/mymfg/mfgimg.hex
        /home/me/mynewt/bin/mfgs/mymfg/raws/0/manifest.json
        /home/me/mynewt/bin/mfgs/mymfg/raws/0/myraw.bin
        /home/me/mynewt/bin/mfgs/mymfg/raws/0/readme.txt
        /home/me/mynewt/bin/mfgs/mymfg/targets/0/elf.elf
        /home/me/mynewt/bin/mfgs/mymfg/targets/0/image.hex
        /home/me/mynewt/bin/mfgs/mymfg/targets/0/image.img
        /home/me/mynewt/bin/mfgs/mymfg/targets/0/manifest.json
```