### PR TITLE
documentation/sphinx: Fix formatting errors in `.rst` files

### DIFF
--- a/docs/command_list/newt_complete.rst
+++ b/docs/command_list/newt_complete.rst
@@ -14,7 +14,7 @@ Install bash autocompletion
         Bash completion has been installed to:
           /usr/local/etc/bash_completion.d
         ==> Summary
-        🍺  /usr/local/Cellar/bash-completion/1.3_1: 189 files, 607.8K
+            /usr/local/Cellar/bash-completion/1.3_1: 189 files, 607.8K
 
 Enable autocompletion for newt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/install/newt_mac.rst
+++ b/docs/install/newt_mac.rst
@@ -78,7 +78,7 @@ commands to upgrade to newt latest:
     ==> Downloading from https://raw.githubusercontent.com/juullabs-oss/binary-releases/master/mynewt-newt-tools_1.5.0/mynewt-newt-1.5.0.sierra.bottle.tar.gz
     ######################################################################## 100.0%
     ==> Pouring mynewt-newt-1.5.0.sierra.bottle.tar.gz
-    🍺  /usr/local/Cellar/mynewt-newt/1.5.0: 3 files, 8.1MB
+        /usr/local/Cellar/mynewt-newt/1.5.0: 3 files, 8.1MB
 
 Installing the Latest Release Version of Newt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +94,7 @@ Run the following command to install the latest release version of newt:
     ==> Downloading from https://raw.githubusercontent.com/JuulLabs-OSS/binary-releases/master/mynewt-newt-tools_1.5.0/mynewt-newt-
     ######################################################################## 100.0%
     ==> Pouring mynewt-newt-1.5.0.sierra.bottle.tar.gz
-    🍺  /usr/local/Cellar/mynewt-newt/1.5.0: 3 files, 8.1MB
+        /usr/local/Cellar/mynewt-newt/1.5.0: 3 files, 8.1MB
 
 **Notes:** Homebrew bottles for newt are available for macOS Sierra. If you are running an earlier version of macOS,
 the installation will install the latest version of Go and compile newt locally.


### PR DESCRIPTION
Removes emojis from code snippets causing issues with LaTeX output generated by Sphinx.