### PR TITLE
build: Skip config and transient packages

### DIFF
--- a/newt/builder/buildutil.go
+++ b/newt/builder/buildutil.go
@@ -84,6 +84,9 @@ func (b *Builder) sortedBuildPackages() []*BuildPackage {
 	}
 
 	for _, bpkg := range b.PkgMap {
+		if bpkg.rpkg.Lpkg.Type() == pkg.PACKAGE_TYPE_CONFIG || bpkg.rpkg.Lpkg.Type() == pkg.PACKAGE_TYPE_TRANSIENT {
+			continue
+		}
 		sorter.bpkgs = append(sorter.bpkgs, bpkg)
 	}
 


### PR DESCRIPTION
config and transient packages do not have any code by design, so there's no need to include them in build. This should fix the problem when package becomes transient at some point but .a for that package is present in build folder from an old build and is still included when linking image.