### PR TITLE
Upgrade non-external repos before loading packages

### DIFF
--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -92,6 +92,15 @@ func initProject(dir string, download bool) error {
 	if err != nil {
 		return err
 	}
+
+	if download {
+		err = globalProject.UpgradeIf(newtutil.NewtForce, newtutil.NewtAsk,
+			                      func(r *repo.Repo) bool { return !r.IsExternal(r.Path()) })
+		if err != nil {
+			return err
+		}
+	}
+
 	if err := globalProject.loadPackageList(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Thanks to this, we will upgrade external repos to proper versions, instead of always upgrading them to versions set in pkg files from master branches of non-external repos.

I.e. if mynewt-core will be upgraded to version 1.11.0, external repos included in mynewt-core pkg.yml files are going be downloaded and upgraded as specified
in those files from mynewt_1_11_0_tag. Without this external repos included in mynewt-core would be upgraded to versions specified in pkgs from mynewt-core's
master branch, which would lead to versions mismatch and probably compilation errors