### PR TITLE
Don't default to shallow clone for 'new' command

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -60,6 +60,14 @@ func newRunCmd(cmd *cobra.Command, args []string) {
 	}
 	defer os.RemoveAll(tmpdir)
 
+	/* For new command don't use shallow copy by default
+	 * as release tag may not be present on tip of master
+	 * branch.
+	 */
+	if util.ShallowCloneDepth < 0 {
+		util.ShallowCloneDepth = 0;
+	}
+
 	if err := dl.Clone("master", tmpdir); err != nil {
 		NewtUsage(nil, err)
 	}


### PR DESCRIPTION
Release tag may no longer be on top of master branch and shallow
copy would result if checkout fail.