### PR TITLE
travis: Run on Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@
 
 language: go
 
+dist: bionic
+
 _addons: &addon_conf
   apt:
     sources:


### PR DESCRIPTION
Update the Travis environment to use Bionic (18.04) instead of Xenial
(16.04) due to issues installing gcc-multilib.