### PR TITLE
Add dependency graph output in DOT format

### DIFF
--- a/newt/builder/depgraph.go
+++ b/newt/builder/depgraph.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 
 	"mynewt.apache.org/newt/newt/parse"
 	"mynewt.apache.org/newt/newt/resolve"
@@ -182,6 +183,27 @@ func DepGraphText(graph DepGraph) string {
 	return buffer.String()
 }
 
+func DepGraphViz(graph DepGraph) string {
+	parents := make([]string, 0, len(graph))
+	for pname, _ := range graph {
+		parents = append(parents, pname)
+	}
+	sort.Strings(parents)
+
+	buffer := bytes.NewBufferString("")
+
+	fmt.Fprintf(buffer, "digraph deps {\n")
+	for _, pname := range parents {
+		for _, child := range graph[pname] {
+			depStr := strings.TrimPrefix(depString(child), child.PkgName)
+			fmt.Fprintf(buffer, "  \"%s\" -> \"%s\" [label=\"%s\"];\n", pname, child.PkgName, depStr)
+		}
+	}
+	fmt.Fprintf(buffer, "}\n")
+
+	return buffer.String()
+}
+
 func RevdepGraphText(graph DepGraph) string {
 	parents := make([]string, 0, len(graph))
 	for pname, _ := range graph {
@@ -202,6 +224,27 @@ func RevdepGraphText(graph DepGraph) string {
 		}
 		fmt.Fprintf(buffer, "]")
 	}
+
+	return buffer.String()
+}
+
+func RevdepGraphViz(graph DepGraph) string {
+	parents := make([]string, 0, len(graph))
+	for pname, _ := range graph {
+		parents = append(parents, pname)
+	}
+	sort.Strings(parents)
+
+	buffer := bytes.NewBufferString("")
+
+	fmt.Fprintf(buffer, "digraph revdeps {\n")
+	for _, pname := range parents {
+		for _, child := range graph[pname] {
+			depStr := strings.TrimPrefix(depString(child), child.PkgName)
+			fmt.Fprintf(buffer, "  \"%s\" -> \"%s\" [label=\"%s\"];\n", child.PkgName, pname, depStr)
+		}
+	}
+	fmt.Fprintf(buffer, "}\n")
 
 	return buffer.String()
 }

--- a/newt/cli/target_cmds.go
+++ b/newt/cli/target_cmds.go
@@ -572,7 +572,7 @@ func targetCopyCmd(cmd *cobra.Command, args []string) {
 		srcTarget.FullName(), dstTarget.FullName())
 }
 
-func targetDepCmd(cmd *cobra.Command, args []string) {
+func targetDepCommonCmd(cmd *cobra.Command, args []string) builder.DepGraph {
 	if len(args) < 1 {
 		NewtUsage(cmd,
 			util.NewNewtError("Must specify target or unittest name"))
@@ -611,13 +611,27 @@ func targetDepCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	return dg
+}
+
+func targetDepCmd(cmd *cobra.Command, args []string) {
+	dg := targetDepCommonCmd(cmd, args)
+
 	if len(dg) > 0 {
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			builder.DepGraphText(dg)+"\n")
 	}
 }
 
-func targetRevdepCmd(cmd *cobra.Command, args []string) {
+func targetDepvizCmd(cmd *cobra.Command, args []string) {
+	dg := targetDepCommonCmd(cmd, args)
+
+	if len(dg) > 0 {
+		fmt.Print(builder.DepGraphViz(dg))
+	}
+}
+
+func targetRevdepCommonCmd(cmd *cobra.Command, args []string) builder.DepGraph {
 	if len(args) < 1 {
 		NewtUsage(cmd, util.NewNewtError("Must specify target name"))
 	}
@@ -655,9 +669,23 @@ func targetRevdepCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	return dg
+}
+
+func targetRevdepCmd(cmd *cobra.Command, args []string) {
+	dg := targetRevdepCommonCmd(cmd, args)
+
 	if len(dg) > 0 {
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			builder.RevdepGraphText(dg)+"\n")
+	}
+}
+
+func targetRevdepvizCmd(cmd *cobra.Command, args []string) {
+	dg := targetRevdepCommonCmd(cmd, args)
+
+	if len(dg) > 0 {
+		fmt.Print(builder.RevdepGraphViz(dg))
 	}
 }
 
@@ -819,6 +847,20 @@ func AddTargetCommands(cmd *cobra.Command) {
 		return append(targetList(), unittestList()...)
 	})
 
+	depvizHelpText := "Output dependency graph in DOT format."
+
+	depvizCmd := &cobra.Command{
+		Use:   "depviz <target> [pkg-1] [pkg-2] [...]",
+		Short: "Output dependency graph in DOT format",
+		Long:  depvizHelpText,
+		Run:   targetDepvizCmd,
+	}
+
+	targetCmd.AddCommand(depvizCmd)
+	AddTabCompleteFn(depvizCmd, func() []string {
+		return append(targetList(), unittestList()...)
+	})
+
 	revdepHelpText := "View a target's reverse-dependency graph."
 
 	revdepCmd := &cobra.Command{
@@ -830,6 +872,20 @@ func AddTargetCommands(cmd *cobra.Command) {
 
 	targetCmd.AddCommand(revdepCmd)
 	AddTabCompleteFn(revdepCmd, func() []string {
+		return append(targetList(), unittestList()...)
+	})
+
+	revdepvizHelpText := "Output reverse-dependency graph in DOT format."
+
+	revdepvizCmd := &cobra.Command{
+		Use:   "revdepviz <target> [pkg-1] [pkg-2] [...]",
+		Short: "Output reverse-dependency graph in DOT format",
+		Long:  revdepvizHelpText,
+		Run:   targetRevdepvizCmd,
+	}
+
+	targetCmd.AddCommand(revdepvizCmd)
+	AddTabCompleteFn(revdepvizCmd, func() []string {
 		return append(targetList(), unittestList()...)
 	})
 


### PR DESCRIPTION
This adds two commands "target depviz" and "target revdepviz" which can
output dependency graph in DOT format. The usage is the same as "target
dep" and "target revdep", only the ouput format is different.