### PR TITLE
mfg: account for updated bootloader path in mfg command

### DIFF
--- a/newt/builder/paths.go
+++ b/newt/builder/paths.go
@@ -28,6 +28,7 @@ import (
 	"mynewt.apache.org/newt/util"
 )
 
+const BUILD_NAME_BOOT = "app/@mcuboot"
 const BUILD_NAME_APP = "app"
 const BUILD_NAME_LOADER = "loader"
 

--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -223,7 +223,12 @@ func newMfgBuildTarget(dt DecodedTarget,
 		t.App().Name())
 	man, err := manifest.ReadManifest(mpath)
 	if err != nil {
-		return MfgBuildTarget{}, util.FmtNewtError("%s", err.Error())
+		mpath = builder.ManifestPath(dt.Name, builder.BUILD_NAME_BOOT,
+			t.App().Name())
+		man, err = manifest.ReadManifest(mpath)
+		if err != nil {
+			return MfgBuildTarget{}, util.FmtNewtError("%s", err.Error())
+		}
 	}
 
 	isBoot := parse.ValueIsTrue(man.Syscfg["BOOT_LOADER"])

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -99,7 +99,7 @@ type MfgEmitter struct {
 // `.bin` files; image targets use `.img`.
 func targetSrcBinPath(t *target.Target, isBoot bool) string {
 	if isBoot {
-		return builder.AppBinPath(t.Name(), builder.BUILD_NAME_APP,
+		return builder.AppBinPath(t.Name(), builder.BUILD_NAME_BOOT,
 			t.App().Name())
 	} else {
 		return builder.AppImgPath(t.Name(), builder.BUILD_NAME_APP,
@@ -108,26 +108,41 @@ func targetSrcBinPath(t *target.Target, isBoot bool) string {
 }
 
 // Calculates the source path of a target's `.elf` file.
-func targetSrcElfPath(t *target.Target) string {
-	return builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name())
+func targetSrcElfPath(t *target.Target, isBoot bool) string {
+	if isBoot {
+		return builder.AppElfPath(t.Name(), builder.BUILD_NAME_BOOT, t.App().Name())
+	} else {
+		return builder.AppElfPath(t.Name(), builder.BUILD_NAME_APP, t.App().Name())
+	}
 }
 
 // Calculates the source path of a target's manifest file.
-func targetSrcManifestPath(t *target.Target) string {
-	return builder.ManifestPath(t.Name(), builder.BUILD_NAME_APP,
-		t.App().Name())
+func targetSrcManifestPath(t *target.Target, isBoot bool) string {
+	if isBoot {
+		return builder.ManifestPath(t.Name(), builder.BUILD_NAME_BOOT,
+			t.App().Name())
+	} else {
+		return builder.ManifestPath(t.Name(), builder.BUILD_NAME_APP,
+			t.App().Name())
+	}
 }
 
 func newMfgEmitTarget(bt MfgBuildTarget) (MfgEmitTarget, error) {
+	var build_name string
+	if bt.IsBoot {
+		build_name = builder.BUILD_NAME_BOOT
+	} else {
+		build_name = builder.BUILD_NAME_APP
+	}
 	return MfgEmitTarget{
 		Name:    bt.Target.FullName(),
 		Offset:  bt.Area.Offset + bt.Offset,
 		Size:    bt.Size,
 		IsBoot:  bt.IsBoot,
 		BinPath: targetSrcBinPath(bt.Target, bt.IsBoot),
-		ElfPath: targetSrcElfPath(bt.Target),
+		ElfPath: targetSrcElfPath(bt.Target, bt.IsBoot),
 		ManifestPath: builder.ManifestPath(bt.Target.Name(),
-			builder.BUILD_NAME_APP, bt.Target.App().Name()),
+			build_name, bt.Target.App().Name()),
 		ExtraManifest: bt.ExtraManifest,
 	}, nil
 }


### PR DESCRIPTION
Bootloader binaries seem to have moved to `app/@mcuboot`, which causes `mfg` command to fail, see https://github.com/apache/mynewt-newt/issues/439. This PR attempts to account for this change.