### PR TITLE
ci: Add support for testing on Windows and Mac

### DIFF
--- a/.github/workflows/test_commands.yml
+++ b/.github/workflows/test_commands.yml
@@ -23,7 +23,11 @@ on: [push, pull_request]
 
 jobs:
   test_commands:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -33,15 +37,19 @@ jobs:
         with:
           release: '12.2.Rel1'
       - name: Install Dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: |
              sudo apt-get update
              sudo apt-get install -y gcc-multilib
       - name: Build newt
+        working-directory: newt
+        shell: bash
         run: |
              go version
-             sh ./build.sh
+             go build
              echo  ${GITHUB_WORKSPACE}/newt >> $GITHUB_PATH
       - name: Test commands
+        shell: bash
         run: |
              newt
              newt help
@@ -76,6 +84,10 @@ jobs:
              newt target revdep nordic_pca10056_btshell
              rm -rf repos/apache-mynewt-mcumgr
              newt upgrade -v
+      - name: Test commands 2
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+             cd project
              newt test @apache-mynewt-core/util/cbmem
              newt build my_blinky_sim
              newt clean my_blinky_sim

--- a/.github/workflows/test_dump.yml
+++ b/.github/workflows/test_dump.yml
@@ -23,22 +23,27 @@ on: [push, pull_request]
 
 jobs:
   test_dump:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         targets: [bleprph-nrf52840pdk, boot-nrf52dk, btshell-nrf52840pdk, btshell-nrf52dk, my_blinky_sim]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '1.16'
       - name: Build newt
+        working-directory: newt
+        shell: bash
         run: |
              go version
-             sh ./build.sh
+             go build
              echo  ${GITHUB_WORKSPACE}/newt >> $GITHUB_PATH
       - name: Test dump
         working-directory: .github/newt_dump/proj
+        shell: bash
         run: |
              echo "Checking target ${{ matrix.targets }}"
              newt target dump ${{ matrix.targets }} | jq 'del(.sysinit)' > tmp.txt

--- a/.github/workflows/test_upgrade.yml
+++ b/.github/workflows/test_upgrade.yml
@@ -23,22 +23,27 @@ on: [push, pull_request]
 
 jobs:
   test_upgrade_success:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         projects: [basic01, basic02, basic03, branches01, dup-overrides, inferrc, one-override, three-overrides]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '1.16'
       - name: Build newt
+        working-directory: newt
+        shell: bash
         run: |
              go version
-             sh ./build.sh
+             go build
              echo  ${GITHUB_WORKSPACE}/newt >> $GITHUB_PATH
              git config --global url."https://github.com/".insteadOf "git@github.com:"
       - name: Test upgrade success
+        shell: bash
         working-directory: .github/newt_upgrade/success/${{ matrix.projects }}
         run: |
              echo "Checking target ${{ matrix.targets }}"
@@ -52,24 +57,28 @@ jobs:
              newt info | grep mynewt-dummy | diff -w expected.txt -
 
   test_upgrade_fail:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         projects: [conflict01, conflict02, nonexistent-commit, nonexistent-version]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: '1.16'
       - name: Build newt
+        working-directory: newt
+        shell: bash
         run: |
              go version
-             sh ./build.sh
+             go build
              echo  ${GITHUB_WORKSPACE}/newt >> $GITHUB_PATH
              git config --global url."https://github.com/".insteadOf "git@github.com:"
       - name: Test upgrade fail
+        shell: bash
         working-directory: .github/newt_upgrade/fail/${{ matrix.projects }}
-        id: upgrade
         run: |
              echo "Checking target ${{ matrix.targets }}"
              ! newt upgrade &> tmp.txt


### PR DESCRIPTION
Some tests are exectured only on Linux (mainly those requiring native bsp support).