### PR TITLE
Fix restrictions evaluation

### DIFF
--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -619,6 +619,8 @@ func (r *Resolver) reloadCfg() (bool, error) {
 		}
 	}
 
+	r.cfg = cfg
+
 	return false, nil
 }
 


### PR DESCRIPTION
The resolving process seems to not update restrictions properly in some
cases. Here's how it fails to update them:

1. reloadCfg loads settings and restrictions (and other data too, but
   that's not relevant here) for all packages resolved in previous pass
2. configuration change is detected
3. dependencies are resolved

At this point package X is added due to pkg.deps constraints based on
syscfg Y.

4. reloadCfg loads settings and restrictions again
5. configuration change is detected
6. dependencies are resolved one more time

At this point, syscfg Y changed and package X is removed as previous
pkg.deps constraints do not apply anymore. Removing package X means
r.cfg.Settings is updated - this is crucial here.

7. reloadCfg load settings and restrictions one more time

And here's the problem: it does not detect that settings have changed
since those from removed package were already removed in previous pass.
Consequently it does not update r.cfg so restrictions state is kept
from previous pass, i.e. before package X was removed.

This can be fixed by always updating r.cfg to latest configuration as
load by reloadCfg.