### PR TITLE
newt: Fix crash when package is missing

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -161,10 +161,12 @@ func buildRunCmd(cmd *cobra.Command, args []string, printShellCmds bool, execute
 		}
 
 		if err := b.Build(); err != nil {
-			if b.AppBuilder.GetModifiedRepos() != nil {
-				util.ErrorMessage(util.VERBOSITY_DEFAULT,
-					"Warning: Following external repos are modified or missing, which might be causing build errors:\n%v\n",
-					b.AppBuilder.GetModifiedRepos())
+			if b.AppBuilder != nil {
+				if b.AppBuilder.GetModifiedRepos() != nil {
+					util.ErrorMessage(util.VERBOSITY_DEFAULT,
+						"Warning: Following external repos are modified or missing, which might be causing build errors:\n%v\n",
+						b.AppBuilder.GetModifiedRepos())
+				}
 			}
 			NewtUsage(nil, err)
 		}


### PR DESCRIPTION
When package from build was missing the b.Build() was returning an error before AppBuilder was created. It was resulting in dereferencing null pointer in such situation.