### PR TITLE
newt: Add ignore flag for upgrade command

### DIFF
--- a/newt/cli/project_cmds.go
+++ b/newt/cli/project_cmds.go
@@ -214,6 +214,8 @@ func AddProjectCommands(cmd *cobra.Command) {
 		"Force upgrade of the repositories to latest state in project.yml")
 	upgradeCmd.PersistentFlags().BoolVarP(&newtutil.NewtAsk,
 		"ask", "a", false, "Prompt user before upgrading any repos")
+	upgradeCmd.PersistentFlags().StringSliceVarP(&newtutil.NewtIgnore, "ignore", "i", []string{},
+		"Names of repositories to skip, separated by a comma or by using multiple flags")
 
 	cmd.AddCommand(upgradeCmd)
 

--- a/newt/newtutil/newtutil.go
+++ b/newt/newtutil/newtutil.go
@@ -39,6 +39,7 @@ var NewtBlinkyTag string = "master"
 var NewtNumJobs int
 var NewtForce bool
 var NewtAsk bool
+var NewtIgnore []string
 
 const CORE_REPO_NAME string = "apache-mynewt-core"
 const ARDUINO_ZERO_REPO_NAME string = "mynewt_arduino_zero"

--- a/newt/project/project.go
+++ b/newt/project/project.go
@@ -634,6 +634,7 @@ func (proj *Project) loadConfig(download bool) error {
 	proj.reposIgnored = make([]string, 0)
 	proj.reposIgnored, err = yc.GetValStringSlice("project.repositories.ignored", nil)
 	util.OneTimeWarningError(err)
+	proj.reposIgnored = append(proj.reposIgnored, newtutil.NewtIgnore...)
 
 	if util.SliceContains(proj.reposIgnored, "apache-mynewt-core") {
 		return util.NewNewtError("apache-mynewt-core repository can't be ignored. " +


### PR DESCRIPTION
This adds --ignore or -i flag for upgrade command. Flags arguments should specify names of repositories that will be ignored while upgrading, separated by a comma. For example:
newt upgrade -i apache-mynewt-nimble -i stm-cmsis_device_f3,stm-stm32f3xx_hal_driver