### PR TITLE
mfg: Add a base address field 

### DIFF
--- a/newt/cli/mfg_cmds.go
+++ b/newt/cli/mfg_cmds.go
@@ -31,6 +31,8 @@ import (
 	"mynewt.apache.org/newt/util"
 )
 
+var baseAddress int
+
 func ResolveMfgPkg(pkgName string) (*pkg.LocalPackage, error) {
 	proj := TryGetProject()
 
@@ -114,7 +116,7 @@ func mfgCreateRunCmd(cmd *cobra.Command, args []string) {
 		NewtUsage(nil, err)
 	}
 
-	me, err := mfg.LoadMfgEmitter(lpkg, ver, keys)
+	me, err := mfg.LoadMfgEmitter(lpkg, ver, keys, baseAddress)
 	if err != nil {
 		NewtUsage(nil, err)
 	}
@@ -156,7 +158,7 @@ func mfgDeployRunCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	me, err := mfg.LoadMfgEmitter(lpkg, ver, nil)
+	me, err := mfg.LoadMfgEmitter(lpkg, ver, nil, baseAddress)
 	if err != nil {
 		NewtUsage(nil, err)
 	}
@@ -179,6 +181,8 @@ func AddMfgCommands(cmd *cobra.Command) {
 		},
 	}
 
+	mfgCmd.PersistentFlags().IntVarP(&baseAddress,
+		"base-address", "b", 0, "Base address of the chip")
 	cmd.AddCommand(mfgCmd)
 
 	mfgCreateCmd := &cobra.Command{

--- a/newt/mfg/misc.go
+++ b/newt/mfg/misc.go
@@ -44,7 +44,7 @@ func loadDecodedMfg(basePath string) (DecodedMfg, error) {
 }
 
 func LoadMfgEmitter(basePkg *pkg.LocalPackage,
-	ver image.ImageVersion, keys []sec.PrivSignKey) (MfgEmitter, error) {
+	ver image.ImageVersion, keys []sec.PrivSignKey, baseAddress int) (MfgEmitter, error) {
 
 	dm, err := loadDecodedMfg(basePkg.BasePath())
 	if err != nil {
@@ -55,6 +55,7 @@ func LoadMfgEmitter(basePkg *pkg.LocalPackage,
 	if err != nil {
 		return MfgEmitter{}, err
 	}
+	mb.BaseAddress = baseAddress
 
 	device, err := mb.calcDevice()
 	if err != nil {


### PR DESCRIPTION
Chips with > 1 core, like `nrf53` have the second core mapped to a different address offset than 0x0 (in the case of nrf53, network core is based at 0x1000000). This PR adds a base address field that can be provided in the `mfg.yml` in an attempt to get `mfg` to create appropriately sized binaries. Without this change, the manufacturing image tends to become very large in size (several megabytes) as the base address for that core is not 0x0.
This PR introduces an optional `base-address` command line option that can be provided as an input to `mfg create`. This value will default to 0 internally if this field is not provided.