### PR TITLE
builder: Print warning if external repository is modified or missing

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -57,6 +57,7 @@ type Builder struct {
 	buildName        string
 	linkElf          string
 	injectedSettings map[string]string
+	modifiedExtRepos []string
 }
 
 func NewBuilder(
@@ -652,6 +653,8 @@ func (b *Builder) Build() error {
 		}
 		entries = append(entries, subEntries...)
 
+		b.modifiedExtRepos = append(b.modifiedExtRepos, bpkg.getModifiedReposNames()...)
+
 		if len(subEntries) > 0 {
 			bpkgCompilerMap[bpkg] = subEntries[0].Compiler
 		}
@@ -892,4 +895,25 @@ func (b *Builder) CleanArtifacts() {
 	for _, p := range paths {
 		os.Remove(p)
 	}
+}
+
+func Contains(elements []string, val string) bool {
+	for _, s := range elements {
+		if val == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *Builder) AppendModifiedRepos(modifiedRepos []string) {
+	for _, repo := range modifiedRepos {
+		if !Contains(b.modifiedExtRepos, repo) {
+			b.modifiedExtRepos = append(b.modifiedExtRepos, repo)
+		}
+	}
+}
+
+func (b *Builder) GetModifiedRepos() []string {
+	return b.modifiedExtRepos
 }

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -20,9 +20,12 @@
 package builder
 
 import (
+	"mynewt.apache.org/newt/newt/downloader"
+	"mynewt.apache.org/newt/newt/repo"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"mynewt.apache.org/newt/newt/newtutil"
 	"mynewt.apache.org/newt/newt/pkg"
@@ -340,4 +343,47 @@ func (bpkg *BuildPackage) privateIncludeDirs(b *Builder) []string {
 	}
 
 	return incls
+}
+
+func (bpkg *BuildPackage) getModifiedReposNames() []string {
+	var modifiedRepos []string
+
+	settings := bpkg.rpkg.Lpkg.PkgY.AllSettings()
+	for settingName, setting := range settings {
+		if strings.HasPrefix(settingName, "repository") {
+			var version string
+
+			dl := downloader.NewGitDownloader()
+			rName := strings.TrimPrefix(settingName, "repository.")
+			r, _ := repo.NewRepo(rName, dl)
+
+			if util.NodeNotExist(r.Path()) {
+				modifiedRepos = append(modifiedRepos, r.Name())
+				continue
+			}
+
+			currentHash, _ := dl.HashFor(r.Path(), "HEAD")
+
+			aSetting, ok := setting.(map[interface{}]interface{})
+			if ok {
+				for field, value := range aSetting {
+					if field == "vers" {
+						aValue, ok := value.(string)
+						if ok {
+							version = strings.TrimSuffix(aValue, "-commit")
+						}
+					}
+				}
+			}
+
+			expectedHash, _ := dl.HashFor(r.Path(), version)
+			dirtyState, _ := r.DirtyState()
+
+			if currentHash != expectedHash || dirtyState != "" {
+				modifiedRepos = append(modifiedRepos, r.Name())
+			}
+		}
+	}
+
+	return modifiedRepos
 }

--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -161,6 +161,11 @@ func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, execute
 		}
 
 		if err := b.Build(); err != nil {
+			if b.AppBuilder.GetModifiedRepos() != nil {
+				util.ErrorMessage(util.VERBOSITY_DEFAULT,
+					"Warning: Following external repos are modified or missing, which might be causing build errors:\n%v\n",
+					b.AppBuilder.GetModifiedRepos())
+			}
 			NewtUsage(nil, err)
 		}
 


### PR DESCRIPTION
This adds functionality described in this issue:
https://github.com/apache/mynewt-newt/issues/524

Warning is only shown when the build failed