### PR TITLE
toolchain: Link all archives with -whole-archive

### DIFF
--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -918,6 +918,7 @@ func (c *Compiler) CompileBinaryCmd(dstFile string, options map[string]bool,
 		cmd = append(cmd, "-Wl,--just-symbols="+elfLib)
 	}
 
+	cmd = append(cmd, "-Wl,-whole-archive")
 	if c.ldResolveCircularDeps {
 		cmd = append(cmd, "-Wl,--start-group")
 		cmd = append(cmd, objList...)
@@ -925,6 +926,7 @@ func (c *Compiler) CompileBinaryCmd(dstFile string, options map[string]bool,
 	} else {
 		cmd = append(cmd, objList...)
 	}
+	cmd = append(cmd, "-Wl,-no-whole-archive")
 
 	if keepSymbols != nil {
 		for _, name := range keepSymbols {


### PR DESCRIPTION
Using -whole-archives guarantees that all objects from .a files are
included in build. It should not affect regular builds since we want to
include all objects from Mynewt packages anyway, but it helps to resolve
weak symbols properly if weak and non-weak counterparts are defined in
the same package/library/archive.