### PR TITLE
Allow to download external repos without project.yml file

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -321,7 +321,19 @@ func (b *Builder) collectCompileEntriesBpkg(bpkg *BuildPackage) (
 
 	if len(bpkg.SourceDirectories) > 0 {
 		for _, relDir := range bpkg.SourceDirectories {
-			dir := bpkg.rpkg.Lpkg.BasePath() + "/" + relDir
+			var dir string
+			repo, path, err := newtutil.ParsePackageString(relDir)
+
+			if err != nil {
+				return nil, err
+			}
+
+			if repo != "" {
+				dir = "repos/" + repo + "/" + path
+			} else {
+				dir = bpkg.rpkg.Lpkg.BasePath() + "/" + relDir
+			}
+
 			if util.NodeNotExist(dir) {
 				return nil, util.NewNewtError(fmt.Sprintf(
 					"Specified source directory %s, does not exist.",

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -270,7 +270,17 @@ func (bpkg *BuildPackage) publicIncludeDirs(b *Builder) []string {
 		util.OneTimeWarningError(err)
 
 		for _, dir := range inclDirs {
-			incls = append(incls, bp+"/"+dir)
+			repo, path, err := newtutil.ParsePackageString(dir)
+
+			if err != nil {
+				util.OneTimeWarningError(err)
+			}
+
+			if repo != "" {
+				incls = append(incls, "repos/"+repo+"/"+path)
+			} else {
+				incls = append(incls, bp+"/"+dir)
+			}
 		}
 	}
 

--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -88,7 +88,9 @@ func escapeFlagsSlice(flags []string) []string {
 
 func trimProjectPath(path string) string {
 	proj := interfaces.GetProject()
-	path, _ = filepath.Rel(proj.Path(), path)
+	if strings.HasPrefix(replaceBackslashes(path), proj.Path()) {
+		path, _ = filepath.Rel(proj.Path(), path)
+	}
 	return replaceBackslashes(path)
 }
 

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -621,9 +621,11 @@ func (inst *Installer) gatherInfo(r *repo.Repo,
 	if vm != nil {
 		// The caller requested a remote query.  Download this repo's latest
 		// `repository.yml` file.
-		if err := r.DownloadDesc(); err != nil {
-			ri.errorText = strings.TrimSpace(err.Error())
-			return ri
+		if !r.IsExternal(r.Path()) {
+			if err := r.DownloadDesc(); err != nil {
+				ri.errorText = strings.TrimSpace(err.Error())
+				return ri
+			}
 		}
 	}
 
@@ -671,7 +673,7 @@ func (inst *Installer) Info(repos []*repo.Repo, remote bool) error {
 	if remote {
 		// Fetch the latest for all repos.
 		for _, r := range repos {
-			if !r.IsLocal() {
+			if !r.IsLocal() && !r.IsExternal(r.Path()) {
 				if err := r.DownloadDesc(); err != nil {
 					return err
 				}

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -450,10 +450,13 @@ func (proj *Project) downloadRepositoryYmlFiles() error {
 	// Download the `repository.yml` file for each root-level repo (those
 	// specified in the `project.yml` file).
 	for _, r := range proj.repos.Sorted() {
-		if !r.IsLocal() {
+		if !r.IsLocal() && !r.IsExternal(r.Path()) {
 			if _, err := r.UpdateDesc(); err != nil {
 				return err
 			}
+		}
+		if r.IsExternal(r.Path()) {
+			r.Downloader().Fetch(r.Path())
 		}
 	}
 

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -194,6 +194,18 @@ func (r *Repo) patchesFilePath() string {
 		"/.patches/"
 }
 
+// Checks for repository.yml file presence in specified repo folder.
+// If there is no such file, the repo in specified folder is external.
+func (r *Repo) IsExternal(dir string) bool {
+	path := dir + "/repository.yml"
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return true
+	} else {
+		return false
+	}
+}
+
 // Check that there is a list of submodules to clone; if the key is
 // not present, assume that all submodules should be cloned, otherwise
 // only those configured will be cloned (or none if "")
@@ -225,13 +237,15 @@ func (r *Repo) downloadRepo(commit string) error {
 			r.Name(), err.Error())
 	}
 
-	yc, err := config.ReadFile(tmpdir + "/" + REPO_FILE_NAME)
-	if err != nil {
-		return err
-	}
+	if !r.IsExternal(tmpdir) {
+		yc, err := config.ReadFile(tmpdir + "/" + REPO_FILE_NAME)
+		if err != nil {
+			return err
+		}
 
-	if err := r.loadSubmoduleConfig(yc); err != nil {
-		return err
+		if err := r.loadSubmoduleConfig(yc); err != nil {
+			return err
+		}
 	}
 
 	if r.hasSubmodules {


### PR DESCRIPTION
This allows to download external repos like SDK packages, which do not contain project.yml files. Now we do not have to keep all of the SDKs in apache-mynewt-core repository. This also allows to use "@<repo-name>" syntax in the pkg.include_dirs and pkg.src_dirs fields to add source/include files from specified folders from external repos.