### PR TITLE
Allow repo hash to correspond to version number

### DIFF
--- a/newt/deprepo/deprepo.go
+++ b/newt/deprepo/deprepo.go
@@ -75,11 +75,13 @@ func (rm RepoMap) Sorted() []*repo.Repo {
 func (vm VersionMap) String() string {
 	s := ""
 
-	for repoName, ver := range vm {
+	names := vm.SortedNames()
+	for _, name := range names {
+		ver := vm[name]
 		if len(s) > 0 {
 			s += "\n"
 		}
-		s += fmt.Sprintf("%s:%s", repoName, ver.String())
+		s += fmt.Sprintf("%s:%s", name, ver.String())
 	}
 	return s
 }


### PR DESCRIPTION
When resolving repo versions, newt uses this procedure:

1. Resolve inter-repo dependencies.
2. Resolve project.yml dependencies. Allow project.yml to override dependencies from step 1.

There was a bug affecting both steps in the procedure.  If a dependency specifies a commit hash that corresponds exactly to a version number, then the dependency was ignored.

This PR fixes the problem so that commit hashes are always honored, whether or not they correspond to version numbers.