### PR TITLE
Copy pkg.deps field when using "target copy"

### DIFF
--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -255,6 +255,7 @@ func (pkg *LocalPackage) Save() error {
 
 	file.WriteString("\n")
 
+	file.WriteString(pkg.sequenceString("pkg.deps"))
 	file.WriteString(pkg.sequenceString("pkg.aflags"))
 	file.WriteString(pkg.sequenceString("pkg.cflags"))
 	file.WriteString(pkg.sequenceString("pkg.cxxflags"))


### PR DESCRIPTION
Now using the command "target copy" will copy the field pkg.deps into the destination target.