### PR TITLE
Include custom commands in `newt dump` output

### DIFF
--- a/newt/dump/dump.go
+++ b/newt/dump/dump.go
@@ -34,6 +34,9 @@ type Report struct {
 	Syscfg          Syscfg              `json:"syscfg"`
 	Sysinit         Sysinit             `json:"sysinit"`
 	Sysdown         Sysdown             `json:"sysdown"`
+	PreBuildCmds    ExtCmd              `json:"pre_build_cmds"`
+	PreLinkCmds     ExtCmd              `json:"pre_link_cmds"`
+	PostLinkCmds    ExtCmd              `json:"post_link_cmds"`
 	Logcfg          Logcfg              `json:"logcfg"`
 	ApiMap          map[string]string   `json:"api_map"`
 	UnsatisfiedApis map[string][]string `json:"unsatisfied_apis"`
@@ -76,6 +79,21 @@ func NewReport(tb *builder.TargetBuilder) (Report, error) {
 		return report, err
 	}
 	report.Sysdown = sd
+
+	report.PreBuildCmds, err = newExtCmd(res.PreBuildCmdCfg)
+	if err != nil {
+		return report, err
+	}
+
+	report.PreLinkCmds, err = newExtCmd(res.PreLinkCmdCfg)
+	if err != nil {
+		return report, err
+	}
+
+	report.PostLinkCmds, err = newExtCmd(res.PostLinkCmdCfg)
+	if err != nil {
+		return report, err
+	}
 
 	lc, err := newLogcfg(res.LCfg)
 	if err != nil {

--- a/newt/dump/extcmd.go
+++ b/newt/dump/extcmd.go
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package dump
+
+import (
+	"strconv"
+
+	"mynewt.apache.org/newt/newt/extcmd"
+	"mynewt.apache.org/newt/util"
+)
+
+type ExtCmdFunc struct {
+	Cmd     string `json:"cmd"`
+	Stage   int    `json:"stage"`
+	PkgName string `json:"package"`
+}
+
+type ExtCmd struct {
+	Cmds []ExtCmdFunc `json:"cmds"`
+}
+
+func newExtCmd(scfg extcmd.ExtCmdCfg) (ExtCmd, error) {
+	cmds := make([]ExtCmdFunc, len(scfg.StageFuncs))
+	for i, f := range scfg.StageFuncs {
+		stage, err := strconv.Atoi(f.Stage.Value)
+		if err != nil {
+			return ExtCmd{}, util.ChildNewtError(err)
+		}
+		cmds[i] = ExtCmdFunc{
+			Cmd:     f.Name,
+			Stage:   stage,
+			PkgName: f.Pkg.FullName(),
+		}
+	}
+
+	return ExtCmd{
+		Cmds: cmds,
+	}, nil
+}


### PR DESCRIPTION
This allows the travis "dump tests" to verify that newt correctly parses the custom command fields in `pkg.yml` files.

NOTE: This PR will break CI.  After it gets merged, I will update the travis tests to expect the changed "dump" output.