### PR TITLE
builder: Allow to specify source files for package

### DIFF
--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -35,6 +35,7 @@ import (
 type BuildPackage struct {
 	rpkg              *resolve.ResolvePackage
 	SourceDirectories []string
+	SourceFiles       []string
 	ci                *toolchain.CompilerInfo
 }
 
@@ -219,6 +220,10 @@ func (bpkg *BuildPackage) CompilerInfo(
 			"pkg.src_dirs", settings)
 		util.OneTimeWarningError(err)
 	}
+
+	bpkg.SourceFiles, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+		"pkg.source_files", settings)
+	util.OneTimeWarningError(err)
 
 	includePaths, err := bpkg.recursiveIncludePaths(b)
 	if err != nil {

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -171,8 +171,14 @@ func (bpkg *BuildPackage) CompilerInfo(
 	ci.IgnoreFiles = []*regexp.Regexp{}
 
 	ignPats, err := bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
-		"pkg.ign_files", settings)
+		"pkg.ignore_files", settings)
 	util.OneTimeWarningError(err)
+
+	if len(ignPats) == 0 {
+		ignPats, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+			"pkg.ign_files", settings)
+		util.OneTimeWarningError(err)
+	}
 
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
@@ -186,8 +192,14 @@ func (bpkg *BuildPackage) CompilerInfo(
 	ci.IgnoreDirs = []*regexp.Regexp{}
 
 	ignPats, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
-		"pkg.ign_dirs", settings)
+		"pkg.ignore_dirs", settings)
 	util.OneTimeWarningError(err)
+
+	if len(ignPats) == 0 {
+		ignPats, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+			"pkg.ign_dirs", settings)
+		util.OneTimeWarningError(err)
+	}
 
 	for _, str := range ignPats {
 		re, err := regexp.Compile(str)
@@ -199,8 +211,14 @@ func (bpkg *BuildPackage) CompilerInfo(
 	}
 
 	bpkg.SourceDirectories, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
-		"pkg.src_dirs", settings)
+		"pkg.source_dirs", settings)
 	util.OneTimeWarningError(err)
+
+	if len(bpkg.SourceDirectories) == 0 {
+		bpkg.SourceDirectories, err = bpkg.rpkg.Lpkg.PkgY.GetValStringSlice(
+			"pkg.src_dirs", settings)
+		util.OneTimeWarningError(err)
+	}
 
 	includePaths, err := bpkg.recursiveIncludePaths(b)
 	if err != nil {

--- a/newt/toolchain/compiler.go
+++ b/newt/toolchain/compiler.go
@@ -666,6 +666,21 @@ func compilerTypeToExts(compilerType int) ([]string, error) {
 	}
 }
 
+func fileNameToCompilerType(filename string) (int, error) {
+	switch filepath.Ext(filename) {
+	case ".c":
+		return COMPILER_TYPE_C, nil
+	case ".s", ".S":
+		return COMPILER_TYPE_ASM, nil
+	case ".cc", ".cpp", ".cxx":
+		return COMPILER_TYPE_CPP, nil
+	case ".a":
+		return COMPILER_TYPE_ARCHIVE, nil
+	default:
+		return -1, util.NewNewtError("Unknown file type for " + filename)
+	}
+}
+
 // Compiles all C files matching the specified file glob.
 func (c *Compiler) CompileC(filename string) error {
 	filename = filepath.ToSlash(filename)
@@ -812,6 +827,21 @@ func (c *Compiler) processEntry(node os.FileInfo, cType int,
 	c.dstDir = prevDstDir
 
 	return entries, err
+}
+
+func (c *Compiler) CollectSingleEntry(filename string) (*CompilerJob, error) {
+	file := filepath.ToSlash(filename)
+	ctype, err := fileNameToCompilerType(file)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &CompilerJob{
+		Filename:     file,
+		Compiler:     c,
+		CompilerType: ctype,
+	}, nil
 }
 
 func (c *Compiler) RecursiveCollectEntries(cType int,


### PR DESCRIPTION
This adds consistent naming for pkg settings to include/ignore source
files and directories in pkg.yml:
- source_dirs
- ignore_dirs
- ignore_files

Old names still work for backwards compatibility, but only if new
variant is not used.