### PR TITLE
newt: Add settings to not execute git on every newt command

### DIFF
--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -588,8 +588,10 @@ func (proj *Project) loadConfig(download bool) error {
 	}
 
 	// Warn the user about incompatibilities with this version of newt.
-	if err := proj.verifyNewtCompat(); err != nil {
-		return err
+	if util.VerifyCompat {
+		if err := proj.verifyNewtCompat(); err != nil {
+			return err
+		}
 	}
 
 	ignoreDirs, err := yc.GetValStringSlice("project.ignore_dirs", nil)

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -49,6 +49,28 @@ func processNewtrc(yc ycfg.YCfg) {
 			util.EscapeShellCmds = b
 		}
 	}
+
+	s, _ = yc.GetValString("verify_compat", nil)
+	if s != "" {
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			log.Warnf(".newtrc contains invalid \"verify_compat\" value: %s; "+
+				"expected \"true\" or \"false\"", s)
+		} else {
+			util.VerifyCompat = b
+		}
+	}
+
+	s, _ = yc.GetValString("write_repos_info", nil)
+	if s != "" {
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			log.Warnf(".newtrc contains invalid \"write_repos_info\" value: %s; "+
+				"expected \"true\" or \"false\"", s)
+		} else {
+			util.WriteReposInfo = b
+		}
+	}
 }
 
 func readNewtrc() ycfg.YCfg {

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -1454,8 +1454,10 @@ func write(cfg Cfg, w io.Writer) {
 	writeCheckMacros(w)
 	fmt.Fprintf(w, "\n")
 
-	writeReposInfo(w)
-	fmt.Fprintf(w, "\n")
+	if util.WriteReposInfo {
+		writeReposInfo(w)
+		fmt.Fprintf(w, "\n")
+	}
 
 	writeSettings(cfg, w)
 	fmt.Fprintf(w, "\n")

--- a/util/util.go
+++ b/util/util.go
@@ -44,6 +44,8 @@ var Verbosity int
 var PrintShellCmds bool
 var ExecuteShell bool
 var EscapeShellCmds bool
+var VerifyCompat = true
+var WriteReposInfo = true
 var logFile *os.File
 
 func ParseEqualsPair(v string) (string, string, error) {


### PR DESCRIPTION
Executing git on Windows can be very slow so this PR is
introducing flags in settings that can disable
compatibility verification between Newt and repositories
as well as disable writing repo information in generated headers.