### PR TITLE
Allow working on repos that lack a "master" branch

### DIFF
--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -366,7 +366,8 @@ func (r *Repo) UpdateDesc() (bool, error) {
 func (r *Repo) EnsureExists() error {
 	// Clone the repo if it doesn't exist.
 	if !r.CheckExists() {
-		if err := r.downloadRepo("master"); err != nil {
+		branch := r.downloader.MainBranch()
+		if err := r.downloadRepo(branch); err != nil {
 			return err
 		}
 	}
@@ -401,7 +402,7 @@ func (r *Repo) downloadFile(commit string, srcPath string) (string, error) {
 }
 
 func (r *Repo) downloadRepositoryYml() error {
-	if _, err := r.downloadFile("master", REPO_FILE_NAME); err != nil {
+	if _, err := r.downloadFile(r.downloader.MainBranch(), REPO_FILE_NAME); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add a new key option `branch:` that can be configured for git/github downloaders, so a user can override the default of "master", and `newt` is gonna look for the yaml files on the given branch, eg:

```
repository.my_development_repo:
    type: git
    url: git@github.com:my_org/my_development_repo.git
    branch: dev
    vers: 0-dev
```

This will clone the repo using "dev" as the default branch.