### PR TITLE
newt: Add pkg.ign_pkgs to skip certain packages when linking

### DIFF
--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -198,6 +198,21 @@ func (bpkg *BuildPackage) CompilerInfo(
 		ci.IgnoreDirs = append(ci.IgnoreDirs, re)
 	}
 
+	ci.IgnorePkgs = []*regexp.Regexp{}
+
+	ignPkgs, err := bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+		"pkg.ign_pkgs", settings)
+	util.OneTimeWarningError(err)
+
+	for _, str := range ignPkgs {
+		re, err := regexp.Compile(str)
+		if err != nil {
+			return nil, util.NewNewtError(
+				"Ignore pkgs, unable to compile re: " + err.Error())
+		}
+		ci.IgnorePkgs = append(ci.IgnorePkgs, re)
+	}
+
 	bpkg.SourceDirectories, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
 		"pkg.src_dirs", settings)
 	util.OneTimeWarningError(err)

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -59,6 +59,7 @@ type CompilerInfo struct {
 	Aflags      []string
 	IgnoreFiles []*regexp.Regexp
 	IgnoreDirs  []*regexp.Regexp
+	IgnorePkgs  []*regexp.Regexp
 }
 
 type CompileCommand struct {
@@ -166,6 +167,7 @@ func NewCompilerInfo() *CompilerInfo {
 	ci.Aflags = []string{}
 	ci.IgnoreFiles = []*regexp.Regexp{}
 	ci.IgnoreDirs = []*regexp.Regexp{}
+	ci.IgnorePkgs = []*regexp.Regexp{}
 
 	return ci
 }
@@ -246,6 +248,7 @@ func (ci *CompilerInfo) AddCompilerInfo(newCi *CompilerInfo) {
 	ci.Aflags = addFlags("aflag", ci.Aflags, newCi.Aflags)
 	ci.IgnoreFiles = append(ci.IgnoreFiles, newCi.IgnoreFiles...)
 	ci.IgnoreDirs = append(ci.IgnoreDirs, newCi.IgnoreDirs...)
+	ci.IgnorePkgs = append(ci.IgnorePkgs, newCi.IgnorePkgs...)
 }
 
 func NewCompiler(compilerDir string, dstDir string,


### PR DESCRIPTION
I've been working on adding unit tests to an existing project using myNewt, but I've not been able to make it work with existing functionality (such as ignore_file and build-time hooks). 

Using FFF, I mocked some function calls to _flash_map.c_ in a unit test for a module. When not using this branch, I get **duplicate_symbols** errors when linking; however, with the changes in this branch the test runs the mocks as expected. The files to be ignored are set in the module's "test/pkg.yml"-file:
`pkg.ign_pkgs: "@apache-mynewt-core/sys/flash_map"`

This is probably not the best way to do it, but it works. Any feedback is appreciated!
 