### PR TITLE
Add Section TLV support to images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
-	github.com/apache/mynewt-artifact v0.0.16
+	github.com/apache/mynewt-artifact v0.0.20
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/shirou/gopsutil v2.20.8+incompatible

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/apache/mynewt-artifact v0.0.15 h1:NOAdYAMjVBGVm/4iOs70+oQnb4StlD2tavk
 github.com/apache/mynewt-artifact v0.0.15/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/apache/mynewt-artifact v0.0.16 h1:MUy07kNuCgZHXqEpJRp3JbZcdT3FkWUW4oiOxf1NW/4=
 github.com/apache/mynewt-artifact v0.0.16/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.20 h1:zf3RACAEGNH0s11QyqB8QeAuMr/e/DmRfHaP5pLjzpw=
+github.com/apache/mynewt-artifact v0.0.20/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -39,6 +39,7 @@ var encKeyFilename string
 var encKeyIndex int
 var hdrPad int
 var imagePad int
+var sections string
 
 // @return                      keys, key ID, error
 func parseKeyArgs(args []string) ([]sec.PrivSignKey, uint8, error) {
@@ -135,10 +136,10 @@ func createImageRunCmd(cmd *cobra.Command, args []string) {
 
 	if useV1 {
 		err = imgprod.ProduceAllV1(b, ver, keys, encKeyFilename, encKeyIndex,
-			hdrPad, imagePad)
+			hdrPad, imagePad, sections)
 	} else {
 		err = imgprod.ProduceAll(b, ver, keys, encKeyFilename, encKeyIndex,
-			hdrPad, imagePad)
+			hdrPad, imagePad, sections)
 	}
 	if err != nil {
 		NewtUsage(nil, err)
@@ -200,6 +201,9 @@ func AddImageCommands(cmd *cobra.Command) {
 		"pad-header", "p", 0, "Pad header to this length")
 	createImageCmd.PersistentFlags().IntVarP(&imagePad,
 		"pad-image", "i", 0, "Pad image to this length")
+
+	createImageCmd.PersistentFlags().StringVarP(&sections,
+		"sections", "S", "", "Section names for TLVs, comma delimited")
 
 	cmd.AddCommand(createImageCmd)
 	AddTabCompleteFn(createImageCmd, targetList)

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -106,10 +106,10 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 
 			if useV1 {
 				err = imgprod.ProduceAllV1(b, ver, keys, encKeyFilename, encKeyIndex,
-					hdrPad, imagePad)
+					hdrPad, imagePad, sections)
 			} else {
 				err = imgprod.ProduceAll(b, ver, keys, encKeyFilename, encKeyIndex,
-					hdrPad, imagePad)
+					hdrPad, imagePad, sections)
 			}
 			if err != nil {
 				NewtUsage(nil, err)
@@ -168,6 +168,8 @@ func AddRunCommands(cmd *cobra.Command) {
 		"pad-header", "p", 0, "Pad header to this length")
 	runCmd.PersistentFlags().IntVarP(&imagePad,
 		"pad-image", "i", 0, "Pad image to this length")
+	runCmd.PersistentFlags().StringVarP(&sections,
+		"sections", "S", "", "Section names for TLVs, comma delimited")
 
 	cmd.AddCommand(runCmd)
 	AddTabCompleteFn(runCmd, func() []string {

--- a/newt/imgprod/v1.go
+++ b/newt/imgprod/v1.go
@@ -209,10 +209,10 @@ func ProduceImagesV1(opts ImageProdOpts) (ProducedImageSetV1, error) {
 
 func ProduceAllV1(t *builder.TargetBuilder, ver image.ImageVersion,
 	sigKeys []sec.PrivSignKey, encKeyFilename string, encKeyIndex int,
-	hdrPad int, imagePad int) error {
+	hdrPad int, imagePad int, sections string) error {
 
 	popts, err := OptsFromTgtBldr(t, ver, sigKeys, encKeyFilename, encKeyIndex,
-		hdrPad, imagePad)
+		hdrPad, imagePad, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This set of patches adds support for the Section TLV to newt.  The Section TLV is used to include information about an elf section in the binary.  This is necessary in some instances because the distributed images do not have accompanying elf files.  The TLV contains a offset and length to denote the elf section offset and length.

This TLV can be used by other tooling to access the specific section contents of a binary.