### PR TITLE
executeShell: escape also '<' and '>'

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -367,7 +367,10 @@ func ShellCommandLimitDbgOutput(
 	if ExecuteShell && (runtime.GOOS == "linux" || runtime.GOOS == "darwin") {
 		cmd := strings.Join(cmdStrs, " ")
 		name = "/bin/sh"
-		args = []string{"-c", strings.Replace(cmd, "\"", "\\\"", -1)}
+		cmd = strings.Replace(cmd, "\"", "\\\"", -1)
+		cmd = strings.Replace(cmd, "<", "\\<", -1)
+		cmd = strings.Replace(cmd, ">", "\\>", -1)
+		args = []string{"-c", cmd}
 	} else {
 		if strings.HasSuffix(cmdStrs[0], ".sh") {
 			var newt_sh = os.Getenv("NEWT_SH")


### PR DESCRIPTION
option --executeShell escaped quotation marks
on lines that were passed to bin/sh.

This also escapes '<' and '>' before running sh.
This allows to have cflags in the form
-DMBEDTLS_USER_CONFIG_FILE=<mbedtls/config_mynewt.h>