### PR TITLE
builder: Add conditional flash map overrides in bsp.yml

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -95,6 +95,14 @@ func NewTargetTester(target *target.Target,
 		injectedSettings: cfgv.NewSettings(nil),
 	}
 
+	if err := t.ensureResolved(); err != nil {
+		return nil, err
+	}
+
+	if err := t.bspPkg.Reload(t.res.Cfg.SettingValues()); err != nil {
+		return nil, err
+	}
+
 	return t, nil
 }
 


### PR DESCRIPTION
This allows to conditionally override flash maps in bsp.yml and target.yml with bsp.flash_map.<CONDITION>
Initial priority of bsp.yml and target.yml is preserved - if there is any bsp.flash_map definition in target.yml, all flash maps from bsp.yml are ignored. Default bsp.flash_map definition (without any condition) is still needed.