### PR TITLE
Fix downloading repo dependencies

### DIFF
--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -583,7 +583,7 @@ func (proj *Project) loadConfig(download bool) error {
 	// Read `repository.yml` files belonging to dependee repos from disk.
 	// These repos might not be specified in the `project.yml` file, but they
 	// are still part of the project.
-	if err := proj.loadRepoDeps(false); err != nil {
+	if err := proj.loadRepoDeps(download); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is a bug left after a previous commit that fixed the download behavirour to only happen for network related commands, like `upgrade`. The repo dependencies was left non-updated at the time, so it would not be possible to resume/retry failures in downloads of dependencies. The bug can also be reproduced by simply removing (`rm -rf`) any repo that is included as dependency of some other repo.