### PR TITLE
Add allowed repositories list

### DIFF
--- a/.github/newt_upgrade/allowed-ignored/expected.txt
+++ b/.github/newt_upgrade/allowed-ignored/expected.txt
@@ -1,0 +1,7 @@
+apache-mynewt-core
+apache-mynewt-mcumgr
+apache-mynewt-nimble
+arm-CMSIS_5
+mbedtls
+mcuboot
+nordic-nrfx

--- a/.github/newt_upgrade/allowed-ignored/project.yml
+++ b/.github/newt_upgrade/allowed-ignored/project.yml
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+project.repositories:
+   - apache-mynewt-core
+
+repository.apache-mynewt-core:
+   type: github
+   vers: 0-dev
+   user: apache
+   repo: mynewt-core
+
+repository.tinyusb:
+   type: github
+   vers: 0.0.0
+   user: hathach
+   repo: tinyusb
+
+project.repositories.allowed:
+   - apache-mynewt-core
+   - apache-mynewt-nimble
+   - apache-mynewt-mcumgr
+   - mcuboot
+   - arm-CMSIS_5
+   - nordic-nrfx
+   - mbedtls
+   - stm-cmsis_device_f3
+   - stm-stm32f3xx_hal_driver
+
+project.repositories.ignored:
+   - stm-cmsis_device_f3
+   - stm-stm32f3xx_hal_driver

--- a/.github/newt_upgrade/fail/core-ignored/expected.txt
+++ b/.github/newt_upgrade/fail/core-ignored/expected.txt
@@ -1,0 +1,1 @@
+Error: apache-mynewt-core repository must be allowed. Please add it to the allowed list and/or remove it from the ignored list.

--- a/.github/newt_upgrade/fail/core-ignored/project.yml
+++ b/.github/newt_upgrade/fail/core-ignored/project.yml
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+project.repositories:
+   - apache-mynewt-core
+
+repository.apache-mynewt-core:
+   type: github
+   vers: 0-dev
+   user: apache
+   repo: mynewt-core
+
+project.repositories.ignored:
+   - apache-mynewt-core

--- a/.github/newt_upgrade/fail/core-not-allowed/expected.txt
+++ b/.github/newt_upgrade/fail/core-not-allowed/expected.txt
@@ -1,0 +1,1 @@
+Error: apache-mynewt-core repository must be allowed. Please add it to the allowed list and/or remove it from the ignored list.

--- a/.github/newt_upgrade/fail/core-not-allowed/project.yml
+++ b/.github/newt_upgrade/fail/core-not-allowed/project.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+project.repositories:
+   - apache-mynewt-core
+
+repository.apache-mynewt-core:
+   type: github
+   vers: 0-dev
+   user: apache
+   repo: mynewt-core
+
+project.repositories.allowed:
+   - apache-mynewt-nimble
+   - apache-mynewt-mcumgr

--- a/.github/workflows/test_upgrade.yml
+++ b/.github/workflows/test_upgrade.yml
@@ -100,3 +100,31 @@ jobs:
              echo "Checking target ${{ matrix.targets }}"
              ! newt upgrade &> tmp.txt
              cat tmp.txt | tail -n `wc -l < expected.txt` | diff -w expected.txt -
+
+  test_upgrade_filters:
+    name: newt upgrade (filters)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 'stable'
+      - name: Build newt
+        working-directory: newt
+        shell: bash
+        run: |
+          go version
+          go build
+          echo  ${GITHUB_WORKSPACE}/newt >> $GITHUB_PATH
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+      - name: Test upgrade allowed-ignored
+        shell: bash
+        working-directory: .github/newt_upgrade/allowed-ignored
+        run: |
+             echo "Test upgrade"
+             newt upgrade
+             ls repos | diff -w expected.txt -

--- a/newt/deprepo/deprepo.go
+++ b/newt/deprepo/deprepo.go
@@ -136,6 +136,10 @@ func BuildDepGraph(repos RepoMap, rootReqs RequirementMap) (DepGraph, error) {
 			reqMap := RequirementMap{}
 			for _, d := range deps {
 				depRepo := repos[d.Name]
+				// This might be nil if d.Name is not on allowed repositories list
+				if depRepo == nil {
+					continue
+				}
 				verReqs, err := depRepo.NormalizeVerReq(d.VerReqs)
 				if err != nil {
 					return nil, err

--- a/newt/install/install.go
+++ b/newt/install/install.go
@@ -199,6 +199,10 @@ func (inst *Installer) ensureDepsInList(repos []*repo.Repo,
 		}
 		for _, d := range deps {
 			depRepo := inst.repos[d.Name]
+			// This might be nil if d.Name is not on allowed repositories list
+			if depRepo == nil {
+				continue
+			}
 			result = append(result, recurse(depRepo)...)
 		}
 

--- a/newt/repo/repo.go
+++ b/newt/repo/repo.go
@@ -397,7 +397,7 @@ func (r *Repo) Upgrade(ver newtutil.RepoVersion) error {
 // from master.  The repo object is then populated with the contents of the
 // downladed file.  If this repo has already had its descriptor updated, this
 // function is a no-op.
-func (r *Repo) UpdateDesc(reposIgnored []string) (bool, error) {
+func (r *Repo) UpdateDesc() (bool, error) {
 	if r.updated {
 		return false, nil
 	}
@@ -417,7 +417,7 @@ func (r *Repo) UpdateDesc(reposIgnored []string) (bool, error) {
 	}
 
 	// Read `repository.yml` and populate this repo object.
-	if err := r.Read(reposIgnored); err != nil {
+	if err := r.Read(); err != nil {
 		return false, err
 	}
 
@@ -555,14 +555,11 @@ func parseRepoDepMap(depName string,
 	return result, nil
 }
 
-func (r *Repo) readDepRepos(yc ycfg.YCfg, reposIgnored []string) error {
+func (r *Repo) readDepRepos(yc ycfg.YCfg) error {
 	depMap, err := yc.GetValStringMap("repo.deps", nil)
 	util.OneTimeWarningError(err)
 
 	for depName, repoMapYml := range depMap {
-		if util.SliceContains(reposIgnored, depName) {
-			continue
-		}
 		rdm, err := parseRepoDepMap(depName, repoMapYml)
 		if err != nil {
 			return util.FmtNewtError(
@@ -580,7 +577,7 @@ func (r *Repo) readDepRepos(yc ycfg.YCfg, reposIgnored []string) error {
 
 // Reads a `repository.yml` file and populates the receiver repo with its
 // contents.
-func (r *Repo) Read(reposIgnored []string) error {
+func (r *Repo) Read() error {
 	r.Init(r.Name(), r.downloader)
 
 	yc, err := config.ReadFile(r.repoFilePath() + "/" + REPO_FILE_NAME)
@@ -607,7 +604,7 @@ func (r *Repo) Read(reposIgnored []string) error {
 		r.vers[vers] = commit
 	}
 
-	if err := r.readDepRepos(yc, reposIgnored); err != nil {
+	if err := r.readDepRepos(yc); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This in addition to ignored repositories list allows to specify a list of repositories that will be upgraded. The list should be placed inside project.yml and look for example like this:

project.repositories.allowed:
    - apache-mynewt-core
    - apache-mynewt-nimble
    - apache-mynewt-mcumgr
    - mcuboot
    - arm-CMSIS_5
    - nordic-nrfx
    - mbedtls

If the same repository will be placed on both lists, it will be ignored by newt.

IMPORTANT NOTE: Ignored repositories will be ignored even if they were previously downloaded. So if repo was downloaded by newt upgrade and then added to ignored list,
targets that depend on this repo won't build.