### PR TITLE
Add '--no-single-branch' to shallow clone for Git repos

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -1052,7 +1052,7 @@ func (gd *GitDownloader) Clone(commit string, dstPath string) error {
 	}
 
 	if util.ShallowCloneDepth > 0 {
-		cmd = append(cmd, "--depth", strconv.Itoa(util.ShallowCloneDepth))
+		cmd = append(cmd, "--depth", strconv.Itoa(util.ShallowCloneDepth), "--no-single-branch")
 	}
 
 	cmd = append(cmd, gd.Url, dstPath)


### PR DESCRIPTION
This is the same as fdc74bd4 but for "pure" Git repos.