### PR TITLE
newt: Upgrade repos specified in project and package only once

### DIFF
--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -241,6 +241,10 @@ func (inst *Installer) shouldUpgradeRepo(
 		return true, nil
 	}
 
+	if r.IsUpgradedFromProjectYml() {
+		return false, nil
+	}
+
 	if !r.VersionsEqual(*curVer, destVer) {
 		return true, nil
 	}
@@ -589,6 +593,9 @@ func (inst *Installer) Upgrade(candidates []*repo.Repo, force bool,
 		destVer := vm[r.Name()]
 		if err := r.Upgrade(destVer); err != nil {
 			return err
+		}
+		if r.IsFromProjectYml() {
+			r.SetIsUpgradedFromProjectYml()
 		}
 		util.StatusMessage(util.VERBOSITY_DEFAULT,
 			"%s successfully upgraded to version %s\n",

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -172,6 +172,15 @@ func NewProject(dir string, download bool) (*Project, error) {
 	return proj, nil
 }
 
+func (proj *Project) isRepoAdded(r *repo.Repo) bool {
+	for _, pr := range proj.repos {
+		if pr.Name() == r.Name() {
+			return true
+		}
+	}
+	return false
+}
+
 func (proj *Project) GetPkgRepos() error {
 
 	for _, pkgList := range proj.packages {
@@ -199,10 +208,13 @@ func (proj *Project) GetPkgRepos() error {
 								repoName, fields["vers"], err.Error())
 						}
 						r.SetPkgName(pkg.Name())
-						if err := proj.addRepo(r, true); err != nil {
-							return err
+
+						if !proj.isRepoAdded(r) {
+							if err := proj.addRepo(r, true); err != nil {
+								return err
+							}
+							proj.rootRepoReqs[repoName] = verReq
 						}
-						proj.rootRepoReqs[repoName] = verReq
 					}
 				}
 			}
@@ -623,7 +635,7 @@ func (proj *Project) loadConfig(download bool) error {
 						"%s (%s)",
 					repoName, fields["vers"], err.Error())
 			}
-
+			r.SetIsFromProjectYml()
 			if err := proj.addRepo(r, download); err != nil {
 				return err
 			}

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -66,6 +66,14 @@ type Repo struct {
 	// version => commit
 	vers map[newtutil.RepoVersion]string
 
+	// Since we are calling upgrade twice - first time for repos from project.yml
+	// and second time for repos from packages, we need to keep track on status
+	// of each repo. If repo is defined in project.yml we want to upgrade it only
+	// once so the version from project.yml stays valid. These flags are used for
+	// this purpose.
+	isFromProjectYml         bool
+	isUpgradedFromProjectYml bool
+
 	hasSubmodules bool
 	submodules    []string
 }
@@ -199,6 +207,22 @@ func (r *Repo) repoFilePath() string {
 func (r *Repo) patchesFilePath() string {
 	return interfaces.GetProject().Path() + "/" + REPOS_DIR +
 		"/.patches/"
+}
+
+func (r *Repo) IsUpgradedFromProjectYml() bool {
+	return r.isUpgradedFromProjectYml
+}
+
+func (r *Repo) SetIsUpgradedFromProjectYml() {
+	r.isUpgradedFromProjectYml = true
+}
+
+func (r *Repo) IsFromProjectYml() bool {
+	return r.isFromProjectYml
+}
+
+func (r *Repo) SetIsFromProjectYml() {
+	r.isFromProjectYml = true
 }
 
 // Checks for repository.yml file presence in specified repo folder.


### PR DESCRIPTION
Now repos that are specified in both project.yml and pkg.yml will be upgraded only once - to the version specified in project.yml