### PR TITLE
Add '--no-single-branch' to shallow clone

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -947,7 +947,7 @@ func (gd *GithubDownloader) Clone(commit string, dstPath string) error {
 	}
 
 	if util.ShallowCloneDepth > 0 {
-		cmd = append(cmd, "--depth", strconv.Itoa(util.ShallowCloneDepth))
+		cmd = append(cmd, "--depth", strconv.Itoa(util.ShallowCloneDepth), "--no-single-branch")
 	}
 
 	cmd = append(cmd, url, dstPath)


### PR DESCRIPTION
Shallow clone should still download all branches and tags to make sure we can find proper version.

This fixes regression introduced by 1dc2b53e as previously after shallow clone we still run fetch on newly cloned repo which updated branches and tags.