### PR TITLE
Add options to skip some git related stuff on each build

### DIFF
--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -22,6 +22,7 @@ package newtutil
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -178,12 +179,17 @@ func MakeTempRepoDir() (string, error) {
 }
 
 func ProjRelPath(path string) string {
-	if strings.HasPrefix(path, "/") {
-		return path
+	if filepath.IsAbs(path) {
+		proj := interfaces.GetProject()
+		if proj != nil {
+			relPath, err := filepath.Rel(proj.Path(), path)
+			if err == nil {
+				path = relPath
+			}
+		}
 	}
 
-	proj := interfaces.GetProject()
-	return strings.TrimPrefix(path, proj.Path()+"/")
+	return path
 }
 
 func PrintNewtVersion() {

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -587,9 +587,11 @@ func (proj *Project) loadConfig(download bool) error {
 		return err
 	}
 
-	// Warn the user about incompatibilities with this version of newt.
-	if err := proj.verifyNewtCompat(); err != nil {
-		return err
+	if !util.SkipNewtCompat {
+		// Warn the user about incompatibilities with this version of newt.
+		if err := proj.verifyNewtCompat(); err != nil {
+			return err
+		}
 	}
 
 	ignoreDirs, err := yc.GetValStringSlice("project.ignore_dirs", nil)

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -56,6 +56,9 @@ func processNewtrc(yc ycfg.YCfg) {
 
 	// default is 0 anyway, no need to initialize first
 	util.ShallowCloneDepth, _ = yc.GetValIntDflt("shallow_clone", nil, -1)
+
+	util.SkipNewtCompat, _ = yc.GetValBoolDflt("skip_newt_compat", nil, false)
+	util.SkipSyscfgRepoHash, _ = yc.GetValBoolDflt("skip_syscfg_repo_hash", nil, false)
 }
 
 func readNewtrc() ycfg.YCfg {

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -1589,8 +1589,10 @@ func write(cfg Cfg, w io.Writer) {
 	writeCheckMacros(w)
 	fmt.Fprintf(w, "\n")
 
-	writeReposInfo(w)
-	fmt.Fprintf(w, "\n")
+	if !util.SkipSyscfgRepoHash {
+		writeReposInfo(w)
+		fmt.Fprintf(w, "\n")
+	}
 
 	writeSettings(cfg, w)
 	fmt.Fprintf(w, "\n")

--- a/util/util.go
+++ b/util/util.go
@@ -49,6 +49,8 @@ var ExecuteShell bool
 var EscapeShellCmds bool
 var ShallowCloneDepth int
 var logFile *os.File
+var SkipNewtCompat bool
+var SkipSyscfgRepoHash bool
 
 func ParseEqualsPair(v string) (string, string, error) {
 	s := strings.Split(v, "=")


### PR DESCRIPTION
This adds two new options to newtrc.yml:
- skip_newt_compat - allows to skip checking newt compatibility
- skip_syscfg_repo_hash - allows to skip generation of repo hashes to
  syscfg

Those can skip operations that are not essential for build but can be
potentially git-intensive which means they are painfully slow on
Windows.

Both options are boolean and disabled by default.