### PR TITLE
upgrade: Don't abort if repo references bad commit

### DIFF
--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -424,11 +424,7 @@ func (inst *Installer) calcVersionMap(candidates []*repo.Repo) (
 	for _, r := range repoList {
 		for commit, _ := range r.CommitDepMap() {
 			equiv, err := r.Downloader().CommitsFor(r.Path(), commit)
-			if err != nil {
-				return nil, err
-			}
-
-			if len(equiv) == 0 {
+			if err != nil || len(equiv) == 0 {
 				util.OneTimeWarning(
 					"repo bases a dependency on a nonexistent commit; "+
 						"repository.yml contains an error; "+


### PR DESCRIPTION
Newt would abort the upgrade if a repo's dependency list specifies a nonexistent commit.  This was bad because it means a repo maintainer could break `newt upgrade` for all users by deleting a tag or by introducing a typo to their `repository.yml` file.

Now newt just warns the user about the problem and proceeds with the upgrade.