### PR TITLE
cmake: escape also '<' and '>'

### DIFF
--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -69,6 +69,8 @@ func escapeFlags(flag string) string {
 	flag = strings.Replace(flag, "\"", "\\\\\\\"", -1)
 	flag = strings.Replace(flag, "(", "\\\\(", -1)
 	flag = strings.Replace(flag, ")", "\\\\)", -1)
+	flag = strings.Replace(flag, "<", "\\\\<", -1)
+	flag = strings.Replace(flag, ">", "\\\\>", -1)
 	return flag
 }
 


### PR DESCRIPTION
cmake execute commands with sh so < and > also has to be escaped like " ( )
This allows to have cflags in the form
-DMBEDTLS_USER_CONFIG_FILE=<mbedtls/config_mynewt.h>