### PR TITLE
Handle cpu count zero reported on raspberry pi

### DIFF
--- a/newt/newt.go
+++ b/newt/newt.go
@@ -44,7 +44,7 @@ func newtDfltNumJobs() int {
 	maxProcs := runtime.GOMAXPROCS(0)
 	numCpu := runtime.NumCPU()
 	cpu, err := cpu.Counts(false)
-	if err == nil {
+	if err == nil && cpu > 0 {
 		numCpu = cpu
 	}
 	var numJobs int


### PR DESCRIPTION
This fixes https://github.com/apache/mynewt-newt/issues/494
On my Raspberry Pi 4 Model B the cpu count is reported as 0 from shirou/gopsutil cpu.Counts without an error which then sets the default to 0 to which silently leads to a failed build since no source files are compiled. Another fix would be to have the default here never be less than 1. 