### PR TITLE
Add commands to build and browse man pages

### DIFF
--- a/newt/cli/man_cmds.go
+++ b/newt/cli/man_cmds.go
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"mynewt.apache.org/newt/newt/man"
+)
+
+func manBuildRunCmd(cmd *cobra.Command, args []string) {
+	proj := TryGetProject()
+	err := man.BuildManPages(proj)
+	if err != nil {
+		NewtUsage(nil, err)
+	}
+}
+
+func manRunCmd(cmd *cobra.Command, args []string) {
+	proj := TryGetProject()
+	err := man.RunMan(proj, args)
+	if err != nil {
+		NewtUsage(nil, err)
+	}
+}
+
+func aproposRunCmd(cmd *cobra.Command, args []string) {
+	proj := TryGetProject()
+	err := man.RunApropos(proj, args)
+	if err != nil {
+		NewtUsage(nil, err)
+	}
+}
+
+func AddManCommands(cmd *cobra.Command) {
+	manBuildCmd := &cobra.Command{
+		Use:   "man-build",
+		Short: "Build man pages",
+		Run:   manBuildRunCmd,
+	}
+
+	cmd.AddCommand(manBuildCmd)
+	AddTabCompleteFn(manBuildCmd, func() []string {
+		return append(targetList(), "all")
+	})
+
+	manCmd := &cobra.Command{
+		Use:   "man <feature-name>",
+		Short: "Browse the man-page for given argument",
+		Run: func(cmd *cobra.Command, args []string) {
+			manRunCmd(cmd, args)
+		},
+	}
+
+	cmd.AddCommand(manCmd)
+	AddTabCompleteFn(manCmd, func() []string {
+		return append(append(targetList(), unittestList()...), "all")
+	})
+
+	aproposCmd := &cobra.Command{
+		Use:   "apropos <search-expression>",
+		Short: "Search manual page names and descriptions",
+		Run: func(cmd *cobra.Command, args []string) {
+			aproposRunCmd(cmd, args)
+		},
+	}
+
+	cmd.AddCommand(aproposCmd)
+	AddTabCompleteFn(aproposCmd, func() []string {
+		return append(append(targetList(), unittestList()...), "all")
+	})
+}

--- a/newt/man/man.go
+++ b/newt/man/man.go
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package man
+
+import (
+	"fmt"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"mynewt.apache.org/newt/newt/project"
+	"mynewt.apache.org/newt/newt/repo"
+	"mynewt.apache.org/newt/util"
+)
+
+const MAN_DOXY_CONF = "man-pages.conf"
+const MAN_REL_PATH = "/man"
+
+func buildDoxyManPages(proj *project.Project, repo *repo.Repo) error {
+	util.StatusMessage(util.VERBOSITY_DEFAULT,
+		"Preparing man-pages, running doxygen for \"%s\"\n", repo.Name())
+
+	doxyCmd := []string{
+		"doxygen",
+		path.Join(repo.Path(), MAN_DOXY_CONF),
+	}
+
+	env := map[string]string{
+		"MANPATH":        path.Join(proj.BasePath, MAN_REL_PATH),
+		"NEWT_PROJ_ROOT": proj.BasePath,
+		"NEWT_REPO_ROOT": repo.Path(),
+	}
+
+	_, err := util.ShellCommand(doxyCmd, env)
+
+	return err
+}
+
+func buildManDb(proj *project.Project) error {
+	util.StatusMessage(util.VERBOSITY_DEFAULT, "Updating man-page index caches\n")
+
+	manDbCmd := []string{
+		"mandb",
+	}
+
+	env := map[string]string{
+		"MANPATH": path.Join(proj.BasePath, MAN_REL_PATH),
+	}
+
+	_, err := util.ShellCommand(manDbCmd, env)
+
+	return err
+}
+
+func BuildManPages(proj *project.Project) error {
+	for _, repo := range proj.Repos() {
+		manPath := path.Join(repo.Path(), MAN_DOXY_CONF)
+		if util.NodeExist(manPath) {
+			err := buildDoxyManPages(proj, repo)
+			if err != nil {
+				return util.NewNewtError(fmt.Sprintf("%s", err.Error()))
+			}
+		}
+	}
+	err := buildManDb(proj)
+	if err != nil {
+		return util.NewNewtError(fmt.Sprintf("%s", err.Error()))
+	}
+
+	return nil
+}
+
+func RunMan(proj *project.Project, args []string) error {
+	binPath, err := exec.LookPath("man")
+	if err != nil {
+		return util.NewNewtError(fmt.Sprintf("%s", err.Error()))
+	}
+
+	manCmd := []string{
+		filepath.ToSlash(binPath),
+		args[0],
+	}
+
+	env := map[string]string{
+		"MANPATH": path.Join(proj.BasePath, MAN_REL_PATH),
+	}
+
+	err = util.ShellInteractiveCommand(manCmd, env, true)
+	if err != nil {
+		return util.NewNewtError(fmt.Sprintf("%s", err.Error()))
+	}
+
+	return nil
+}
+
+func RunApropos(proj *project.Project, args []string) error {
+	aproposCmd := []string{
+		"apropos",
+		args[0],
+	}
+
+	env := map[string]string{
+		"MANPATH": path.Join(proj.BasePath, MAN_REL_PATH),
+	}
+
+	output, err := util.ShellCommand(aproposCmd, env)
+	if err != nil {
+		return util.NewNewtError(fmt.Sprintf("%s", err.Error()))
+	}
+
+	fmt.Printf("%s", output)
+	return nil
+}

--- a/newt/newt.go
+++ b/newt/newt.go
@@ -157,6 +157,7 @@ func main() {
 	cli.AddValsCommands(cmd)
 	cli.AddMfgCommands(cmd)
 	cli.AddDocsCommands(cmd)
+	cli.AddManCommands(cmd)
 
 	/* only pass the first two args to check for complete command */
 	if len(os.Args) > 2 {


### PR DESCRIPTION
This adds a PoC level support for `newt` to generate and browse the doxygen in man-page format. No proper error handling, etc, is currently implemented...

When generating man-pages it looks for a file names `man-pages.conf ` in all repos, and if found those are run under doxygen. Generating man-pages:

```sh
$ newt man-build
Preparing man-pages, running doxygen for "apache-mynewt-nimble"
Preparing man-pages, running doxygen for "apache-mynewt-core"
Updating man-page index caches
```

Searching:

```sh
$ newt apropos os_mutex_
os_mutex_test_basic.c (3) - (unknown subject)
os_mutex_test_case_1.c (3) - (unknown subject)
os_mutex_test_case_2.c (3) - (unknown subject)
os_mutex_init (3)    - (unknown subject)
os_mutex_pend (3)    - (unknown subject)
os_mutex_release (3) - (unknown subject)
```

Browse a man page:

```
$ newt man os_mutex_pend
OSMutex(3)                                        Library Functions Manual                                       OSMutex(3)

NAME
       OSMutex

SYNOPSIS
   Data Structures
       struct os_mutex
           OS mutex structure.

   Functions
       os_mutex::SLIST_HEAD (, os_task) mu_head
       os_error_t os_mutex_init (struct os_mutex *mu)
           Create a mutex and initialize it.
       os_error_t os_mutex_release (struct os_mutex *mu)
           Release a mutex.
       os_error_t os_mutex_pend (struct os_mutex *mu, os_time_t timeout)
           Pend (wait) for a mutex.

   Variables
       uint8_t os_mutex::_pad
       uint8_t os_mutex::mu_prio
           Mutex owner's default priority.
       uint16_t os_mutex::mu_level
           Mutex call nesting level.
       struct os_task * os_mutex::mu_owner
           Task that owns the mutex.

Detailed Description
Function Documentation
...
```

The `man` commands loads the page in the given `PAGER` as would be expected...

Requires a `man-pages.conf` for each repo, eg: https://github.com/apache/mynewt-core/pull/2168
