### PR TITLE
builder: Allow to override compiler in target

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -66,7 +66,6 @@ type TargetBuilder struct {
 
 func NewTargetTester(target *target.Target,
 	testPkg *pkg.LocalPackage) (*TargetBuilder, error) {
-
 	if err := target.Validate(testPkg == nil); err != nil {
 		return nil, err
 	}
@@ -76,8 +75,13 @@ func NewTargetTester(target *target.Target,
 		return nil, err
 	}
 
+	compilerName := bspPkg.CompilerName
+	if len(target.CompilerName) > 0 {
+		compilerName = target.CompilerName
+	}
+
 	compilerPkg, err := project.GetProject().ResolvePackage(
-		bspPkg.Repo(), bspPkg.CompilerName)
+		bspPkg.Repo(), compilerName)
 	if err != nil {
 		return nil, err
 	}

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -46,6 +46,7 @@ type Target struct {
 	BspName      string
 	AppName      string
 	LoaderName   string
+	CompilerName string
 	BuildProfile string
 	HeaderSize   uint32
 	KeyFile      string
@@ -95,6 +96,9 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 	util.OneTimeWarningError(err)
 
 	target.LoaderName, err = yc.GetValString("target.loader", nil)
+	util.OneTimeWarningError(err)
+
+	target.CompilerName, err = yc.GetValString("target.compiler", nil)
 	util.OneTimeWarningError(err)
 
 	target.BuildProfile, err = yc.GetValString("target.build_profile", nil)


### PR DESCRIPTION
This allows to override compiler packge in target using "target.compiler" key.