### PR TITLE
newt: Switch resolution warnings from debug to warn log lvl

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -285,7 +285,7 @@ func (t *TargetBuilder) validateAndWriteCfg() error {
 
 	warningText := strings.TrimSpace(t.res.WarningText())
 	if warningText != "" {
-		log.Debug(warningText)
+		log.Warn(warningText)
 	}
 
 	for _, line := range t.res.DeprecatedWarning() {


### PR DESCRIPTION
Now newt warns about undefined settings on default