### PR TITLE
syscfg: Always use full repo name in syscfg.h defs

### DIFF
--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -1592,7 +1592,7 @@ func sanitizePkgName(name string) string {
 func writePackages(lpkgs []*pkg.LocalPackage, w io.Writer) {
 	pkgs := []string{}
 	for _, lpkg := range lpkgs {
-		pkgs = append(pkgs, sanitizePkgName(lpkg.FullName()))
+		pkgs = append(pkgs, sanitizePkgName(lpkg.NameWithRepo()))
 	}
 
 	sort.Strings(pkgs)


### PR DESCRIPTION
CI builds have either mynewt-core or mynewt-nimble used as local repository so the repo name is omitted in syscfg.h package defs. This causes build issues since defines do not match those generated in generic configuration, i.e. local project is used as local repo.

To avoid issues in future we'll always use full repo name for defs in syscfg.h, this way those are stable regardless of repo location.

Note: repository name for local repo is the project name and it overrides repository.yml name, if any.