### PR TITLE
`newt info`: Include newt version at top of output

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -127,6 +127,8 @@ func upgradeRunCmd(cmd *cobra.Command, args []string) {
 }
 
 func infoRunCmd(cmd *cobra.Command, args []string) {
+	newtutil.PrintNewtVersion()
+
 	proj := TryGetProject()
 
 	// If no arguments specified, print status of all installed repos.

--- a/newt/newt.go
+++ b/newt/newt.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 
@@ -136,10 +135,7 @@ func newtCmd() *cobra.Command {
 		Long:    versHelpText,
 		Example: versHelpEx,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Apache Newt\n")
-			fmt.Printf("   Version: %s\n", newtutil.NewtVersionStr)
-			fmt.Printf("  Git Hash: %s\n", newtutil.NewtGitHash)
-			fmt.Printf("Build Date: %s\n", newtutil.NewtDate)
+			newtutil.PrintNewtVersion()
 		},
 	}
 

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -185,3 +185,8 @@ func ProjRelPath(path string) string {
 	proj := interfaces.GetProject()
 	return strings.TrimPrefix(path, proj.Path()+"/")
 }
+
+func PrintNewtVersion() {
+	util.StatusMessage(util.VERBOSITY_DEFAULT, "Apache Newt %s / %s / %s\n",
+		NewtVersionStr, NewtGitHash, NewtDate)
+}


### PR DESCRIPTION
The `newt info` command displays information about each repo in the user's project.  Including the newt version makes the output more useful when a user reports an issue.