### PR TITLE
newt: Always generate link tables header

### DIFF
--- a/newt/builder/extcmd.go
+++ b/newt/builder/extcmd.go
@@ -197,14 +197,6 @@ func getLinkTableEntry(name string) string {
 func (t *TargetBuilder) generateLinkTables() {
 	var s []string
 
-	for _, pkg := range t.res.LpkgRpkgMap {
-		s = append(s, pkg.Lpkg.LinkTables()...)
-	}
-
-	if len(s) == 0 {
-		return
-	}
-
 	dir := GeneratedBaseDir(t.target.FullName()) + "/link/include"
 	err := os.MkdirAll(dir, os.ModePerm)
 	if err != nil {
@@ -215,6 +207,14 @@ func (t *TargetBuilder) generateLinkTables() {
 	linkHeader, err := os.Create(dir + "/link_tables.ld.h")
 	if err != nil {
 		log.Error("Generate link tables error:\n", err)
+		return
+	}
+
+	for _, pkg := range t.res.LpkgRpkgMap {
+		s = append(s, pkg.Lpkg.LinkTables()...)
+	}
+
+	if len(s) == 0 {
 		return
 	}
 


### PR DESCRIPTION
Now link tables header will always be generated.
Script that generates default linker scripts requires this file to exist, so we generate it even when
it is going to be empty.