### PR TITLE
cmake: Fix setting compile flags

### DIFF
--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -129,7 +129,7 @@ func CmakeSourceObjectWrite(w io.Writer, cj toolchain.CompilerJob,
 	fmt.Fprintf(w, `set_property(SOURCE %s APPEND_STRING
 														PROPERTY
 														COMPILE_FLAGS
-														"%s")`,
+														" %s")`,
 		cj.Filename,
 		strings.Join(escapeFlagsSlice(otherFlags), " "))
 	fmt.Fprintln(w)


### PR DESCRIPTION
By some recent change in gcc or cmake the compilation flags for sources
defined in CMakeLists.txt would get reordered in a way that the first -D
flag would come after the last -m flag. As a result we would get a gcc error
"Unrecognized command line argument: -mthumb-interwork-DAPP_NAME=<app-name>"
Adding space before the first flag in CMakeLists.txt file fixes the problem.