### PR TITLE
Use rc-tag-inference in inter-repo dependencies

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -728,14 +728,11 @@ func (gd *GenericDownloader) LatestRc(path string,
 
 	notag := strings.TrimSuffix(base, "_tag")
 	if notag == base {
-		return "", nil
+		return base, nil
 	}
 
 	restr := fmt.Sprintf("^%s_rc(\\d+)_tag$", regexp.QuoteMeta(notag))
-	re, err := regexp.Compile(restr)
-	if err != nil {
-		return "", util.FmtNewtError("internal error: %s", err.Error())
-	}
+	re := regexp.MustCompile(restr)
 
 	bestNum := -1
 	bestStr := ""
@@ -748,6 +745,10 @@ func (gd *GenericDownloader) LatestRc(path string,
 				bestStr = commit
 			}
 		}
+	}
+
+	if bestStr == "" {
+		bestStr = base
 	}
 
 	return bestStr, nil

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -423,6 +423,11 @@ func (inst *Installer) calcVersionMap(candidates []*repo.Repo) (
 
 	for _, r := range repoList {
 		for commit, _ := range r.CommitDepMap() {
+			commit, err := r.Downloader().LatestRc(r.Path(), commit)
+			if err != nil {
+				return nil, err
+			}
+
 			equiv, err := r.Downloader().CommitsFor(r.Path(), commit)
 			if err != nil {
 				return nil, err

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -291,7 +291,7 @@ func (r *Repo) updateRepo(commit string) error {
 				"Error updating \"%s\": %s", r.Name(), err.Error())
 		}
 
-		if newCommit != "" {
+		if newCommit != commit {
 			util.StatusMessage(util.VERBOSITY_DEFAULT,
 				"in repo \"%s\": commit \"%s\" does not exist; "+
 					"using \"%s\" instead\n",


### PR DESCRIPTION
A repo can specify dependencies in its `repository.yml` file, e.g.,

```
    repo.deps:
        apache-mynewt-nimble:
            type: github
            user: apache
            repo: mynewt-nimble
            vers:
                mynewt_1_4_0_tag: 1.0.0
```

The `mynewt_1_4_0_tag` tag of *this repo* depends on nimble 1.0.0.  If `mynewt_1_4_0_tag` does not exist, then `newt upgrade` would fail.

The tag-validity check that newt was doing here was too strict.  If the specified tag doesn't exist, newt should attempt rc-tag-inference.  For example, if `mynewt_1_4_0_tag` does not exist, newt should check for the latest corresponding rc tag (e.g., `mynewt_1_4_0_rc1_tag`).  If one is found, then the dependency list is valid after all.

Newt already applies this rc-tag-inference procedure when it actually performs the upgrade.  However, the check that happens before the upgrade was not using rc-tag-inference.  This commit adds rc-tag-inference to this check.
