### PR TITLE
Allow overriding MYNEWT_DOWNLOADER from command line

### DIFF
--- a/newt/cli/build_cmds.go
+++ b/newt/cli/build_cmds.go
@@ -347,6 +347,10 @@ func loadRunCmd(cmd *cobra.Command, args []string) {
 		NewtUsage(cmd, util.NewNewtError("Must specify target"))
 	}
 
+	if util.InjectSyscfg != "" {
+		util.InjectSyscfg = "MYNEWT_DOWNLOADER=" + util.InjectSyscfg
+	}
+
 	TryGetProject()
 
 	t := ResolveTarget(args[0])
@@ -501,6 +505,8 @@ func AddBuildCommands(cmd *cobra.Command) {
 		"Extra commands to send to JTAG software")
 	loadCmd.PersistentFlags().StringVarP(&imgFileOverride, "imgfile", "", "",
 		"Path of .img file to load instead of target artifact")
+	loadCmd.Flags().StringVarP(&util.InjectSyscfg, "loader", "L", "",
+		"Override loader value from syscfg")
 
 	debugHelpText := "Open a debugger session for <target-name>"
 

--- a/newt/cli/run_cmds.go
+++ b/newt/cli/run_cmds.go
@@ -44,6 +44,10 @@ func runRunCmd(cmd *cobra.Command, args []string) {
 		useV2 = true
 	}
 
+	if util.InjectSyscfg != "" {
+		util.InjectSyscfg = "MYNEWT_DOWNLOADER=" + util.InjectSyscfg
+	}
+
 	TryGetProject()
 
 	b, err := TargetBuilderForTargetOrUnittest(args[0])
@@ -170,6 +174,8 @@ func AddRunCommands(cmd *cobra.Command) {
 		"pad-image", "i", 0, "Pad image to this length")
 	runCmd.PersistentFlags().StringVarP(&sections,
 		"sections", "S", "", "Section names for TLVs, comma delimited")
+	runCmd.Flags().StringVarP(&util.InjectSyscfg, "loader", "L", "",
+		"Override loader value from syscfg")
 
 	cmd.AddCommand(runCmd)
 	AddTabCompleteFn(runCmd, func() []string {


### PR DESCRIPTION
This adds new flag to load and run commands.
The flag (--loader or short -L) allows to override the MYNEWT_DOWNLOADER value from syscfg. Usage example:

--loader stm32_programmer_cli