### PR TITLE
Fix copying repos with symlinks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/otiai10/copy v1.6.0 // indirect
 	github.com/shirou/gopsutil v2.20.8+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cast v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,12 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
+github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/util/util.go
+++ b/util/util.go
@@ -38,6 +38,8 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/otiai10/copy"
 )
 
 var Verbosity int
@@ -539,37 +541,16 @@ func CopyFile(srcFile string, dstFile string) error {
 }
 
 func CopyDir(srcDirStr, dstDirStr string) error {
-	srcDir, err := os.Open(srcDirStr)
+	opt := copy.Options{
+		OnSymlink: func(src string) copy.SymlinkAction {
+			return copy.Shallow
+		},
+	}
+
+	err := copy.Copy(srcDirStr, dstDirStr, opt)
+
 	if err != nil {
 		return ChildNewtError(err)
-	}
-
-	info, err := srcDir.Stat()
-	if err != nil {
-		return ChildNewtError(err)
-	}
-
-	if err := os.MkdirAll(dstDirStr, info.Mode()); err != nil {
-		return ChildNewtError(err)
-	}
-
-	infos, err := srcDir.Readdir(-1)
-	if err != nil {
-		return ChildNewtError(err)
-	}
-
-	for _, info := range infos {
-		src := srcDirStr + "/" + info.Name()
-		dst := dstDirStr + "/" + info.Name()
-		if info.IsDir() {
-			if err := CopyDir(src, dst); err != nil {
-				return err
-			}
-		} else {
-			if err := CopyFile(src, dst); err != nil {
-				return err
-			}
-		}
 	}
 
 	return nil


### PR DESCRIPTION
The CopyDir implementation did not created symlinks but instead was
creating copy of a files resultign in dirty repo.