### PR TITLE
syscfg: Write defs for each APIs provided by included packages

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -292,7 +292,11 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 	srcDir := GeneratedSrcDir(t.target.FullName())
 
 	lpkgs := resolve.RpkgSliceToLpkgSlice(t.res.MasterSet.Rpkgs)
-	if err := syscfg.EnsureWritten(t.res.Cfg, incDir, lpkgs); err != nil {
+	apis := []string{}
+	for api := range t.res.ApiMap {
+		apis = append(apis, api)
+	}
+	if err := syscfg.EnsureWritten(t.res.Cfg, incDir, lpkgs, apis); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This adds symbols in syscfg.h for each API provided by packages included in build. The symbol name has "MYNEWT_API_" prefix followed with sanitized API name, all illegal characters in resulting name are replaced with "_".

This allows to check if any package included in build provides specific API. Could be useful if some API is not strictly required, but we can use it if provided by some package.