### PR TITLE
newt: Support legacy TLV option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
-	github.com/apache/mynewt-artifact v0.0.20
+	github.com/apache/mynewt-artifact v0.0.21
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/shirou/gopsutil v2.20.8+incompatible
@@ -16,3 +16,4 @@ require (
 	github.com/ugorji/go/codec v1.1.7
 	golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4
 )
+

--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -35,6 +35,7 @@ import (
 
 var useV1 bool
 var useV2 bool
+var useLegacyTLV bool
 var encKeyFilename string
 var encKeyIndex int
 var hdrPad int
@@ -136,10 +137,10 @@ func createImageRunCmd(cmd *cobra.Command, args []string) {
 
 	if useV1 {
 		err = imgprod.ProduceAllV1(b, ver, keys, encKeyFilename, encKeyIndex,
-			hdrPad, imagePad, sections)
+			hdrPad, imagePad, sections, useLegacyTLV)
 	} else {
 		err = imgprod.ProduceAll(b, ver, keys, encKeyFilename, encKeyIndex,
-			hdrPad, imagePad, sections)
+			hdrPad, imagePad, sections, useLegacyTLV)
 	}
 	if err != nil {
 		NewtUsage(nil, err)
@@ -204,6 +205,9 @@ func AddImageCommands(cmd *cobra.Command) {
 
 	createImageCmd.PersistentFlags().StringVarP(&sections,
 		"sections", "S", "", "Section names for TLVs, comma delimited")
+
+	createImageCmd.PersistentFlags().BoolVarP(&useLegacyTLV,
+		"legacy-tlvs", "L", false, "Use legacy TLV values for NONCE and SECRET_ID")
 
 	cmd.AddCommand(createImageCmd)
 	AddTabCompleteFn(createImageCmd, targetList)

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -106,10 +106,10 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 
 			if useV1 {
 				err = imgprod.ProduceAllV1(b, ver, keys, encKeyFilename, encKeyIndex,
-					hdrPad, imagePad, sections)
+					hdrPad, imagePad, sections, useLegacyTLV)
 			} else {
 				err = imgprod.ProduceAll(b, ver, keys, encKeyFilename, encKeyIndex,
-					hdrPad, imagePad, sections)
+					hdrPad, imagePad, sections, useLegacyTLV)
 			}
 			if err != nil {
 				NewtUsage(nil, err)

--- a/newt/imgprod/imgprod.go
+++ b/newt/imgprod/imgprod.go
@@ -54,6 +54,7 @@ type ImageProdOpts struct {
 	HdrPad            int
 	ImagePad          int
 	DummyC            *toolchain.Compiler
+	UseLegacyTLV      bool
 }
 
 type ProducedImage struct {
@@ -153,6 +154,7 @@ func produceApp(opts ImageProdOpts, loaderHash []byte) (ProducedImage, error) {
 		LoaderHash:        loaderHash,
 		HdrPad:            opts.HdrPad,
 		ImagePad:          opts.ImagePad,
+		UseLegacyTLV:      opts.UseLegacyTLV,
 	}
 
 	ri, err := image.GenerateImage(igo)
@@ -270,7 +272,7 @@ func ProduceManifest(opts manifest.ManifestCreateOpts) error {
 
 func OptsFromTgtBldr(b *builder.TargetBuilder, ver image.ImageVersion,
 	sigKeys []sec.PrivSignKey, encKeyFilename string, encKeyIndex int,
-	hdrPad int, imagePad int, sections []image.Section) (ImageProdOpts, error) {
+	hdrPad int, imagePad int, sections []image.Section, useLegacyTLV bool) (ImageProdOpts, error) {
 
 	// This compiler is just used for converting .img files to .hex files, so
 	// dummy paths are OK.
@@ -305,6 +307,7 @@ func OptsFromTgtBldr(b *builder.TargetBuilder, ver image.ImageVersion,
 		HdrPad:         hdrPad,
 		ImagePad:       imagePad,
 		Sections:       sections,
+		UseLegacyTLV:   useLegacyTLV,
 	}
 
 	if b.LoaderBuilder != nil {
@@ -318,7 +321,7 @@ func OptsFromTgtBldr(b *builder.TargetBuilder, ver image.ImageVersion,
 
 func ProduceAll(t *builder.TargetBuilder, ver image.ImageVersion,
 	sigKeys []sec.PrivSignKey, encKeyFilename string, encKeyIndex int,
-	hdrPad int, imagePad int, sectionString string) error {
+	hdrPad int, imagePad int, sectionString string, useLegacyTLV bool) error {
 
 	elfPath := t.AppBuilder.AppElfPath()
 
@@ -366,7 +369,7 @@ func ProduceAll(t *builder.TargetBuilder, ver image.ImageVersion,
 	}
 
 	popts, err := OptsFromTgtBldr(t, ver, sigKeys, encKeyFilename, encKeyIndex,
-		hdrPad, imagePad, sections)
+		hdrPad, imagePad, sections, useLegacyTLV)
 	if err != nil {
 		return err
 	}

--- a/newt/imgprod/v1.go
+++ b/newt/imgprod/v1.go
@@ -209,10 +209,10 @@ func ProduceImagesV1(opts ImageProdOpts) (ProducedImageSetV1, error) {
 
 func ProduceAllV1(t *builder.TargetBuilder, ver image.ImageVersion,
 	sigKeys []sec.PrivSignKey, encKeyFilename string, encKeyIndex int,
-	hdrPad int, imagePad int, sections string) error {
+	hdrPad int, imagePad int, sections string, useLegacyTLV bool) error {
 
 	popts, err := OptsFromTgtBldr(t, ver, sigKeys, encKeyFilename, encKeyIndex,
-		hdrPad, imagePad, nil)
+		hdrPad, imagePad, nil, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch adds support for generating images using legacy TLV values for
AES_NONCE and SECRET_ID.  This allows newer newt tool versions to be able to
create new application images for devices which only support legacy TLV values.

Bumps mynewt-artifact to v0.0.21

Signed-off-by: Andy Gross <andy.gross@juul.com>