### PR TITLE
newt: Add external repos patches support

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -131,6 +131,7 @@ func upgradeRunCmd(cmd *cobra.Command, args []string) {
 	interfaces.SetProject(proj)
 
 	proj.GetPkgRepos()
+	proj.SetGitEnvVariables()
 
 	pred := makeRepoPredicate(args)
 	if err := proj.UpgradeIf(

--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -97,6 +97,10 @@ type Downloader interface {
 	// If such a commit exists, it is returned.  Otherwise, "" is returned.
 	LatestRc(path string, base string) (string, error)
 
+	// Applies patches provided inside "patches" directory.
+	// If no patch is provided function does nothing
+	ApplyPatches(path string, patches []string) error
+
 	// Returns the branch that contains the YAML control files; this option
 	// allows implementers to override "master" as the main branch.
 	MainBranch() string
@@ -449,6 +453,26 @@ func (gd *GenericDownloader) Checkout(repoDir string, commit string) error {
 
 	_, err = executeGitCommand(repoDir, cmd, true)
 	return err
+}
+
+func (gd *GenericDownloader) ApplyPatches(repoDir string, patches []string) error {
+	cmd := []string{
+		"am",
+	}
+	cmd = append(cmd, patches...)
+
+	_, err := executeGitCommand(repoDir, cmd, true)
+	if err != nil {
+		// Abort git am if applying patches failed
+		cmd = []string{
+			"am",
+			"--abort",
+		}
+		executeGitCommand(repoDir, cmd, true)
+
+		return err
+	}
+	return nil
 }
 
 // Update one submodule tree in a repo (under path)

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -602,6 +602,16 @@ func (inst *Installer) Upgrade(candidates []*repo.Repo, force bool,
 			r.Name(), destVer.String())
 	}
 
+	for _, r := range candidates {
+		err = r.ApplyPatches()
+		if err != nil {
+			util.StatusMessage(util.VERBOSITY_DEFAULT,
+				"Applying patches in repository %s failed\n", r.Name())
+
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -44,6 +44,7 @@ const REPO_DEFAULT_PERMS = 0755
 
 const REPO_FILE_NAME = "repository.yml"
 const REPOS_DIR = "repos"
+const PATCHES_DIR = "patches"
 
 type Repo struct {
 	name       string
@@ -76,6 +77,10 @@ type Repo struct {
 
 	hasSubmodules bool
 	submodules    []string
+
+	// Used with external repos. If package that adds external repository provides patches for it,
+	// the paths to them are going to be stored here.
+	patches []string
 }
 
 type RepoDependency struct {
@@ -122,6 +127,19 @@ func (r *Repo) ignoreDir(dir string) bool {
 
 func (r *Repo) Downloader() downloader.Downloader {
 	return r.downloader
+}
+
+func (r *Repo) AddPatch(path string) {
+	r.patches = append(r.patches, path)
+}
+
+func (r *Repo) ApplyPatches() error {
+	if len(r.patches) == 0 {
+		return nil
+	}
+
+	err := r.Downloader().ApplyPatches(r.Path(), r.patches)
+	return err
 }
 
 func (repo *Repo) FilteredSearchList(


### PR DESCRIPTION
Now if package that adds external repository contains directory patches/*external_repo_name*, newt will try to apply patches inside this directory to the external repo.