### PR TITLE
newt: Extend link tables filter

### DIFF
--- a/newt/builder/extcmd.go
+++ b/newt/builder/extcmd.go
@@ -189,6 +189,7 @@ func getLinkTableEntry(name string) string {
 
 	entry := indent + "__" + name + "_start__ = .;\n" +
 		indent + "KEEP(*(." + name + "))\n" +
+		indent + "KEEP(*(SORT(." + name + ".*)))\n" +
 		indent + "__" + name + "_end__ = .;\n\n"
 
 	return entry


### PR DESCRIPTION
So far for link time generated tables only exact section name was added to filter like in this example:

```yml
pkg.link_tables:
    - foo
```

would generate link_tables.ld.h with following content
```ld
        __foo_start__ = .;
        KEEP(*(.foo))
        __foo_end__ = .;
```

Now additional filter will be added
```ld
        __foo_start__ = .;
        KEEP(*(.foo))
        KEEP(*(SORT(.foo.*)))
        __foo_end__ = .;
```

This is general rule for many sections like .text or .data

This is specifically required for xc32 compiler that adds variable name to section by itself even though `__attribute__((section, "foo"))` is used and arm gcc treats name in attribute verbatim and not as prefix.