### PR TITLE
Print OneTimeWarning errors to stderr

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -850,7 +850,7 @@ func OneTimeWarning(text string, args ...interface{}) {
 		warnings[body] = struct{}{}
 
 		body := fmt.Sprintf(text, args...)
-		StatusMessage(VERBOSITY_QUIET, "WARNING: %s\n", body)
+		ErrorMessage(VERBOSITY_QUIET, "WARNING: %s\n", body)
 	}
 }
 


### PR DESCRIPTION
OneTimeWarning currently prints to `stdout`, which when warnings are found, results in test cases run in CI to fail, so update it to print to `stderr`.