### PR TITLE
newt upgrade: Fix repo conflict error message

### DIFF
--- a/newt/deprepo/deprepo.go
+++ b/newt/deprepo/deprepo.go
@@ -238,15 +238,20 @@ func PruneMatrix(m *Matrix, repos RepoMap, rootReqs RequirementMap) error {
 // of repos in the project.
 func PruneDepGraph(dg DepGraph, keep []*repo.Repo) {
 	for k, _ := range dg {
-		found := false
-		for _, r := range keep {
-			if r.Name() == k.Name {
-				found = true
-				break
+		// The empty string indicates a `project.yml` requirement.  Always
+		// keep these.
+		if k.Name != "" {
+			found := false
+
+			for _, r := range keep {
+				if k.Name == r.Name() {
+					found = true
+					break
+				}
 			}
-		}
-		if !found {
-			delete(dg, k)
+			if !found {
+				delete(dg, k)
+			}
 		}
 	}
 }

--- a/newt/deprepo/graph.go
+++ b/newt/deprepo/graph.go
@@ -192,11 +192,14 @@ func (dg DepGraph) Reverse() RevdepGraph {
 
 	for dependent, nodes := range dg {
 		for _, node := range nodes {
-			rg[node.Name] = append(rg[node.Name], RevdepGraphNode{
-				Name:    dependent.Name,
-				Ver:     dependent.Ver,
-				VerReqs: node.VerReqs,
-			})
+			// Nothing depends on project.yml (""), so exclude it from the result.
+			if node.Name != "" {
+				rg[node.Name] = append(rg[node.Name], RevdepGraphNode{
+					Name:    dependent.Name,
+					Ver:     dependent.Ver,
+					VerReqs: node.VerReqs,
+				})
+			}
 		}
 	}
 

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -670,8 +670,13 @@ func (inst *Installer) calcVersionMap(candidates []*repo.Repo) (
 	for name, nodes := range rg {
 		for _, node := range nodes {
 			if newtutil.CompareRepoVersions(node.Ver, vm[node.Name]) == 0 {
-				if err := inst.assignCommits(vm, name, node.VerReqs, false); err != nil {
-					return nil, err
+				// Don't consider project.yml dependencies here.  Those get
+				// assigned last so that they can override inter-repo
+				// dependencies.
+				if node.Name != "" {
+					if err := inst.assignCommits(vm, name, node.VerReqs, false); err != nil {
+						return nil, err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If a `newt upgrade` operation fails due to conflicting repo requirements, the error message should indicate which requirements are in conflict.  The bug was that the error message was missing "root requirements" (requirements specified in project.yml), so the message
was incomplete.

For example (before fix):
```
    Error: Repository conflicts:
        Installation of repo "mynewt-dummy-repo-04" is blocked:
            mynewt-dummy-repo-01,1.0.0 requires mynewt-dummy-repo-04 ==1.0.0
```
After fix:
```
    Error: Repository conflicts:
        Installation of repo "mynewt-dummy-repo-04" is blocked:
                           project.yml requires mynewt-dummy-repo-04 ==1.0.2/0eaf06337c8f8dc8c49fffa884a6a0c2fb223d73
            mynewt-dummy-repo-01,1.0.0 requires mynewt-dummy-repo-04 ==1.0.0
```