### PR TITLE
[DO NOT MERGE] Allow per-package elements in image manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	github.com/ugorji/go/codec v1.1.7
 	golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4
 )
+
+replace github.com/apache/mynewt-artifact => github.com/ccollins476ad/mynewt-artifact v0.0.0-20200820214647-a7fa50d16b05

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/apache/mynewt-artifact v0.0.15/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29
 github.com/apache/mynewt-artifact v0.0.16 h1:MUy07kNuCgZHXqEpJRp3JbZcdT3FkWUW4oiOxf1NW/4=
 github.com/apache/mynewt-artifact v0.0.16/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/ccollins476ad/mynewt-artifact v0.0.0-20200820211203-bc98fd3e9307 h1:af0ObJcSqNulIZj0o76k0rhX+JRg5JCAm2/emQujyTI=
+github.com/ccollins476ad/mynewt-artifact v0.0.0-20200820211203-bc98fd3e9307/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/ccollins476ad/mynewt-artifact v0.0.0-20200820214647-a7fa50d16b05 h1:QvCnEfqsuR7y9z4LxlfZ1DZKw6+9a4zle77kiFC2/Uc=
+github.com/ccollins476ad/mynewt-artifact v0.0.0-20200820214647-a7fa50d16b05/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -317,30 +317,8 @@ func (b *Builder) collectCompileEntriesBpkg(bpkg *BuildPackage) (
 		return nil, err
 	}
 
-	srcDirs := []string{}
-
-	if len(bpkg.SourceDirectories) > 0 {
-		for _, relDir := range bpkg.SourceDirectories {
-			dir := bpkg.rpkg.Lpkg.BasePath() + "/" + relDir
-			if util.NodeNotExist(dir) {
-				return nil, util.NewNewtError(fmt.Sprintf(
-					"Specified source directory %s, does not exist.",
-					dir))
-			}
-			srcDirs = append(srcDirs, dir)
-		}
-	} else {
-		srcDir := bpkg.rpkg.Lpkg.BasePath() + "/src"
-		if util.NodeNotExist(srcDir) {
-			// Nothing to compile.
-			return nil, nil
-		}
-
-		srcDirs = append(srcDirs, srcDir)
-	}
-
-	entries := []toolchain.CompilerJob{}
-	for _, dir := range srcDirs {
+	var entries []toolchain.CompilerJob
+	for _, dir := range bpkg.SourceDirectories() {
 		subEntries, err := collectCompileEntriesDir(dir, c,
 			b.targetBuilder.bspPkg.Arch, nil)
 		if err != nil {

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -34,7 +34,7 @@ import (
 
 type BuildPackage struct {
 	rpkg              *resolve.ResolvePackage
-	SourceDirectories []string
+	sourceDirectories []string
 	ci                *toolchain.CompilerInfo
 }
 
@@ -198,7 +198,7 @@ func (bpkg *BuildPackage) CompilerInfo(
 		ci.IgnoreDirs = append(ci.IgnoreDirs, re)
 	}
 
-	bpkg.SourceDirectories, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+	bpkg.sourceDirectories, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
 		"pkg.src_dirs", settings)
 	util.OneTimeWarningError(err)
 
@@ -296,4 +296,28 @@ func (bpkg *BuildPackage) privateIncludeDirs(b *Builder) []string {
 	}
 
 	return incls
+}
+
+func (bpkg *BuildPackage) SourceDirectories() []string {
+	var dirs []string
+
+	if len(bpkg.sourceDirectories) > 0 {
+		for _, relDir := range bpkg.sourceDirectories {
+			dir := bpkg.rpkg.Lpkg.BasePath() + "/" + relDir
+			if util.NodeNotExist(dir) {
+				util.OneTimeWarning(
+					"specified source directory does not exist: pkg=%s dir=%s",
+					bpkg.rpkg.Lpkg.FullName(), dir)
+			} else {
+				dirs = append(dirs, bpkg.rpkg.Lpkg.BasePath()+"/"+relDir)
+			}
+		}
+	} else {
+		dir := bpkg.rpkg.Lpkg.BasePath() + "/src"
+		if util.NodeExist(dir) {
+			dirs = []string{dir}
+		}
+	}
+
+	return dirs
 }

--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -229,6 +229,11 @@ func (b *Builder) AppBinBasePath() string {
 		filepath.Base(b.appPkg.rpkg.Lpkg.FullName())
 }
 
+func (b *Builder) ExtraManifestPath() string {
+	return b.PkgBinDir(b.appPkg) + "/" +
+		filepath.Base(b.appPkg.rpkg.Lpkg.FullName()) + "_extra_manifest.json"
+}
+
 func (b *Builder) CompileCmdsPath() string {
 	// The path depends on whether we are building an app or running a test.
 	var basePath string

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -587,6 +587,11 @@ func (t *TargetBuilder) Build() error {
 		return err
 	}
 
+	// Construct the "extra" map in the manifest.json file.
+	if err := t.AppBuilder.CoalesceExtraManifest(); err != nil {
+		return err
+	}
+
 	/* Link the app. */
 	if err := t.AppBuilder.Link(linkerScripts, t.extraADirs()); err != nil {
 		return err


### PR DESCRIPTION
## DO NOT MERGE

https://github.com/apache/mynewt-artifact/pull/28 needs to be merged.  After it is merged, the artifact library should be tagged with a new version number.  Finally, newt's `go.mod` should be changed to point to the new version tag rather than the PR branch that it currently points to.

----

A package's src directory can contain filenames matching this pattern: `*extra_manifest.json`.  Such files are collected at build-time and coalesced into a map in the image manifest called "extra".

A build-time script can include data in the "extra" section by emitting `*extra_manifest.json` files to `$MYNEWT_USER_SRC_DIR`.
