### PR TITLE
`--imgfile` and `--elffile` options

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -105,6 +105,7 @@ var extraJtagCmd string
 var noGDB_flag bool
 var diffFriendly_flag bool
 var imgFileOverride string
+var elfFileOverride string
 
 func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, executeShell bool) {
 	if len(args) < 1 {
@@ -373,7 +374,7 @@ func debugRunCmd(cmd *cobra.Command, args []string) {
 		NewtUsage(nil, err)
 	}
 
-	if err := b.Debug(extraJtagCmd, false, noGDB_flag); err != nil {
+	if err := b.Debug(extraJtagCmd, false, noGDB_flag, elfFileOverride); err != nil {
 		NewtUsage(cmd, err)
 	}
 }
@@ -504,6 +505,8 @@ func AddBuildCommands(cmd *cobra.Command) {
 		"", "Extra commands to send to JTAG software")
 	debugCmd.PersistentFlags().BoolVarP(&noGDB_flag, "noGDB", "n", false,
 		"Do not start GDB from command line")
+	debugCmd.PersistentFlags().StringVarP(&elfFileOverride, "elffile", "",
+		"", "Path of .elf file to debug instead of target artifact")
 
 	cmd.AddCommand(debugCmd)
 	AddTabCompleteFn(debugCmd, targetList)

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -104,6 +104,7 @@ func pkgToUnitTests(pack *pkg.LocalPackage) []*pkg.LocalPackage {
 var extraJtagCmd string
 var noGDB_flag bool
 var diffFriendly_flag bool
+var imgFileOverride string
 
 func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, executeShell bool) {
 	if len(args) < 1 {
@@ -350,7 +351,7 @@ func loadRunCmd(cmd *cobra.Command, args []string) {
 		NewtUsage(nil, err)
 	}
 
-	if err := b.Load(extraJtagCmd); err != nil {
+	if err := b.Load(extraJtagCmd, imgFileOverride); err != nil {
 		NewtUsage(cmd, err)
 	}
 }
@@ -487,6 +488,8 @@ func AddBuildCommands(cmd *cobra.Command) {
 
 	loadCmd.PersistentFlags().StringVarP(&extraJtagCmd, "extrajtagcmd", "", "",
 		"Extra commands to send to JTAG software")
+	loadCmd.PersistentFlags().StringVarP(&imgFileOverride, "imgfile", "", "",
+		"Path of .img file to load instead of target artifact")
 
 	debugHelpText := "Open a debugger session for <target-name>"
 

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -120,7 +120,7 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 			NewtUsage(nil, err)
 		}
 
-		if err := b.Debug(extraJtagCmd, true, noGDB_flag); err != nil {
+		if err := b.Debug(extraJtagCmd, true, noGDB_flag, ""); err != nil {
 			NewtUsage(nil, err)
 		}
 	}

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -116,7 +116,7 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		if err := b.Load(extraJtagCmd); err != nil {
+		if err := b.Load(extraJtagCmd, ""); err != nil {
 			NewtUsage(nil, err)
 		}
 


### PR DESCRIPTION
This PR adds two command line options:

---

#### newt load: --imgfile

This option allows the user to specify the .img file to load onto the device.  If the option is unspecified, newt loads the image file from the target's bin directory as before.

---

#### newt debug: --elffile

This option allows the user to specify the .elf file to load into gdb.  If the option is unspecified, newt uses the .elf file from the target's bin directory as before.

---

These changes are limited in a few ways:
1. `--imgfile` is not compatible with split images.  Newt will abort the load operation in this case.
2. Neither of these options were added to the `run` command.  The point of `run` is to build, load, and debug the image just built, so these options didn't seem very useful here.  Also, the implementation would have been a bit convoluted since the user would have to specify neither or both or these options for them to make sense.