### PR TITLE
builder: Print load commands output on default

### DIFF
--- a/newt/builder/load.go
+++ b/newt/builder/load.go
@@ -158,16 +158,18 @@ func Load(binBasePath string, bspPkg *pkg.BspPackage,
 		binBasePath,
 	}
 
-	util.StatusMessage(util.VERBOSITY_VERBOSE, "Load command: %s\n",
+	util.StatusMessage(util.VERBOSITY_DEFAULT, "Load command: %s\n",
 		strings.Join(cmd, " "))
 	util.StatusMessage(util.VERBOSITY_VERBOSE, "Environment:\n")
 	for _, v := range env {
 		util.StatusMessage(util.VERBOSITY_VERBOSE, "* %s\n", v)
 	}
-	if _, err := util.ShellCommand(cmd, env); err != nil {
+
+	if err := util.ShellCommandStreamOutput(cmd, env, true, !util.HideLoadCmdOutput); err != nil {
 		return err
 	}
-	util.StatusMessage(util.VERBOSITY_VERBOSE, "Successfully loaded image.\n")
+
+	util.StatusMessage(util.VERBOSITY_DEFAULT, "Successfully loaded image.\n")
 
 	return nil
 }

--- a/newt/settings/settings.go
+++ b/newt/settings/settings.go
@@ -59,6 +59,7 @@ func processNewtrc(yc ycfg.YCfg) {
 
 	util.SkipNewtCompat, _ = yc.GetValBoolDflt("skip_newt_compat", nil, false)
 	util.SkipSyscfgRepoHash, _ = yc.GetValBoolDflt("skip_syscfg_repo_hash", nil, false)
+	util.HideLoadCmdOutput, _ = yc.GetValBoolDflt("hide_load_output", nil, false)
 }
 
 func readNewtrc() ycfg.YCfg {


### PR DESCRIPTION
Now load command output will be printed on default. To disable this add "hide_load_output: 1" to ~/.newt/newtrc.yml