### PR TITLE
ci: Add smoke test for newt upgrade --shallow=1

### DIFF
--- a/.github/workflows/test_commands.yml
+++ b/.github/workflows/test_commands.yml
@@ -83,6 +83,9 @@ jobs:
              newt target cmake nordic_pca10056_btshell
              newt target dep nordic_pca10056_btshell
              newt target revdep nordic_pca10056_btshell
+             rm -rf repos
+             newt upgrade --shallow=1
+             newt upgrade -v
              rm -rf repos/apache-mynewt-mcumgr
              newt upgrade -v
       - name: Test commands 2


### PR DESCRIPTION
This is used in core CI but was not tested here.