### PR TITLE
Add possibility to define global cflags in packages

### DIFF
--- a/newt/builder/cmake.go
+++ b/newt/builder/cmake.go
@@ -212,6 +212,11 @@ func (b *Builder) CMakeTargetWrite(w io.Writer, targetCompiler *toolchain.Compil
 	var linkFlags []string
 	var libraries []string
 
+	err := b.appendAppCflags(bpkgs)
+	if err != nil {
+		return err
+	}
+
 	c := targetCompiler
 	c.AddInfo(b.GetCompilerInfo())
 


### PR DESCRIPTION
This adds possibility to use global cflags in packages. Until now only cflags defined in app package were used globally while compiling. Now it is possible to add such flags in every package by using "app.cflags" field in package's yaml file. This also adds new command to show which packages within the target contain those global flags.