### PR TITLE
Add Cflags and Include paths to pre_build_cmds environment

### DIFF
--- a/newt/builder/buildutil.go
+++ b/newt/builder/buildutil.go
@@ -315,5 +315,8 @@ func (b *Builder) EnvVars(imageSlot int) (map[string]string, error) {
 		env[k] = v
 	}
 
+	env["MYNEWT_INCLUDE_PATH"] = strings.Join(b.compilerInfo.Includes, ":")
+	env["MYNEWT_CFLAGS"] = strings.Join(b.compilerInfo.Cflags, " ")
+
 	return env, nil
 }


### PR DESCRIPTION
Add the CFLAGS and INCLUDE_PATH as used by newt to the environment when
starting a pre_build_cmd. I need this to execute rust bindgen correctly.
This program will parse the mynewt headers and generate rust code from
that and therefore it needs the correct c-flags and include paths.