### PR TITLE
Fixes for 1.8 release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,69 +200,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-This product bundles pretty, which is available under the MIT license.  For
-details, see:
-     * newt/vendor/github.com/kr/pretty/License
-     * newtmgr/vendor/github.com/kr/pretty/License
-
-This product bundles kr/text, which is available under the MIT license.  For
-details, see:
-     * newt/vendor/github.com/kr/text/License
-     * newtmgr/vendor/github.com/kr/text/License
-
-This product bundles mapstructure, which is available under the MIT license.
-For details, see:
-    * newt/vendor/github.com/mitchellh/mapstructure/LICENSE
-    * newtmgr/vendor/github.com/mitchellh/mapstructure/LICENSE
-
-This product bundles logrus, which is available under the MIT license.  For
-details, see:
-    * newt/vendor/github.com/sirupsen/logrus/LICENSE
-    * newtmgr/vendor/github.com/sirupsen/logrus/LICENSE
-
-This product bundles Cast, which is available under the MIT license.  For
-details, see:
-    * newt/vendor/github.com/spf13/cast/LICENSE
-    * newtmgr/vendor/github.com/spf13/cast/LICENSE
-
-This product bundles jWalterWeatherman, which is available under the MIT
-license.  For details, see:
-    * newt/vendor/github.com/spf13/jwalterweatherman/LICENSE
-    * newtmgr/vendor/github.com/spf13/jwalterweatherman/LICENSE
-
-This product bundles pflag, which is available under the "3-clause BSD"
-license.  For details, see:
-    * newt/vendor/github.com/spf13/pflag/LICENSE
-    * newtmgr/vendor/github.com/spf13/pflag/LICENSE
-
-This product bundles the unix Go package, which is available under the
-"3-clause BSD" license.  For details, see:
-    * newt/vendor/golang.org/x/sys/LICENSE
-    * newtmgr/vendor/golang.org/x/sys/LICENSE
-
-This product bundles fsnotify.v1, which is available under the "3-clause BSD"
-license.  For details, see:
-    * newt/vendor/gopkg.in/fsnotify.v1/LICENSE
-    * newtmgr/vendor/gopkg.in/fsnotify.v1/LICENSE
-
 This product bundles yaml.v2's Go port of libyaml, which is available under the
 MIT license.  For details, see:
-    * newt/vendor/mynewt.apache.org/newt/yaml/apic.go
-    * newt/vendor/mynewt.apache.org/newt/yaml/emitterc.go
-    * newt/vendor/mynewt.apache.org/newt/yaml/parserc.go
-    * newt/vendor/mynewt.apache.org/newt/yaml/readerc.go
-    * newt/vendor/mynewt.apache.org/newt/yaml/scannerc.go
-    * newt/vendor/mynewt.apache.org/newt/yaml/writerc.go
-    * newt/vendor/mynewt.apache.org/newt/yaml/yamlh.go
-    * newt/vendor/mynewt.apache.org/newt/yaml/yamlprivateh.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/apic.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/emitterc.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/parserc.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/readerc.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/scannerc.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/writerc.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/yamlh.go
-    * newtmgr/vendor/mynewt.apache.org/newt/yaml/yamlprivateh.go
     * yaml/apic.go
     * yaml/emitterc.go
     * yaml/parserc.go
@@ -271,41 +210,3 @@ MIT license.  For details, see:
     * yaml/writerc.go
     * yaml/yamlh.go
     * yaml/yamlprivateh.go
-
-This product bundles viper, which is available under the MIT license.  For
-details, see:
-    * newt/vendor/mynewt.apache.org/newt/viper/LICENSE
-    * newtmgr/vendor/mynewt.apache.org/newt/viper/LICENSE
-    * viper/LICENSE
-
-This product bundles go-crc16, which is available under the MIT license.  For
-details, see:
-    * newtmgr/vendor/github.com/joaojeronimo/go-crc16/README.md
-
-This product bundles GATT, which is available under the "3-clause BSD" license.
-For details, see:
-    * newtmgr/vendor/github.com/runtimeinc/gatt
-
-This product bundles xpc, which is available under the MIT license.  For
-details, see:
-    * newtmgr/vendor/github.com/runtimeinc/gatt/xpc/LICENSE
-
-This product bundles gioctl, which is available under the MIT license.  For
-details, see:
-    * newtmgr/vendor/github.com/runtimeinc/gatt/linux/gioctl/LICENSE.md
-
-This product bundles tarm/serial, which is available under the "3-clause BSD"
-license.  For details, see:
-    * newtmgr/vendor/github.com/tarm/serial/LICENSE
-
-This product bundles ugorji/go/codec, which is available under the MIT license.
-For details, see:
-    * newtmgr/vendor/github.com/ugorji/go/LICENSE
-
-This product bundles go-coap which is available under the MIT license.
-For details, see:
-    * newtmgr/vendor/github.com/dustin/go-coap/LICENSE
-
-This product bundles go-homedir which is available under the MIT license.
-For details, see:
-    * newtmgr/vendor/github.com/mitchellh/go-homedir/LICENSE

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Mynewt
-Copyright 2015-2017 The Apache Software Foundation
+Copyright 2015-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # RELEASE NOTES
 
-18 March 2029 - Apache Newt v1.8.0
+18 March 2020 - Apache Newt v1.8.0
 
 For full release notes, please visit the
 [Apache Mynewt Wiki](https://cwiki.apache.org/confluence/display/MYNEWT/Release+Notes).


### PR DESCRIPTION
Updates dates and removes no longer bundled vendor/ libraries from
LICENSE file.