### PR TITLE
Generate mod log names

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -304,7 +304,7 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 		return err
 	}
 
-	if err := t.res.LCfg.EnsureWritten(incDir); err != nil {
+	if err := t.res.LCfg.EnsureWritten(incDir, srcDir, pkg.ShortName(t.target.Package())); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This adds "name:" to syscfg.logs nodes.
This is optional log name.

With this change newt tool also generates file:
_\<bsp\>_**-logcfg.c** that contains function:
`const char *logcfg_log_module_name(uint8_t id)`

that can be used to get module name for generated mod logs.

If name is not present like in this example:
```
syscfg.logs:
    BMA400_LOG:
        module: MYNEWT_VAL(BMA400_LOG_MODULE)
        level: MYNEWT_VAL(BMA400_LOG_LVL)
```

module name will be taken from **BMA400_LOG** by cutting off trailing _LOG to make it **BMA400**