### PR TITLE
newt: Allow third linker script to maximize split image size

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -579,7 +579,7 @@ func (t *TargetBuilder) Build() error {
 		if err := t.buildLoader(); err != nil {
 			return err
 		}
-		linkerScripts = t.bspPkg.Part2LinkerScripts
+		linkerScripts = t.bspPkg.SplitAppLinkerScripts
 	}
 
 	// Execute the set of pre-link user scripts.

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -426,7 +426,13 @@ func (t *TargetBuilder) buildLoader() error {
 	/* Tentatively link the app (using the normal single image linker
 	 * script)
 	 */
-	if err := t.AppBuilder.TentativeLink(t.bspPkg.LinkerScripts,
+	var appLinkerScripts []string
+	if len(t.bspPkg.WholeAppLinkerScripts) > 0 {
+		appLinkerScripts = t.bspPkg.WholeAppLinkerScripts
+	} else {
+		appLinkerScripts = t.bspPkg.LinkerScripts
+	}
+	if err := t.AppBuilder.TentativeLink(appLinkerScripts,
 		t.extraADirs()); err != nil {
 
 		return err

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -38,6 +38,7 @@ type BspPackage struct {
 	CompilerName          string
 	Arch                  string
 	LinkerScripts         []string
+	WholeAppLinkerScripts []string /* scripts to tentatively link app for split image as though it had full use of both slots */
 	SplitAppLinkerScripts []string /* scripts to link app to second partition */
 	DownloadScript        string
 	DebugScript           string
@@ -145,6 +146,8 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 		return err
 	}
 
+	bsp.WholeAppLinkerScripts, err = bsp.resolveLinkerScriptSetting(
+		settings, "bsp.wholeapplinkerscript")
 	if err != nil {
 		return err
 	}

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -35,17 +35,17 @@ const BSP_YAML_FILENAME = "bsp.yml"
 
 type BspPackage struct {
 	*LocalPackage
-	CompilerName       string
-	Arch               string
-	LinkerScripts      []string
-	Part2LinkerScripts []string /* scripts to link app to second partition */
-	DownloadScript     string
-	DebugScript        string
-	OptChkScript       string
-	ImageOffset        int
-	ImagePad           int
-	FlashMap           flashmap.FlashMap
-	BspV               ycfg.YCfg
+	CompilerName          string
+	Arch                  string
+	LinkerScripts         []string
+	SplitAppLinkerScripts []string /* scripts to link app to second partition */
+	DownloadScript        string
+	DebugScript           string
+	OptChkScript          string
+	ImageOffset           int
+	ImagePad              int
+	FlashMap              flashmap.FlashMap
+	BspV                  ycfg.YCfg
 }
 
 func (bsp *BspPackage) BspYamlPath() string {
@@ -145,10 +145,22 @@ func (bsp *BspPackage) Reload(settings map[string]string) error {
 		return err
 	}
 
-	bsp.Part2LinkerScripts, err = bsp.resolveLinkerScriptSetting(
-		settings, "bsp.part2linkerscript")
 	if err != nil {
 		return err
+	}
+
+	bsp.SplitAppLinkerScripts, err = bsp.resolveLinkerScriptSetting(
+		settings, "bsp.splitapplinkerscript")
+	if err != nil {
+		return err
+	}
+
+	if len(bsp.SplitAppLinkerScripts) == 0 {
+		bsp.SplitAppLinkerScripts, err = bsp.resolveLinkerScriptSetting(
+			settings, "bsp.part2linkerscript")
+		if err != nil {
+			return err
+		}
 	}
 
 	bsp.DownloadScript, err = bsp.resolvePathSetting(


### PR DESCRIPTION
This resolves a limitation of the split image build process, allowing for larger builds.

Prior to this change, the split build process worked like so:

1. Build the app image, linking against the regular "bsp.linkerscript" ld script.
2. Build the loader image, also linking against the regular "bsp.linkerscript" ld script.
3. Compare the resulting elfs from app and loader, look for common functions, and substitute their addresses from the loader's elf into the app's elf.
4. Re-link the app against the special "bsp.part2linkerscript" ld script, which maps everything into slot 2's address space, except for those addresses already mapped into the loader's elf in step 3 (and also do some hardware-specific monkeying, if needed).

That doesn't use the split image setup to its full potential, though. The regular linker script needs to enforce that the resulting image fits inside the provided flash area, but in the case of the build in step 1, this flash area is less than what is actually available, as it counts the various symbols that will be re-linked and eliminated from the image in step 4. That artificially limits the size of the app to its own code, plus the shared code, minus any non-overlapping code in the loader image. In reality, it has (almost) the entirely of both flash areas to play with, as long as the portion shared with the loader doesn't overflow in step 2, and it doesn't overstep the various needs of the boot loader (though existing scripts don't account for that as it stands).

This PR changes step 1 to use an optional third linker script specified by "bsp.wholeapplinkerscript". This allows a bsp to specify an initial app linker script that allows the full use of both image slots; in the absence of such a script, it falls back on existing behavior. The resulting app image may not be workable if too much of it consists of dependencies on loader code, but that will be revealed later by a failure in step 3. 

It also changes the name of the setting in step 4 to "bsp.splitapplinkerscript", which is more accurate and implies the connection between the two settings ("bsp.part2linkerscript" was misleading anyway, as technically that was stage 3 of the linking process). It maintains backwards compatibility with existing bsp.yml files that still use "bsp.part2linkerscript", but in the presence of both, prefers "bsp.splitapplinkerscript".
