### PR TITLE
builder: Fix false positive flash map errors

### DIFF
--- a/newt/builder/targetbuild.go
+++ b/newt/builder/targetbuild.go
@@ -95,13 +95,15 @@ func NewTargetTester(target *target.Target,
 		injectedSettings: cfgv.NewSettings(nil),
 	}
 
-	if err := t.ensureResolved(); err != nil {
+	if err := t.ensureResolved(false); err != nil {
 		return nil, err
 	}
 
 	if err := t.bspPkg.Reload(t.res.Cfg.SettingValues()); err != nil {
 		return nil, err
 	}
+
+	t.res.Cfg.DetectErrors(bspPkg.FlashMap)
 
 	return t, nil
 }
@@ -174,7 +176,7 @@ func (t *TargetBuilder) resolveTransientPkgs(lps []*pkg.LocalPackage) {
 	}
 }
 
-func (t *TargetBuilder) ensureResolved() error {
+func (t *TargetBuilder) ensureResolved(detectErr bool) error {
 	if t.res != nil {
 		return nil
 	}
@@ -238,7 +240,7 @@ func (t *TargetBuilder) ensureResolved() error {
 
 	var err error
 	t.res, err = resolve.ResolveFull(
-		loaderSeeds, appSeeds, t.injectedSettings, t.bspPkg.FlashMap)
+		loaderSeeds, appSeeds, t.injectedSettings, t.bspPkg.FlashMap, detectErr)
 	if err != nil {
 		return err
 	}
@@ -267,7 +269,7 @@ func (t *TargetBuilder) ensureResolved() error {
 }
 
 func (t *TargetBuilder) Resolve() (*resolve.Resolution, error) {
-	if err := t.ensureResolved(); err != nil {
+	if err := t.ensureResolved(true); err != nil {
 		return nil, err
 	}
 
@@ -275,7 +277,7 @@ func (t *TargetBuilder) Resolve() (*resolve.Resolution, error) {
 }
 
 func (t *TargetBuilder) validateAndWriteCfg() error {
-	if err := t.ensureResolved(); err != nil {
+	if err := t.ensureResolved(true); err != nil {
 		return err
 	}
 
@@ -384,7 +386,7 @@ func (t *TargetBuilder) extraADirs() []string {
 }
 
 func (t *TargetBuilder) PrepBuild() error {
-	if err := t.ensureResolved(); err != nil {
+	if err := t.ensureResolved(true); err != nil {
 		return err
 	}
 
@@ -836,7 +838,7 @@ func (t *TargetBuilder) MaxImgSizes() []int {
 }
 
 func (t *TargetBuilder) CreateDepGraph() (DepGraph, error) {
-	if err := t.ensureResolved(); err != nil {
+	if err := t.ensureResolved(true); err != nil {
 		return nil, err
 	}
 
@@ -844,7 +846,7 @@ func (t *TargetBuilder) CreateDepGraph() (DepGraph, error) {
 }
 
 func (t *TargetBuilder) CreateRevdepGraph() (DepGraph, error) {
-	if err := t.ensureResolved(); err != nil {
+	if err := t.ensureResolved(true); err != nil {
 		return nil, err
 	}
 

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -1168,7 +1168,8 @@ func ResolveFull(
 	loaderSeeds []*pkg.LocalPackage,
 	appSeeds []*pkg.LocalPackage,
 	injectedSettings *cfgv.Settings,
-	flashMap flashmap.FlashMap) (*Resolution, error) {
+	flashMap flashmap.FlashMap,
+	detectErr bool) (*Resolution, error) {
 
 	// First, calculate syscfg and determine which package provides each
 	// required API.  Syscfg and APIs are project-wide; that is, they are
@@ -1239,7 +1240,9 @@ func ResolveFull(
 	if loaderSeeds == nil {
 		res.AppSet.Rpkgs = r.rpkgSlice()
 		res.LoaderSet = nil
-		res.Cfg.DetectErrors(flashMap)
+		if detectErr == true {
+			res.Cfg.DetectErrors(flashMap)
+		}
 		return res, nil
 	}
 
@@ -1290,7 +1293,9 @@ func ResolveFull(
 		return nil, err
 	}
 
-	res.Cfg.DetectErrors(flashMap)
+	if detectErr == true {
+		res.Cfg.DetectErrors(flashMap)
+	}
 
 	return res, nil
 }


### PR DESCRIPTION
To allow conditional overrides of flash map it's necessary to resolve target, because otherwise the syscfgs that determine the choice of a different flash map will not be available. The problem was that every resolving was trying to detect errors in configuration (also in flash map). As the resolving had to be done before bsp package reloading, while detecting errors the default flash map is loaded. If this default flash map did not define some flash areas used in the target configuration, an error was reported even if the flash map that should override the default one was correct.

Now we don't try to detect error while doing this particular resolving. Instead we do this after reloading bsp package so the properly chosen flash map is used in error detection.