### PR TITLE
compiler: Add compiler flags $(...) patterns 

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -116,8 +116,15 @@ func (t *TargetBuilder) NewCompiler(dstDir string, buildProfile string) (
 		buildProfile = t.target.BuildProfile
 	}
 
+	var cfg *cfgv.Settings
+	cfg = nil
+
+	if t.AppBuilder != nil {
+		cfg = t.AppBuilder.cfg.SettingValues()
+	}
+
 	c, err := toolchain.NewCompiler(
-		t.compilerPkg.BasePath(), dstDir, buildProfile)
+		t.compilerPkg.BasePath(), dstDir, buildProfile, cfg)
 
 	return c, err
 }

--- a/newt/mfg/emit.go
+++ b/newt/mfg/emit.go
@@ -167,7 +167,7 @@ func getCompilerFromBsp(bsp *pkg.BspPackage) (*toolchain.Compiler, error) {
 	}
 
 	c, err := toolchain.NewCompiler(compilerPkg.BasePath(), "",
-		target.DEFAULT_BUILD_PROFILE)
+		target.DEFAULT_BUILD_PROFILE, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds the possibility to define and use $(...) patterns with
compiler flags. To do so you have to define new value in compiler's syscfg.yml
file, for example:

EXAMPLE_FLAGS:
  value:"-my -compiler -flags"

Expression "$(EXAMPLE_FLAGS)" used in any compiler flags definition in compiler.yml will
be now replaced with the defined value (in this case whith "-my -compiler -flags").
It is also possible to override or add new patterns from other syscfg.yml files, for example
from some application's syscfg.yml