### PR TITLE
ci: Use latest stable go version for building

### DIFF
--- a/.github/workflows/test_commands.yml
+++ b/.github/workflows/test_commands.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: 'stable'
       - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
         with:
           release: '12.2.Rel1'

--- a/.github/workflows/test_dump.yml
+++ b/.github/workflows/test_dump.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: 'stable'
       - name: Build newt
         working-directory: newt
         shell: bash

--- a/.github/workflows/test_upgrade.yml
+++ b/.github/workflows/test_upgrade.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: 'stable'
       - name: Build newt
         working-directory: newt
         shell: bash
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: 'stable'
       - name: Build newt
         working-directory: newt
         shell: bash


### PR DESCRIPTION
This should make it easier for upgrading dependencies.