### PR TITLE
Fix misleading error message for mfg raw

### DIFF
--- a/newt/mfg/decode.go
+++ b/newt/mfg/decode.go
@@ -225,7 +225,7 @@ func decodeRaw(yamlRaw interface{}, entryIdx int) (DecodedRaw, error) {
 	filenameVal := kv["name"]
 	if filenameVal == nil {
 		return dr, util.FmtNewtError(
-			"mfg raw entry missing required field \"filename\"")
+			"mfg raw entry missing required field \"name\"")
 	}
 	dr.Filename = cast.ToString(filenameVal)
 


### PR DESCRIPTION
Code checked existence of "name" field in yaml file
and when not found reports that "filename" was missing.

Now correct missing filed is reported.