### PR TITLE
newt: Add possibility to mark package as experimental

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -284,7 +284,11 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 		log.Warn(line)
 	}
 
-	for _, line := range t.res.ExperimentalWarning() {
+	for _, line := range t.res.CfgExperimentalWarning() {
+		log.Warn(line)
+	}
+
+	for _, line := range t.res.PkgExperimentalWarning() {
 		log.Warn(line)
 	}
 

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -1358,8 +1358,25 @@ func (res *Resolution) DeprecatedWarning() []string {
 	return res.Cfg.DeprecatedWarning()
 }
 
-func (res *Resolution) ExperimentalWarning() []string {
+func (res *Resolution) CfgExperimentalWarning() []string {
 	return res.Cfg.ExperimentalWarning()
+}
+
+func (res *Resolution) PkgExperimentalWarning() []string {
+	lines := []string{}
+
+	for pkg := range res.LpkgRpkgMap {
+		experimental, err := pkg.PkgY.GetValBool("pkg.experimental", nil)
+		if err != nil {
+			log.Errorf("Internal error; Could not read package %s yml file", pkg.Name())
+		}
+		if experimental {
+			lines = append(lines,
+				fmt.Sprintf("Use of experimental package %s", pkg.Name()))
+		}
+	}
+
+	return lines
 }
 
 func LogTransientWarning(lpkg *pkg.LocalPackage) {


### PR DESCRIPTION
This adds possibility to mark package as experimental by adding "pkg.experimental: 1" line in the pkg.yml file.