### PR TITLE
 Allow to inject syscfg from command line

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -440,6 +440,9 @@ func AddBuildCommands(cmd *cobra.Command) {
 	buildCmd.Flags().BoolVarP(&printShellCmds, "printCmds", "p", false,
 		"Print executed build commands")
 
+	buildCmd.Flags().StringVarP(&util.InjectSyscfg, "syscfg", "S", "",
+		"Injected syscfg settings, key=value pairs separated by colon")
+
 	buildCmd.Flags().BoolVar(&executeShell, "executeShell", false,
 		"Execute build command using /bin/sh (Linux and MacOS only)")
 

--- a/newt/cli/image_cmds.go
+++ b/newt/cli/image_cmds.go
@@ -209,6 +209,9 @@ func AddImageCommands(cmd *cobra.Command) {
 	createImageCmd.PersistentFlags().BoolVarP(&useLegacyTLV,
 		"legacy-tlvs", "L", false, "Use legacy TLV values for NONCE and SECRET_ID")
 
+	createImageCmd.Flags().StringVarP(&util.InjectSyscfg, "syscfg", "", "",
+		"Injected syscfg settings, key=value pairs separated by colon")
+
 	cmd.AddCommand(createImageCmd)
 	AddTabCompleteFn(createImageCmd, targetList)
 

--- a/newt/cli/target_cfg_cmds.go
+++ b/newt/cli/target_cfg_cmds.go
@@ -62,8 +62,16 @@ func printSetting(entry syscfg.CfgEntry) {
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			"    * Overridden: ")
 		for i := 1; i < len(entry.History); i++ {
-			util.StatusMessage(util.VERBOSITY_DEFAULT, "%s, ",
-				entry.History[i].Source.FullName())
+			var fullName string
+
+			lpkg := entry.History[i].Source
+			if lpkg == nil {
+				fullName = "<command line>"
+			} else {
+				fullName = lpkg.FullName()
+			}
+
+			util.StatusMessage(util.VERBOSITY_DEFAULT, "%s, ", fullName)
 		}
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			"default=%s\n", entry.History[0].Value)
@@ -82,8 +90,16 @@ func printBriefSetting(entry syscfg.CfgEntry) {
 	var extras []string
 
 	if len(entry.History) > 1 {
-		s := fmt.Sprintf("overridden by %s",
-			entry.History[len(entry.History)-1].Source.FullName())
+		var fullName string
+
+		lpkg := entry.History[len(entry.History)-1].Source
+		if lpkg == nil {
+			fullName = "<command line>"
+		} else {
+			fullName = lpkg.FullName()
+		}
+
+		s := fmt.Sprintf("overridden by %s", fullName)
 		extras = append(extras, s)
 	}
 	if len(entry.ValueRefName) > 0 {
@@ -786,6 +802,9 @@ func targetCfgCmdAll() []*cobra.Command {
 		Run:   targetConfigShowCmd,
 	}
 
+	configShowCmd.Flags().StringVarP(&util.InjectSyscfg, "syscfg", "S", "",
+		"Injected syscfg settings, key=value pairs separated by colon")
+
 	configCmd.AddCommand(configShowCmd)
 	AddTabCompleteFn(configShowCmd, func() []string {
 		return append(targetList(), unittestList()...)
@@ -798,6 +817,9 @@ func targetCfgCmdAll() []*cobra.Command {
 		Run:   targetConfigBriefCmd,
 	}
 
+	configBriefCmd.Flags().StringVarP(&util.InjectSyscfg, "syscfg", "S", "",
+		"Injected syscfg settings, key=value pairs separated by colon")
+
 	configCmd.AddCommand(configBriefCmd)
 	AddTabCompleteFn(configBriefCmd, func() []string {
 		return append(targetList(), unittestList()...)
@@ -809,6 +831,9 @@ func targetCfgCmdAll() []*cobra.Command {
 		Long:  "View a flat table of target's system configuration",
 		Run:   targetConfigFlatCmd,
 	}
+
+	configFlatCmd.Flags().StringVarP(&util.InjectSyscfg, "syscfg", "S", "",
+		"Injected syscfg settings, key=value pairs separated by colon")
 
 	configCmd.AddCommand(configFlatCmd)
 	AddTabCompleteFn(configFlatCmd, func() []string {

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -598,6 +598,7 @@ func (r *Resolver) reloadCfg() (bool, error) {
 		return false, err
 	}
 
+	cfg.AddInjectedSettings()
 	cfg.ResolveValueRefs()
 
 	// Determine if any new settings have been added or if any existing

--- a/util/util.go
+++ b/util/util.go
@@ -44,6 +44,7 @@ import (
 
 var Verbosity int
 var PrintShellCmds bool
+var InjectSyscfg string
 var ExecuteShell bool
 var EscapeShellCmds bool
 var logFile *os.File


### PR DESCRIPTION
This adds new -S/--syscfg command line switch to build and config
commands which allows to inject syscfg settings from command line.
Injected settings have highest priority and thus will override any
other value set by any other package.

The purpose of this setting is to easily allow to use single targets
to build multiple similar images, e.g. that have only different BLE
public address different. It is not intended to be used instead of
having multiple targets to build different images (which is still
preferred setup), but to allow quickly build variants of the same
target wihout need to edit files every time.