### PR TITLE
Add support for conditional submodules updates

### DIFF
--- a/newt/ycfg/ycfg.go
+++ b/newt/ycfg/ycfg.go
@@ -266,6 +266,10 @@ func (yc *YCfg) find(key string) *YCfgNode {
 	return cur
 }
 
+func (yc *YCfg) HasKey(key string) bool {
+	return yc.find(key) != nil
+}
+
 // Get retrieves all nodes with the specified key.  If it encounters a parse
 // error in the tree, it ignores the bad node and continues the search.  All
 // bad nodes are indicated in the returned error.  In this sense, the returned


### PR DESCRIPTION
This adds support for repos to inform which submodules are required for a proper build on Mynewt. The main driver for this feature is that the current `ext/mbedtls` on mcuboot is a submodule that is not required by Mynewt builds, and the amount of submodules is going to grow in the future, eg, https://github.com/JuulLabs-OSS/mcuboot/pull/653.

The way this works is `newt` is going to look for a "repo.submodules" key inside the "repository.yml" file. This is a list of submodules to be cloned. One of two things could happen:

1) If the key is no present `newt` is going to clone all submodules (to preserve compatibility).
2) If the key is found, each of the submodules declared will be cloned one by one.

For example, if "repository.yml" has the following contents:

```
repo.submodules: ""
```

In this case submodule cloning is skipped (with a verbose message stating it).

```
repo.submodules:
    - "ext/mbetls"
    - "boot/cypress/somemodule"
```

This will clone the two modules declared but not other submodules that might eventually exist.

This PR also makes cloning submodules recursive, so submodules inside submodules are also cloned.