### PR TITLE
Log exported environnment variables with `-ldebug`

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -227,8 +228,19 @@ func (t *TargetBuilder) ensureResolved() error {
 
 	// Configure the basic set of environment variables in the current process.
 	env := BasicEnvVars("", t.bspPkg)
-	for k, v := range env {
-		if err := os.Setenv(k, v); err != nil {
+	keys := make([]string, 0, len(env))
+	for k, _ := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	log.Debugf("exporting environment variables:")
+	for _, k := range keys {
+		v := env[k]
+		log.Debugf("    %s=%s", k, env[k])
+
+		err := os.Setenv(k, v)
+		if err != nil {
 			return util.FmtNewtError(
 				"failed to set env var %s=%s: %s", k, v, err.Error())
 		}


### PR DESCRIPTION
This PR adds some additional information to the debug log.

Here is an example from a `newt build -ldebug <...>` run:
```
2020/04/22 10:39:03.864 [DEBUG] exporting environment variables:
2020/04/22 10:39:03.865 [DEBUG]     BIN_ROOT=/Users/ccollins/proj/myproj/bin
2020/04/22 10:39:03.865 [DEBUG]     BSP_PATH=/Users/ccollins/proj/myproj/repos/apache-mynewt-core/hw/bsp/native
2020/04/22 10:39:03.865 [DEBUG]     CORE_PATH=/Users/ccollins/proj/myproj/repos/apache-mynewt-core
2020/04/22 10:39:03.866 [DEBUG]     MYNEWT_NEWT_PATH=/Users/ccollins/go/bin/newt
2020/04/22 10:39:03.866 [DEBUG]     MYNEWT_PROJECT_ROOT=/Users/ccollins/proj/myproj
```