### PR TITLE
Don't do shallow clone on default

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -65,7 +65,7 @@ func newRunCmd(cmd *cobra.Command, args []string) {
 	 * branch.
 	 */
 	if util.ShallowCloneDepth < 0 {
-		util.ShallowCloneDepth = 0;
+		util.ShallowCloneDepth = 0
 	}
 
 	if err := dl.Clone("master", tmpdir); err != nil {

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -883,11 +883,6 @@ func (gd *GithubDownloader) Clone(commit string, dstPath string) error {
 
 	if util.ShallowCloneDepth > 0 {
 		cmd = append(cmd, "--depth", strconv.Itoa(util.ShallowCloneDepth))
-	} else if util.ShallowCloneDepth < 0 {
-		// default for clone, if not set by user, is to do shallow clone
-		cmd = append(cmd, "--depth", "1")
-		util.OneTimeWarning("Creating a shallow clone by default. " +
-			"To unshallow repository later use \"git fetch --unshallow\".")
 	}
 
 	cmd = append(cmd, url, dstPath)
@@ -983,11 +978,6 @@ func (gd *GitDownloader) Clone(commit string, dstPath string) error {
 
 	if util.ShallowCloneDepth > 0 {
 		cmd = append(cmd, "--depth", strconv.Itoa(util.ShallowCloneDepth))
-	} else if util.ShallowCloneDepth < 0 {
-		// default for clone, if not set by user, is to do shallow clone
-		cmd = append(cmd, "--depth", "1")
-		util.OneTimeWarning("Creating a shallow clone by default. " +
-			"To unshallow repository later use \"git fetch --unshallow\".")
 	}
 
 	cmd = append(cmd, gd.Url, dstPath)

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -55,7 +55,7 @@ func processNewtrc(yc ycfg.YCfg) {
 	}
 
 	// default is 0 anyway, no need to initialize first
-	util.ShallowCloneDepth, _ = yc.GetValIntDflt("shallow_clone", nil, -1)
+	util.ShallowCloneDepth, _ = yc.GetValInt("shallow_clone", nil)
 
 	util.SkipNewtCompat, _ = yc.GetValBoolDflt("skip_newt_compat", nil, false)
 	util.SkipSyscfgRepoHash, _ = yc.GetValBoolDflt("skip_syscfg_repo_hash", nil, false)


### PR DESCRIPTION
Default shallow clone option was causing some issues, so it is better to keep it as opt-in.