### PR TITLE
Remove "final-atom" target specifier type

### DIFF
--- a/newt/cli/util.go
+++ b/newt/cli/util.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -99,17 +98,6 @@ func ResolveTarget(name string) *target.Target {
 	// Check the local "targets" directory.
 	if t := targetMap[TARGET_DEFAULT_DIR+"/"+name]; t != nil {
 		return t
-	}
-
-	// Check each repo alphabetically.
-	fullNames := []string{}
-	for fullName, _ := range targetMap {
-		fullNames = append(fullNames, fullName)
-	}
-	for _, fullName := range util.SortFields(fullNames...) {
-		if name == filepath.Base(fullName) {
-			return targetMap[fullName]
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Remove "final-atom" target specifier type

Prior to this commit, newt allowed a target to be specified in any of three ways:

1. Fully qualified name:
`@myrepo/targets/blinky`

2. Implicit `targets` directory in local repo:
`blinky` (resolves to `targets/blinky`)

3. Final atom in target package name:
`slinky_sim` (could resolve to `extra/my_stuff/slinky_sim`)

This commit removes support for the third type of specifier.

This third type of specifies is actually just a buggy attempt to support something else.  The intent was to allow the name of a target in a different repo without requiring the the `@repo-name` prefix.  The implementation is buggy because it allows the user to omit more than just the repo name.  It also applies to the top-level project when it is only intended for targets in other repos.

Allowing this type of specifier is bad because it can lead to ambiguities.  For example, if a project contains two targets:

* targets/arch1/blinky
* targets/arch2/blinky

then the command `newt build blinky` is ambiguous.  Currently, newt just selects the target whose name comes first in a lexicographic sort (arch1).

Rather than detect ambiguities, this commit just removes support for this type of target specifier entirely.