### PR TITLE
Relax empty values override restriction

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -383,7 +383,7 @@ func (entry *CfgEntry) priorityViolations() []CfgPriority {
 		curType := normalizePkgType(p.Source.Type())
 		defType := normalizePkgType(entry.PackageDef.Type())
 
-		if p.Source != entry.PackageDef && curType <= defType {
+		if p.Source != entry.PackageDef && curType <= defType && entry.History[0].Value != "" {
 			priority := CfgPriority{
 				PackageDef:  entry.PackageDef,
 				PackageSrc:  p.Source,


### PR DESCRIPTION
With this change syscfg variables that are defined but don't have
default values in syscfg.defs, can be set in other packages and not only
bsp/app/target.

This way MCU packages can set values that otherwise would have to be
set by every BSP.

Since there is no default value, single package that provides value
is not creating any conflicts.