### PR TITLE
imgprod: Close .img before passing it to objcopy

### DIFF
--- a/newt/imgprod/imgprod.go
+++ b/newt/imgprod/imgprod.go
@@ -77,9 +77,10 @@ func writeImageFiles(ri image.Image, imgFilename string, hexFilename string,
 		return util.FmtNewtError(
 			"can't open image file \"%s\" %s", imgFilename, err.Error())
 	}
-	defer imgFile.Close()
 
-	if _, err := ri.Write(imgFile); err != nil {
+	_, err = ri.Write(imgFile)
+	imgFile.Close()
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This fixes a bug in the Windows port of newt.

Newt produces a .hex file by running `objcopy` on the .img file.  It was doing this immediately after creating the .img file, before closing it. In Windows, objcopy cannot open a file when it is already open by a different process, so the command fails.

The fix is to close the .img file before executing objcopy.