### PR TITLE
newt/syscfg: Expand nested MYNEWT_VAL references

### DIFF
--- a/newt/val/valsetting.go
+++ b/newt/val/valsetting.go
@@ -57,8 +57,7 @@ func (vs *ValSetting) IntVal() (int, error) {
 func ResolveValSetting(s string, cfg *syscfg.Cfg) (ValSetting, error) {
 	refName, val, err := cfg.ExpandRef(s)
 	if err != nil {
-		return ValSetting{},
-			util.FmtNewtError("value \"%s\" references undefined setting", s)
+		return ValSetting{}, err
 	}
 
 	return ValSetting{


### PR DESCRIPTION
Now Newt will resolve references of nested MYNEWT_VAL references.

Example:
CONFIG_A: MYNEWT_VAL(CONFIG_B)
CONFIG_B: MYNEWT_VAL(CONFIG_C)
CONFIG_C: 1

Before this change the outcome of this configuration would depend on configs resolution order.
If CONFIG_A would be resolved before CONFIG_B the final outcome would be: 

CONFIG_A: 'MYNEWT_VAL(CONFIG_C)' <- string copied from not yet resolved CONFIG_B
CONFIG_B: 1
CONFIG_C: 1

Now all the configs will get value 1, as expected.