### PR TITLE
newt: Fix config check for entries with description

### DIFF
--- a/.github/workflows/test_ambiguous_cfg.yml
+++ b/.github/workflows/test_ambiguous_cfg.yml
@@ -63,4 +63,4 @@ jobs:
           cp -r .github/targets/ambiguous_fail project/targets
           cd project/
           ! newt build ambiguous_fail &> tmp.txt
-          grep "Error: Setting CONSOLE_IMPLEMENTATION collision - two conditions true:" tmp.txt -q
+          grep "Error: setting CONSOLE_IMPLEMENTATION collision - two conditions true:" tmp.txt -q

--- a/newt/ycfg/ycfg.go
+++ b/newt/ycfg/ycfg.go
@@ -22,6 +22,7 @@ package ycfg
 import (
 	"fmt"
 	"mynewt.apache.org/newt/newt/cfgv"
+	"reflect"
 	"strings"
 
 	"github.com/spf13/cast"
@@ -470,8 +471,8 @@ func (yc *YCfg) GetStringMap(
 			}
 
 			if _, exists := result[k]; exists {
-				if (entry.Value != result[k].Value) && (result[k].Expr != nil) {
-					return nil, fmt.Errorf("Setting %s collision - two conditions true:\n[%s, %s]\n"+
+				if !reflect.DeepEqual(entry.Value, result[k].Value) && (result[k].Expr != nil) && (entry.Expr != nil) {
+					return nil, fmt.Errorf("setting %s collision - two conditions true:\n[%s, %s]\n"+
 						"Conflicting file: %s",
 						k, entry.Expr.String(), result[k].Expr.String(), yc.name)
 				}


### PR DESCRIPTION
When "description" key was included in entry's Value field
it was causing that interface was holding other
type then we expected and newt was crashing.
Now we extract only "value" key from Value
interface and call reflect.DeepEqual, which will
prevent crashing.