### PR TITLE
Update go.sum with correct sums

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/apache/mynewt-artifact v0.0.16 h1:MUy07kNuCgZHXqEpJRp3JbZcdT3FkWUW4oi
 github.com/apache/mynewt-artifact v0.0.16/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/apache/mynewt-artifact v0.0.20 h1:zf3RACAEGNH0s11QyqB8QeAuMr/e/DmRfHaP5pLjzpw=
 github.com/apache/mynewt-artifact v0.0.20/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
+github.com/apache/mynewt-artifact v0.0.21 h1:1Gf5c+HRQvGmXdcAXZkBp/Bfe9tIKkRF6WeM09cOM8s=
+github.com/apache/mynewt-artifact v0.0.21/go.mod h1:vFUd47t74KPQMzSBhQ2qp5Hc7D29OU/Tl3xHtFwN3k8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=


### PR DESCRIPTION
This patch adds the sums for the latest mynewt-artifact changes into the go.sum file.

Signed-off-by: Andy Gross <andy.gross@juul.com>