### PR TITLE
Emit `size` in mfg manifest target entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
-	github.com/apache/mynewt-artifact v0.0.15
+	github.com/apache/mynewt-artifact v0.0.16
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/apache/mynewt-artifact v0.0.9 h1:Pv/nAD50Zvom6YJ5gzQG7M4jsItPA3txSV/5
 github.com/apache/mynewt-artifact v0.0.9/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/apache/mynewt-artifact v0.0.15 h1:NOAdYAMjVBGVm/4iOs70+oQnb4StlD2tavkvwJiTbhI=
 github.com/apache/mynewt-artifact v0.0.15/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.16 h1:MUy07kNuCgZHXqEpJRp3JbZcdT3FkWUW4oiOxf1NW/4=
+github.com/apache/mynewt-artifact v0.0.16/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -48,6 +48,7 @@ type MfgBuildTarget struct {
 	Target        *target.Target
 	Area          flash.FlashArea
 	Offset        int
+	Size          int
 	IsBoot        bool
 	BinPath       string
 	ExtraManifest map[string]interface{}
@@ -229,12 +230,21 @@ func newMfgBuildTarget(dt DecodedTarget,
 
 	isBoot := parse.ValueIsTrue(man.Syscfg["BOOT_LOADER"])
 
+	binPath := targetSrcBinPath(t, isBoot)
+
+	st, err := os.Stat(binPath)
+	if err != nil {
+		return MfgBuildTarget{}, errors.Wrapf(err,
+			"failed to determine size of file \"%s\"", binPath)
+	}
+
 	return MfgBuildTarget{
 		Target:        t,
 		Area:          area,
 		Offset:        dt.Offset,
+		Size:          int(st.Size()),
 		IsBoot:        isBoot,
-		BinPath:       targetSrcBinPath(t, isBoot),
+		BinPath:       binPath,
 		ExtraManifest: dt.ExtraManifest,
 	}, nil
 }

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -53,6 +53,7 @@ type CpEntry struct {
 type MfgEmitTarget struct {
 	Name          string
 	Offset        int
+	Size          int
 	IsBoot        bool
 	BinPath       string
 	ElfPath       string
@@ -121,6 +122,7 @@ func newMfgEmitTarget(bt MfgBuildTarget) (MfgEmitTarget, error) {
 	return MfgEmitTarget{
 		Name:    bt.Target.FullName(),
 		Offset:  bt.Area.Offset + bt.Offset,
+		Size:    bt.Size,
 		IsBoot:  bt.IsBoot,
 		BinPath: targetSrcBinPath(bt.Target, bt.IsBoot),
 		ElfPath: targetSrcElfPath(bt.Target),
@@ -386,6 +388,7 @@ func (me *MfgEmitter) emitManifest() ([]byte, error) {
 			Name:         t.Name,
 			ManifestPath: MfgTargetManifestPath(me.Name, i),
 			Offset:       t.Offset,
+			Size:         t.Size,
 			Extra:        t.ExtraManifest,
 		}
 


### PR DESCRIPTION
MfgManifestTarget.Size was recently added to the artifact library.