### PR TITLE
Warn use about invalid commit strings

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -580,9 +580,6 @@ func (gd *GenericDownloader) CommitsFor(
 
 	var commits []string
 
-	// Always insert the specified string into the set.
-	commits = append(commits, commit)
-
 	// Add all commits that are equivalent to the specified string.
 	for _, c := range gd.commits {
 		if commit == c.hash {


### PR DESCRIPTION
This PR changes newt so that it warns the user about something during `newt upgrade`.  The warned-about condition is: A `repository.yml` file contains an invalid commit string in its `repo.deps` map (i.e., it hangs dependencies off of a commit that doesn't exist).  
