### PR TITLE
Fix for @repo targets

### DIFF
--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -220,7 +220,7 @@ func newMfgBuildTarget(dt DecodedTarget,
 	}
 
 	mpath := builder.ManifestPath(dt.Name, builder.BUILD_NAME_APP,
-		t.App().Name())
+		t.App().FullName())
 	man, err := manifest.ReadManifest(mpath)
 	if err != nil {
 		return MfgBuildTarget{}, util.FmtNewtError("%s", err.Error())

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -100,22 +100,22 @@ type MfgEmitter struct {
 func targetSrcBinPath(t *target.Target, isBoot bool) string {
 	if isBoot {
 		return builder.AppBinPath(t.Name(), builder.BUILD_NAME_APP,
-			t.App().Name())
+			t.App().FullName())
 	} else {
 		return builder.AppImgPath(t.Name(), builder.BUILD_NAME_APP,
-			t.App().Name())
+			t.App().FullName())
 	}
 }
 
 // Calculates the source path of a target's `.elf` file.
 func targetSrcElfPath(t *target.Target) string {
-	return builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name())
+	return builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().FullName())
 }
 
 // Calculates the source path of a target's manifest file.
 func targetSrcManifestPath(t *target.Target) string {
 	return builder.ManifestPath(t.Name(), builder.BUILD_NAME_APP,
-		t.App().Name())
+		t.App().FullName())
 }
 
 func newMfgEmitTarget(bt MfgBuildTarget) (MfgEmitTarget, error) {
@@ -127,7 +127,7 @@ func newMfgEmitTarget(bt MfgBuildTarget) (MfgEmitTarget, error) {
 		BinPath: targetSrcBinPath(bt.Target, bt.IsBoot),
 		ElfPath: targetSrcElfPath(bt.Target),
 		ManifestPath: builder.ManifestPath(bt.Target.Name(),
-			builder.BUILD_NAME_APP, bt.Target.App().Name()),
+			builder.BUILD_NAME_APP, bt.Target.App().FullName()),
 		ExtraManifest: bt.ExtraManifest,
 	}, nil
 }


### PR DESCRIPTION
Without the fix, building targets such as
target.app: "@mcuboot/boot/mynewt" fails,
since the path to the .manifest, .hex and .bin is wrong.

This can be fixed by using the target app's FullName() instead of Name().