### PR TITLE
builder: Add private includes only to specific packages

### DIFF
--- a/newt/builder/build.go
+++ b/newt/builder/build.go
@@ -322,6 +322,10 @@ func (b *Builder) collectCompileEntriesBpkg(bpkg *BuildPackage) (
 		return nil, err
 	}
 
+	var privateIncCi toolchain.CompilerInfo
+	privateIncCi.Includes = bpkg.privateIncludeDirs(b)
+	c.AddInfo(&privateIncCi)
+
 	srcDirs := []string{}
 
 	if len(bpkg.SourceDirectories) > 0 {

--- a/newt/builder/buildpackage.go
+++ b/newt/builder/buildpackage.go
@@ -243,7 +243,7 @@ func (bpkg *BuildPackage) CompilerInfo(
 		return nil, err
 	}
 
-	ci.Includes = append(bpkg.privateIncludeDirs(b), includePaths...)
+	ci.Includes = append(ci.Includes, includePaths...)
 	bpkg.ci = ci
 
 	return bpkg.ci, nil


### PR DESCRIPTION
Instead of adding private includes paths to every package we should add them to the specific packages