### PR TITLE
newt: Extend link tables symbols

### DIFF
--- a/newt/builder/extcmd.go
+++ b/newt/builder/extcmd.go
@@ -188,6 +188,7 @@ func getLinkTableEntry(name string) string {
 	indent := "        "
 
 	entry := indent + "__" + name + "_start__ = .;\n" +
+		indent + name + " = .;\n" +
 		indent + "KEEP(*(." + name + "))\n" +
 		indent + "KEEP(*(SORT(." + name + ".*)))\n" +
 		indent + "__" + name + "_end__ = .;\n\n"


### PR DESCRIPTION
So far for link time generated tables two symbols
were create for each table:

```yml
pkg.link_tables:
    - foo
```
would generate link_tables.ld.h with following content
```ld
        __foo_start__ = .;
        KEEP(*(.foo))
        KEEP(*(SORT(.foo.*)))
        __foo_end__ = .;
```
Now additional symbol `foo` will be generated it will make it more straightforward to use link-time tables in source code where table can be access directly
by a name specified in yml
```ld
        __foo_start__ = .;
        foo = .;
        KEEP(*(.foo))
        KEEP(*(SORT(.foo.*)))
        __foo_end__ = .;
```