### PR TITLE
Fix skipping the copy of empty dirs on tree copies

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -372,58 +372,6 @@ func untrackedFilesFromCheckoutErr(err error) []string {
 	return files
 }
 
-// applyMcubootPreHack attempts to clean up the mcuboot repo so that the
-// subsequent checkout operation will succeed.  This hack is required because a
-// directory in the mcuboot repo was replaced with a submodule.  Git is unable
-// to transition from a post-replace commit to a pre-replace commit because
-// some files in the submodule used to exist in the mcuboot repo itself.  If
-// this issue is detected, this function deletes the submodule directory so
-// that the checkout operation can be attempted again.
-func applyMcubootPreHack(repoDir string, err error) error {
-	if !strings.HasSuffix(repoDir, "repos/mcuboot") {
-		// Not the mcuboot repo.
-		return err
-	}
-
-	// Check for an "untracked files" error.
-	files := untrackedFilesFromCheckoutErr(err)
-	if len(files) == 0 {
-		// Not a hackable error.
-		return err
-	}
-
-	for _, file := range files {
-		if !strings.HasPrefix(file, "ext/mbedtls") {
-			return err
-		}
-	}
-
-	path := repoDir + "/ext/mbedtls"
-	log.Debugf("applying mcuboot hack: removing %s", path)
-	os.RemoveAll(path)
-	return nil
-}
-
-// applyMcubootPostHack attempts to clean up the mcuboot repo so that the
-// subsequent checkout operation will succeed.  This hack is required because a
-// directory in the mcuboot repo was replaced with a submodule.  This hack
-// should be applied after a successful checkout from a pre-replace commit to a
-// post-replace commit.  This function deletes an orphan directory left behind
-// by the checkout operation.
-func applyMcubootPostHack(repoDir string, output string) {
-	if !strings.HasSuffix(repoDir, "repos/mcuboot") {
-		// Not the mcuboot repo.
-		return
-	}
-
-	// Check for a "unable to rmdir" warning (pre- to post- submodule move).
-	if strings.Contains(output, "unable to rmdir 'sim/mcuboot-sys/mbedtls'") {
-		path := repoDir + "/sim/mcuboot-sys/mbedtls"
-		log.Debugf("applying mcuboot hack: removing %s", path)
-		os.RemoveAll(path)
-	}
-}
-
 func (gd *GenericDownloader) Checkout(repoDir string, commit string) error {
 	// Get the hash corresponding to the commit in case the caller specified a
 	// branch or tag.  We always want to check out a hash and end up in a
@@ -439,20 +387,8 @@ func (gd *GenericDownloader) Checkout(repoDir string, commit string) error {
 		hash,
 	}
 
-	o, err := executeGitCommand(repoDir, cmd, true)
-	if err != nil {
-		if err := applyMcubootPreHack(repoDir, err); err != nil {
-			return err
-		}
-
-		if _, err := executeGitCommand(repoDir, cmd, true); err != nil {
-			return err
-		}
-	} else {
-		applyMcubootPostHack(repoDir, string(o))
-	}
-
-	return nil
+	_, err = executeGitCommand(repoDir, cmd, true)
+	return err
 }
 
 // Update one submodule tree in a repo (under path)

--- a/util/util.go
+++ b/util/util.go
@@ -525,7 +525,7 @@ func CopyDir(srcDirStr, dstDirStr string) error {
 		return ChildNewtError(err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(dstDirStr), info.Mode()); err != nil {
+	if err := os.MkdirAll(dstDirStr, info.Mode()); err != nil {
 		return ChildNewtError(err)
 	}
 


### PR DESCRIPTION
The CopyDir implementation did not copy empty directories which was resulting in a dirty repo after the tree copy with non-cloned submodules (empty dirs) was performed.

The issue resulted from calling `MkdirAll` with the parent directory of the current directory under copy, followed by a `ReadDir` which would result in an empty list of files/dirs, skipping the directory creation (by skipping the recursive tree copy).

Also removes the mcuboot submodule hack.