### PR TITLE
build.sh: Invoke sh as a login shell

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -l
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
This fixes #390

build.sh depends on the `go` executable.  This executable may not be in the user's path when /bin/sh is invoked as a non-login shell (a non-login shell does not execute the various "profile" scripts).  Since we don't package `go` as part of the newt distribution, we should not assume it
is available to the build script in a non-login shell.