### PR TITLE
newt new: Infer latest "rc" tag for blinky

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -60,12 +60,22 @@ func newRunCmd(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	if err := dl.Clone(newtutil.NewtBlinkyTag, tmpdir); err != nil {
+	if err := dl.Clone("master", tmpdir); err != nil {
+		NewtUsage(nil, err)
+	}
+
+	commit, err := dl.LatestRc(tmpdir, newtutil.NewtBlinkyTag)
+	if err != nil {
+		NewtUsage(nil, err)
+	}
+
+	err = dl.Checkout(tmpdir, commit)
+	if err != nil {
 		NewtUsage(nil, err)
 	}
 
 	util.StatusMessage(util.VERBOSITY_DEFAULT, "Installing "+
-		"skeleton in %s...\n", newDir)
+		"skeleton in %s (commit: %s)\n", newDir, commit)
 
 	if err := util.CopyDir(tmpdir, newDir); err != nil {
 		NewtUsage(cmd, err)


### PR DESCRIPTION
To prevent code churn during the release process, newt infers the latest "rc" tag when updating a Mynewt repo (rather than forcing the maintainer to update the non-rc tag each time a new release candidate is created).

This tag inference feature was applied to repos during `newt upgrade`. It was not applied to the blinky repo during `newt new`.'

This PR adds tag inference to `newt new`.