### PR TITLE
Don't panic in case of other error types in NewtUsage

### DIFF
--- a/newt/cli/util.go
+++ b/newt/cli/util.go
@@ -50,8 +50,6 @@ func NewtUsage(cmd *cobra.Command, err error) {
 			log.Debugf("%+v", err)
 		} else if ne, ok := err.(*util.NewtError); ok {
 			log.Debugf("%s", ne.StackTrace)
-		} else {
-			panic(fmt.Sprintf("unexpected error type: %T", err))
 		}
 
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())


### PR DESCRIPTION
It does not make sense to panic before printing error

Fix for https://github.com/apache/mynewt-newt/issues/519