### PR TITLE
Fix clone of repos for non-[install|upgrade] cmds

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -103,7 +103,7 @@ func makeRepoPredicate(repoNames []string) func(r *repo.Repo) bool {
 }
 
 func installRunCmd(cmd *cobra.Command, args []string) {
-	proj := TryGetProject()
+	proj := TryGetOrDownloadProject()
 	interfaces.SetProject(proj)
 
 	pred := makeRepoPredicate(args)
@@ -115,7 +115,7 @@ func installRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func upgradeRunCmd(cmd *cobra.Command, args []string) {
-	proj := TryGetProject()
+	proj := TryGetOrDownloadProject()
 	interfaces.SetProject(proj)
 
 	pred := makeRepoPredicate(args)
@@ -180,7 +180,7 @@ func infoRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func syncRunCmd(cmd *cobra.Command, args []string) {
-	proj := TryGetProject()
+	proj := TryGetOrDownloadProject()
 	pred := makeRepoPredicate(args)
 
 	if err := proj.UpgradeIf(

--- a/newt/cli/util.go
+++ b/newt/cli/util.go
@@ -222,6 +222,21 @@ func TryGetProject() *project.Project {
 	return p
 }
 
+func TryGetOrDownloadProject() *project.Project {
+	var p *project.Project
+	var err error
+
+	if p, err = project.TryGetOrDownloadProject(); err != nil {
+		NewtUsage(nil, err)
+	}
+
+	for _, w := range p.Warnings() {
+		util.ErrorMessage(util.VERBOSITY_QUIET, "* Warning: %s\n", w)
+	}
+
+	return p
+}
+
 func ResolveUnittest(pkgName string) (*target.Target, error) {
 	// Each unit test package gets its own target.  This target is a copy
 	// of the base unit test package, just with an appropriate name.  The


### PR DESCRIPTION
Add a new function `TryGetOrDownloadProject()` that should be called by commands that want to check out a repo, eg, upgrade/install/sync. Older `TryGetProject()` now just checks that repos exist and bail out with an error if they don't.