### PR TITLE
newt: Properly handle rc tags in newt info

### DIFF
--- a/.github/newt_upgrade/success/basic01/expected.txt
+++ b/.github/newt_upgrade/success/basic01/expected.txt
@@ -1,5 +1,5 @@
     * mynewt-dummy-repo-01: 11badf27c834a587f9a4d14c30f861bc10af75c4, 0.0.0
-    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 0.0.0
-    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 0.0.0
+    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 2.0.1 (rc)
+    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 2.0.1 (rc)
     * mynewt-dummy-repo-04: 503782e265da53629ed26af485d01a3b7ac80cbd, 0.0.0
     * mynewt-dummy-repo-05: 59a441a8d183bab2f0f5bb5c3306462c9ddf86cd, 0.0.0

--- a/.github/newt_upgrade/success/branches01/expected.txt
+++ b/.github/newt_upgrade/success/branches01/expected.txt
@@ -1,5 +1,5 @@
     * mynewt-dummy-repo-01: 0d52ff5eed266459edda0384d41745acb4297c89
-    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 0.0.0
-    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 0.0.0
+    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 2.0.1 (rc)
+    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 2.0.1 (rc)
     * mynewt-dummy-repo-04: 503782e265da53629ed26af485d01a3b7ac80cbd, 0.0.0
     * mynewt-dummy-repo-05: ea8ffb94ad4ddb39c5179924316f0ebef1e2c90f

--- a/.github/newt_upgrade/success/inferrc/expected.txt
+++ b/.github/newt_upgrade/success/inferrc/expected.txt
@@ -1,2 +1,2 @@
-    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 0.0.0
-    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 0.0.0
+    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 2.0.1 (rc)
+    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 2.0.1 (rc)

--- a/newt/newtutil/repo_version.go
+++ b/newt/newtutil/repo_version.go
@@ -51,6 +51,7 @@ type RepoVersion struct {
 	Revision  int64
 	Stability string
 	Commit    string
+	Rc        bool
 }
 
 func (v *RepoVersion) IsNormalized() bool {
@@ -115,6 +116,10 @@ func (ver *RepoVersion) String() string {
 
 	if ver.Stability != VERSION_STABILITY_NONE {
 		s += fmt.Sprintf("-%s", ver.Stability)
+	}
+
+	if ver.Rc {
+		s += fmt.Sprintf(" (rc)")
 	}
 
 	return s

--- a/newt/repo/version.go
+++ b/newt/repo/version.go
@@ -23,6 +23,7 @@ package repo
 
 import (
 	"mynewt.apache.org/newt/newt/downloader"
+	"regexp"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -196,9 +197,18 @@ func (r *Repo) HashFromVer(ver newtutil.RepoVersion) (string, error) {
 // commits exist, they are not considered here.
 func (r *Repo) VersFromCommit(commit string) []newtutil.RepoVersion {
 	var vers []newtutil.RepoVersion
+	var rc bool
+
+	restr := `rc\d+_tag`
+	re := regexp.MustCompile(restr)
+	if re.MatchString(commit) {
+		commit = re.ReplaceAllString(commit, "tag")
+		rc = true
+	}
 
 	for v, c := range r.vers {
 		if c == commit {
+			v.Rc = rc
 			vers = append(vers, v)
 		}
 	}


### PR DESCRIPTION
Now newt info properly prints internal repo versions with rc tags.