### PR TITLE
newt info: Query each repo in parallel

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -152,23 +152,12 @@ func gitPath() (string, error) {
 }
 
 func executeGitCommand(dir string, cmd []string, logCmd bool) ([]byte, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, util.NewNewtError(err.Error())
-	}
-
 	gp, err := gitPath()
 	if err != nil {
 		return nil, err
 	}
 
-	if err := os.Chdir(dir); err != nil {
-		return nil, util.ChildNewtError(err)
-	}
-
-	defer os.Chdir(wd)
-
-	gitCmd := []string{gp}
+	gitCmd := []string{gp, "-C", dir}
 	gitCmd = append(gitCmd, cmd...)
 	output, err := util.ShellCommandLimitDbgOutput(gitCmd, nil, logCmd, -1)
 	if err != nil {

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -92,9 +92,6 @@ func initProject(dir string, download bool) error {
 	if err != nil {
 		return err
 	}
-	if err := globalProject.loadPackageList(); err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -732,7 +729,7 @@ func findProjectDir(dir string) (string, error) {
 	return dir, nil
 }
 
-func (proj *Project) loadPackageList() error {
+func (proj *Project) loadPackageList() {
 	proj.packages = interfaces.PackageList{}
 
 	// Go through a list of repositories, starting with local, and search for
@@ -746,11 +743,13 @@ func (proj *Project) loadPackageList() error {
 
 		proj.warnings = append(proj.warnings, warnings...)
 	}
-
-	return nil
 }
 
 func (proj *Project) PackageList() interfaces.PackageList {
+	if proj.packages == nil {
+		proj.loadPackageList()
+	}
+
 	return proj.packages
 }
 

--- a/util/batch.go
+++ b/util/batch.go
@@ -1,0 +1,53 @@
+package util
+
+type batchProcFn func(idx int, thread int) error
+
+// BatchIndices processes a range of indices in parallel.  Each index is passed
+// to the specified callback.
+
+// start: The first index to process.
+// count: The number of indices to process.
+// numThreads: The number of go routines to use.
+// proc: The callback to pass each index to.
+func BatchIndices(start int, count int, numThreads int, proc batchProcFn) error {
+	idxch := make(chan int)
+	donech := make(chan error)
+	abortch := make(chan struct{})
+
+	for i := 0; i < numThreads; i++ {
+		go func(thread int) {
+			for idx := range idxch {
+				select {
+				case <-abortch:
+					donech <- nil
+					return
+
+				default:
+					err := proc(idx, thread)
+					if err != nil {
+						donech <- err
+						return
+					}
+				}
+			}
+
+			donech <- nil
+		}(i)
+	}
+
+	for i := 0; i < count; i++ {
+		idxch <- start + i
+	}
+	close(idxch)
+
+	var firstErr error
+	for i := 0; i < numThreads; i++ {
+		err := <-donech
+		if err != nil && firstErr == nil {
+			close(abortch)
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}


### PR DESCRIPTION
This isn't a huge speedup, but it's something.  Example:

#### Before
```
[ccollins@ccollins:~/repos/myproj]$ time newt info
Apache Newt 1.9.0-dev / unknown / unknown
<...>
real    0m1.103s
user    0m0.539s
sys     0m0.696s
```

#### After
```
[ccollins@ccollins:~/repos/myproj]$ time newt info
Apache Newt 1.9.0-dev / unknown / unknown
<...>
real    0m0.529s
user    0m0.403s
sys     0m0.651s
```

My plan was to make `newt upgrade` run in parallel, but that didn't make a meaningful difference.