### PR TITLE
builder: Add package names to the environment variables

### DIFF
--- a/newt/builder/buildutil.go
+++ b/newt/builder/buildutil.go
@@ -321,5 +321,12 @@ func (b *Builder) EnvVars(imageSlot int) (map[string]string, error) {
 	env["MYNEWT_INCLUDE_PATH"] = strings.Join(b.compilerInfo.Includes, ":")
 	env["MYNEWT_CFLAGS"] = strings.Join(b.compilerInfo.Cflags, " ")
 
+	pkgNames := []string{}
+	for _, p := range b.PkgMap {
+		pkgNames = append(pkgNames, p.rpkg.Lpkg.FullName())
+	}
+	sort.Strings(pkgNames)
+	env["MYNEWT_PACKAGES"] = strings.Join(pkgNames, ":")
+
 	return env, nil
 }


### PR DESCRIPTION
This adds a list of the package names to the environment variables. I use this for my rust bindings. I only enable the bindings for packages that are actually enabled.