### PR TITLE
Allow to add external repos from pkg.yml

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -124,6 +124,8 @@ func upgradeRunCmd(cmd *cobra.Command, args []string) {
 	proj := TryGetOrDownloadProject()
 	interfaces.SetProject(proj)
 
+	proj.GetPkgRepos()
+
 	pred := makeRepoPredicate(args)
 	if err := proj.UpgradeIf(
 		newtutil.NewtForce, newtutil.NewtAsk, pred); err != nil {

--- a/newt/interfaces/interfaces.go
+++ b/newt/interfaces/interfaces.go
@@ -19,12 +19,15 @@
 
 package interfaces
 
+import "mynewt.apache.org/newt/newt/ycfg"
+
 type PackageInterface interface {
 	Name() string
 	FullName() string
 	BasePath() string
 	Repo() RepoInterface
 	Type() PackageType
+	PkgConfig() *ycfg.YCfg
 }
 
 type PackageType int

--- a/newt/pkg/localpackage.go
+++ b/newt/pkg/localpackage.go
@@ -112,6 +112,10 @@ func (pkg *LocalPackage) BasePath() string {
 	return pkg.basePath
 }
 
+func (pkg *LocalPackage) PkgConfig() *ycfg.YCfg {
+	return &pkg.PkgY
+}
+
 func (pkg *LocalPackage) RelativePath() string {
 	proj := interfaces.GetProject()
 	return strings.TrimPrefix(pkg.BasePath(), proj.Path())

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -54,6 +54,9 @@ type Repo struct {
 	local      bool
 	ncMap      compat.NewtCompatMap
 
+	// If repo was added from package (not from project.yml), this variable stores name of this package
+	pkgName string
+
 	// True if this repo was cloned during this invocation of newt.
 	newlyCloned bool
 
@@ -71,6 +74,10 @@ type RepoDependency struct {
 	Name    string
 	VerReqs newtutil.RepoVersion
 	Fields  map[string]string
+}
+
+func (r *Repo) SetPkgName(pName string) {
+	r.pkgName = pName
 }
 
 func (r *Repo) CommitDepMap() map[string][]*RepoDependency {


### PR DESCRIPTION
This allows to add exernal repositories to pkg.yml files. Repositories will be downloaded when "newt upgrade" command is called. The syntax of adding new repo to the pkg.yml file is the same as adding new repo to the project.yml file.