### PR TITLE
Fixed issue where packages with the same sysinit value were odered in…

### DIFF
--- a/.github/newt_sysinit/expected.txt
+++ b/.github/newt_sysinit/expected.txt
@@ -1,0 +1,17 @@
+Brief sysinit config for targets/nordic_pca10056_btshell:
+ STAGE   | PACKAGE                                           | FUNCTION                | SETTING                     
+---------+---------------------------------------------------+-------------------------+------------------------------
+ 0       | @apache-mynewt-core/kernel/os                     | os_pkg_init             | OS_SYSINIT_STAGE            
+ 9       | @apache-mynewt-core/sys/flash_map                 | flash_map_init          | FLASH_MAP_SYSINIT_STAGE     
+ 10      | @apache-mynewt-core/sys/stats/full                | stats_module_init       | STATS_SYSINIT_STAGE         
+ 20      | @apache-mynewt-core/sys/console/full              | console_pkg_init        | CONSOLE_SYSINIT_STAGE       
+ 100     | @apache-mynewt-core/sys/log/full                  | log_init                | LOG_SYSINIT_STAGE_MAIN      
+ 100     | @apache-mynewt-core/sys/log/modlog                | modlog_init             | MODLOG_SYSINIT_STAGE        
+ 250     | @apache-mynewt-nimble/nimble/transport            | ble_transport_init      |                             
+ 251     | @apache-mynewt-nimble/nimble/transport            | ble_transport_hs_init   |                             
+ 301     | @apache-mynewt-nimble/nimble/host/services/gap    | ble_svc_gap_init        | BLE_SVC_GAP_SYSINIT_STAGE   
+ 302     | @apache-mynewt-nimble/nimble/host/services/gatt   | ble_svc_gatt_init       | BLE_SVC_GATT_SYSINIT_STAGE  
+ 303     | @apache-mynewt-nimble/nimble/host/services/ans    | ble_svc_ans_init        | BLE_SVC_ANS_SYSINIT_STAGE   
+ 500     | @apache-mynewt-nimble/nimble/host/store/config    | ble_store_config_init   | BLE_STORE_SYSINIT_STAGE     
+ 500     | @apache-mynewt-core/sys/shell                     | shell_init              | SHELL_SYSINIT_STAGE         
+         | @apache-mynewt-nimble/nimble/transport            | ble_transport_ll_init   |                             

--- a/.github/workflows/test_sysinit.yml
+++ b/.github/workflows/test_sysinit.yml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Test sysinit
+
+on: [push, pull_request]
+
+jobs:
+  test_sysinit:
+    name: other
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 'stable'
+      - uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78
+        with:
+          release: '12.2.Rel1'
+      - name: Install Dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+             sudo apt-get update
+             sudo apt-get install -y gcc-multilib
+      - name: Build newt
+        working-directory: newt
+        shell: bash
+        run: |
+             go version
+             go build
+             echo  ${GITHUB_WORKSPACE}/newt >> $GITHUB_PATH
+      - name: Test_sysinit
+        shell: bash
+        run: |
+             newt
+             newt help
+             newt version
+             newt new project
+             cp -r .github/targets/nordic_pca10056_btshell project/targets
+             cd project/
+             newt upgrade -v --escape=false apache-mynewt-core apache-mynewt-nimble
+             newt info
+             newt target sysinit brief nordic_pca10056_btshell > tmp.txt
+             diff -w tmp.txt ../.github/newt_sysinit/expected.txt


### PR DESCRIPTION
… non-deterministic and no longer lexicographic order

This helps make sure sysinit order is reproducible between builds. 