### PR TITLE
builder: Allow to override some bsp settings in target

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -77,9 +77,6 @@ func NewTargetTester(target *target.Target,
 	}
 
 	compilerName := bspPkg.CompilerName
-	if len(target.CompilerName) > 0 {
-		compilerName = target.CompilerName
-	}
 
 	compilerPkg, err := project.GetProject().ResolvePackage(
 		bspPkg.Repo(), compilerName)

--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -71,7 +71,7 @@ func NewTargetTester(target *target.Target,
 		return nil, err
 	}
 
-	bspPkg, err := pkg.NewBspPackage(target.Bsp())
+	bspPkg, err := pkg.NewBspPackage(target.Bsp(), target.GetBspYCfgOverride())
 	if err != nil {
 		return nil, err
 	}

--- a/newt/flashmap/flashmap.go
+++ b/newt/flashmap/flashmap.go
@@ -228,8 +228,7 @@ func Read(ymlFlashMap map[string]interface{}, pkgName string) (FlashMap, error) 
 }
 
 func flashMapVarDecl(fm FlashMap) string {
-	return fmt.Sprintf("const struct flash_area %s[%d]", C_VAR_NAME,
-		len(fm.Areas))
+	return fmt.Sprintf("const struct flash_area %s[FLASH_AREA_COUNT]", C_VAR_NAME)
 }
 
 func writeFlashAreaHeader(w io.Writer, area flash.FlashArea) {
@@ -247,6 +246,8 @@ func writeFlashMapHeader(w io.Writer, fm FlashMap) {
 	fmt.Fprintf(w, "#define H_MYNEWT_SYSFLASH_\n")
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "#include \"flash_map/flash_map.h\"\n")
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "#define FLASH_AREA_COUNT %d\n", len(fm.Areas))
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "%s", C_VAR_COMMENT)
 	fmt.Fprintf(w, "extern %s;\n", flashMapVarDecl(fm))

--- a/newt/flashmap/flashmap.go
+++ b/newt/flashmap/flashmap.go
@@ -46,6 +46,7 @@ const C_VAR_COMMENT = `/**
 `
 
 type FlashMap struct {
+	PkgName     string
 	Areas       map[string]flash.FlashArea
 	Overlaps    [][]flash.FlashArea
 	IdConflicts [][]flash.FlashArea
@@ -195,8 +196,10 @@ func (flashMap FlashMap) ErrorText() string {
 	return flash.ErrorText(flashMap.Overlaps, flashMap.IdConflicts)
 }
 
-func Read(ymlFlashMap map[string]interface{}) (FlashMap, error) {
+func Read(ymlFlashMap map[string]interface{}, pkgName string) (FlashMap, error) {
 	flashMap := newFlashMap()
+
+	flashMap.PkgName = pkgName
 
 	ymlAreas := ymlFlashMap["areas"]
 	if ymlAreas == nil {
@@ -247,6 +250,8 @@ func writeFlashMapHeader(w io.Writer, fm FlashMap) {
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "%s", C_VAR_COMMENT)
 	fmt.Fprintf(w, "extern %s;\n", flashMapVarDecl(fm))
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "/* Flash map was defined in %s */\n", fm.PkgName)
 	fmt.Fprintf(w, "\n")
 
 	for _, area := range fm.SortedAreas() {

--- a/newt/mfg/build.go
+++ b/newt/mfg/build.go
@@ -163,7 +163,7 @@ func calcBsp(dm DecodedMfg,
 		return nil, util.FmtNewtError("multiple BSPs detected")
 	}
 
-	bsp, err := pkg.NewBspPackage(bspLpkg)
+	bsp, err := pkg.NewBspPackage(bspLpkg, nil)
 	if err != nil {
 		return nil, util.FmtNewtError(err.Error())
 	}

--- a/newt/pkg/bsp_package.go
+++ b/newt/pkg/bsp_package.go
@@ -200,14 +200,14 @@ func (bsp *BspPackage) Reload(settings *cfgv.Settings) error {
 			"(bsp.arch)")
 	}
 
-	_, ycfg = bsp.selectKey("bsp.flash_map")
+	ypkg, ycfg = bsp.selectKey("bsp.flash_map")
 	ymlFlashMap, err := ycfg.GetValStringMap("bsp.flash_map", settings)
 	util.OneTimeWarningError(err)
 	if ymlFlashMap == nil {
 		return util.NewNewtError("BSP does not specify a flash map " +
 			"(bsp.flash_map)")
 	}
-	bsp.FlashMap, err = flashmap.Read(ymlFlashMap)
+	bsp.FlashMap, err = flashmap.Read(ymlFlashMap, ypkg.FullName())
 	if err != nil {
 		return err
 	}

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -46,7 +46,6 @@ type Target struct {
 	BspName      string
 	AppName      string
 	LoaderName   string
-	CompilerName string
 	BuildProfile string
 	HeaderSize   uint32
 	KeyFile      string
@@ -100,9 +99,6 @@ func (target *Target) Load(basePkg *pkg.LocalPackage) error {
 	util.OneTimeWarningError(err)
 
 	target.LoaderName, err = yc.GetValString("target.loader", nil)
-	util.OneTimeWarningError(err)
-
-	target.CompilerName, err = yc.GetValString("target.compiler", nil)
 	util.OneTimeWarningError(err)
 
 	target.BuildProfile, err = yc.GetValString("target.build_profile", nil)

--- a/newt/target/target.go
+++ b/newt/target/target.go
@@ -77,6 +77,10 @@ func LoadTarget(basePkg *pkg.LocalPackage) (*Target, error) {
 	return target, nil
 }
 
+func (target *Target) GetBspYCfgOverride() *pkg.BspYCfgOverride {
+	return pkg.NewBspYCfgOverride(target.basePkg, &target.TargetY)
+}
+
 func (target *Target) TargetYamlPath() string {
 	return fmt.Sprintf("%s/%s", target.basePkg.BasePath(), TARGET_FILENAME)
 }


### PR DESCRIPTION
Target can now override some settings defined in BSP:
- bsp.compiler
- bsp.image_offset
- bsp.image_pad
- bsp.flash_map
- bsp.linkerscript
- bsp.part2linkerscript

To override, simply define the same key in target.yml and it will take precedence over the one defined in bsp.yml.