### PR TITLE
cmake: Fix trimming project path on Windows

### DIFF
--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -141,7 +141,7 @@ func CmakeSourceObjectWrite(w io.Writer, cj toolchain.CompilerJob,
 	otherFlags = util.SortFields(otherFlags...)
 
 	fmt.Fprintf(w,
-`set_property(SOURCE %s APPEND_STRING
+		`set_property(SOURCE %s APPEND_STRING
              PROPERTY COMPILE_FLAGS
              "%s")`,
 		cj.Filename,
@@ -261,7 +261,7 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 	compileFlags = util.SortFields(compileFlags...)
 
 	fmt.Fprintf(w,
-`set_property(TARGET %s APPEND_STRING
+		`set_property(TARGET %s APPEND_STRING
              PROPERTY
              COMPILE_FLAGS
              "%s")`,
@@ -290,7 +290,7 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 	lFlags = append(lFlags, cxxFlags...)
 
 	fmt.Fprintf(w,
-`set_target_properties(%s
+		`set_target_properties(%s
                       PROPERTIES
                       ARCHIVE_OUTPUT_DIRECTORY %s
                       LIBRARY_OUTPUT_DIRECTORY %s
@@ -341,7 +341,7 @@ func CmakeCompilerInfoWrite(w io.Writer, archiveFile string, bpkg *BuildPackage,
 	replaceBackslashesSlice(includes)
 
 	fmt.Fprintf(w,
-`set_target_properties(%s
+		`set_target_properties(%s
                       PROPERTIES
                       ARCHIVE_OUTPUT_DIRECTORY %s
                       LIBRARY_OUTPUT_DIRECTORY %s

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -88,8 +88,8 @@ func escapeFlagsSlice(flags []string) []string {
 
 func trimProjectPath(path string) string {
 	proj := interfaces.GetProject()
-	path = strings.TrimPrefix(path, proj.Path()+"/")
-	return path
+	path, _ = filepath.Rel(proj.Path(), path)
+	return replaceBackslashes(path)
 }
 
 func trimProjectPathSlice(elements []string) {
@@ -198,7 +198,7 @@ func (b *Builder) CMakeBuildPackageWrite(w io.Writer, bpkg *BuildPackage,
 	fmt.Fprintf(w, "add_library(%s %s)\n",
 		EscapePkgName(pkgName),
 		strings.Join(files, " "))
-	archivePath := replaceBackslashes(trimProjectPath(filepath.Dir(b.ArchivePath(bpkg))))
+	archivePath := trimProjectPath(filepath.Dir(b.ArchivePath(bpkg)))
 	CmakeCompilerInfoWrite(w, archivePath, bpkg, entries[0], otherIncludes)
 
 	return bpkg, nil
@@ -241,7 +241,7 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 			ExtractLibraryName(filename)))
 	}
 
-	elfOutputDir := replaceBackslashes(trimProjectPath(filepath.Dir(b.AppElfPath())))
+	elfOutputDir := trimProjectPath(filepath.Dir(b.AppElfPath()))
 	fmt.Fprintf(w, "file(WRITE %s \"\")\n", replaceBackslashes(filepath.Join(elfOutputDir, "null.c")))
 	fmt.Fprintf(w, "add_executable(%s %s)\n\n", elfName,
 		replaceBackslashes(filepath.Join(elfOutputDir, "null.c")))


### PR DESCRIPTION
strings.TrimPrefix does not work properly if path already uses
backshasles as path separator, filepath.Rel will take care of that
automatically.