### PR TITLE
Add shorthand form for choices

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -490,7 +490,14 @@ func readSetting(name string, lpkg *pkg.LocalPackage,
 	}
 
 	if vals["choices"] != nil {
-		choices := cast.ToStringSlice(vals["choices"])
+		var choices []string
+		switch vals["choices"].(type) {
+		default:
+			choices = cast.ToStringSlice(vals["choices"])
+		case string:
+			choices = strings.Split(vals["choices"].(string), ",")
+		}
+
 		entry.ValidChoices = choices
 
 		sort.Slice(choices, func(a, b int) bool {


### PR DESCRIPTION
Choices can now be also specified as comma-separated string. This means
both following choices definitions are valid and define the same set of
allowed values:

```
choices:
  - foo
  - bar
  - foobar
```
```
choices: foo,bar,foobar
```