### PR TITLE
newt: Add constant syscfg for each package

### DIFF
--- a/.github/newt_dump/answers/bleprph-nrf52840pdk.json
+++ b/.github/newt_dump/answers/bleprph-nrf52840pdk.json
@@ -6038,6 +6038,576 @@
         ],
         "state": "good"
       },
+      "PKG_apps/bleprph": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/apps/bleprph"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_boot/bootutil": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/boot/bootutil"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_boot/split": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/boot/split"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_compiler/arm-none-eabi-m4": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/compiler/arm-none-eabi-m4"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_crypto/mbedtls": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/crypto/mbedtls"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_crypto/tinycrypt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/crypto/tinycrypt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_encoding/base64": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/encoding/base64"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_encoding/cborattr": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/encoding/cborattr"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_encoding/tinycbor": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/encoding/tinycbor"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_fs/fcb": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/fs/fcb"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/bsp/nordic_pca10040": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/bsp/nordic_pca10040"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/cmsis-core": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/cmsis-core"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/nimble/nrf52": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/nimble/nrf52"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart/uart_hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic/nrf52xxx": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_kernel/os": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/kernel/os"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_libc/baselibc": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/libc/baselibc"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_mgmt/imgmgr": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/mgmt/imgmgr"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_mgmt/mgmt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/mgmt/mgmt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_mgmt/newtmgr": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/mgmt/newtmgr"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_mgmt/newtmgr/nmgr_os": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/mgmt/newtmgr/nmgr_os"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_mgmt/newtmgr/transport/ble": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/mgmt/newtmgr/transport/ble"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/controller": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/controller"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/drivers/nrf52": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/drivers/nrf52"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/ans": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/ans"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/gap": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/gap"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/gatt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/gatt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/store/config": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/store/config"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/util": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/util"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/transport": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/transport"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/transport/ram": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/transport/ram"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_porting/npl/mynewt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/porting/npl/mynewt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/config": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/config"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/console/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/console/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/defs": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/defs"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/flash_map": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/flash_map"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/id": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/id"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/common": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/common"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/modlog": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/modlog"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/mfg": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/mfg"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/reboot": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/reboot"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/stats/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/stats/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sys": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sys"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysdown": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysdown"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysinit": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysinit"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_targets/bleprph-nrf52840pdk": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "targets/bleprph-nrf52840pdk"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_time/datetime": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/time/datetime"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/cbmem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/cbmem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/crc": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/crc"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/mem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/mem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/rwlock": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/rwlock"
+          }
+        ],
+        "state": "const"
+      },
       "PWM_0": {
         "type": "raw",
         "history": [

--- a/.github/newt_dump/answers/boot-nrf52dk.json
+++ b/.github/newt_dump/answers/boot-nrf52dk.json
@@ -2078,6 +2078,266 @@
         ],
         "state": "good"
       },
+      "PKG_apps/boot": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/apps/boot"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_boot/bootutil": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/boot/bootutil"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_compiler/arm-none-eabi-m4": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/compiler/arm-none-eabi-m4"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_crypto/mbedtls": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/crypto/mbedtls"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/bsp/nordic_pca10040": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/bsp/nordic_pca10040"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/cmsis-core": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/cmsis-core"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart/uart_hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic/nrf52xxx": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_kernel/os": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/kernel/os"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_libc/baselibc": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/libc/baselibc"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/console/stub": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/console/stub"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/defs": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/defs"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/flash_map": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/flash_map"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/common": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/common"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/modlog": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/modlog"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/stub": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/stub"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/mfg": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/mfg"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sys": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sys"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysdown": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysdown"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysinit": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysinit"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_targets/boot-nrf52dk": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "targets/boot-nrf52dk"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/mem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/mem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/rwlock": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/rwlock"
+          }
+        ],
+        "state": "const"
+      },
       "PWM_0": {
         "type": "raw",
         "history": [

--- a/.github/newt_dump/answers/btshell-nrf52840pdk.json
+++ b/.github/newt_dump/answers/btshell-nrf52840pdk.json
@@ -4322,6 +4322,416 @@
         ],
         "state": "good"
       },
+      "PKG_apps/btshell": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/apps/btshell"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_compiler/arm-none-eabi-m4": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/compiler/arm-none-eabi-m4"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_crypto/tinycrypt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/crypto/tinycrypt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/bsp/nordic_pca10040": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/bsp/nordic_pca10040"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/cmsis-core": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/cmsis-core"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/nimble/nrf52": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/nimble/nrf52"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart/uart_hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic/nrf52xxx": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_kernel/os": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/kernel/os"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_libc/baselibc": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/libc/baselibc"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/controller": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/controller"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/drivers/nrf52": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/drivers/nrf52"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/ans": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/ans"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/gap": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/gap"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/gatt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/gatt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/store/ram": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/store/ram"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/transport": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/transport"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/transport/ram": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/transport/ram"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_porting/npl/mynewt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/porting/npl/mynewt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/console/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/console/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/defs": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/defs"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/flash_map": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/flash_map"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/common": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/common"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/modlog": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/modlog"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/mfg": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/mfg"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/shell": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/shell"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/stats/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/stats/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sys": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sys"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysdown": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysdown"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysinit": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysinit"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_targets/btshell-nrf52840pdk": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "targets/btshell-nrf52840pdk"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_time/datetime": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/time/datetime"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/cbmem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/cbmem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/mem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/mem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/rwlock": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/rwlock"
+          }
+        ],
+        "state": "const"
+      },
       "PWM_0": {
         "type": "raw",
         "history": [

--- a/.github/newt_dump/answers/btshell-nrf52dk.json
+++ b/.github/newt_dump/answers/btshell-nrf52dk.json
@@ -4322,6 +4322,416 @@
         ],
         "state": "good"
       },
+      "PKG_apps/btshell": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/apps/btshell"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_compiler/arm-none-eabi-m4": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/compiler/arm-none-eabi-m4"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_crypto/tinycrypt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/crypto/tinycrypt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/bsp/nordic_pca10040": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/bsp/nordic_pca10040"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/cmsis-core": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/cmsis-core"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/nimble/nrf52": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/nimble/nrf52"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart/uart_hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/nordic/nrf52xxx": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/nordic/nrf52xxx"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_kernel/os": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/kernel/os"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_libc/baselibc": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/libc/baselibc"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/controller": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/controller"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/drivers/nrf52": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/drivers/nrf52"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/ans": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/ans"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/gap": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/gap"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/services/gatt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/services/gatt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/host/store/ram": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/host/store/ram"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/transport": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/transport"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_nimble/transport/ram": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/nimble/transport/ram"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_porting/npl/mynewt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-nimble/porting/npl/mynewt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/console/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/console/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/defs": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/defs"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/flash_map": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/flash_map"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/common": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/common"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/modlog": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/modlog"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/mfg": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/mfg"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/shell": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/shell"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/stats/full": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/stats/full"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sys": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sys"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysdown": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysdown"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysinit": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysinit"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_targets/btshell-nrf52dk": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "targets/btshell-nrf52dk"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_time/datetime": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/time/datetime"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/cbmem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/cbmem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/mem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/mem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/rwlock": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/rwlock"
+          }
+        ],
+        "state": "const"
+      },
       "PWM_0": {
         "type": "raw",
         "history": [

--- a/.github/newt_dump/answers/my_blinky_sim.json
+++ b/.github/newt_dump/answers/my_blinky_sim.json
@@ -1322,6 +1322,256 @@
         ],
         "state": "good"
       },
+      "PKG_apps/blinky": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "apps/blinky"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_compiler/sim": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/compiler/sim"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_crypto/tinycrypt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/crypto/tinycrypt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/bsp/native": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/bsp/native"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/flash/enc_flash": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/flash/enc_flash"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/flash/enc_flash/ef_tinycrypt": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/flash/enc_flash/ef_tinycrypt"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/drivers/uart/uart_hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/drivers/uart/uart_hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/hal": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/hal"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_hw/mcu/native": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/hw/mcu/native"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_kernel/os": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/kernel/os"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_kernel/sim": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/kernel/sim"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_net/ip/mn_socket": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/net/ip/mn_socket"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_net/ip/native_sockets": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/net/ip/native_sockets"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/console/stub": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/console/stub"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/defs": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/defs"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/flash_map": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/flash_map"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/log/modlog": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/log/modlog"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/mfg": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/mfg"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sys": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sys"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysdown": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysdown"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_sys/sysinit": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/sys/sysinit"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_targets/my_blinky_sim": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "targets/my_blinky_sim"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/mem": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/mem"
+          }
+        ],
+        "state": "const"
+      },
+      "PKG_util/rwlock": {
+        "type": "raw",
+        "history": [
+          {
+            "value": "1",
+            "package": "@apache-mynewt-core/util/rwlock"
+          }
+        ],
+        "state": "const"
+      },
       "RWLOCK_DEBUG": {
         "type": "raw",
         "history": [

--- a/newt/resolve/resolve.go
+++ b/newt/resolve/resolve.go
@@ -601,6 +601,7 @@ func (r *Resolver) reloadCfg() (bool, error) {
 
 	cfg.AddInjectedSettings()
 	cfg.ResolveValueRefs()
+	cfg.AddPkgNamesSettings(lpkgs)
 
 	// Determine if any new settings have been added or if any existing
 	// settings have changed.

--- a/newt/syscfg/marshal.go
+++ b/newt/syscfg/marshal.go
@@ -33,6 +33,7 @@ var cfgSettingNameTypeMap = map[string]CfgSettingType{
 
 var cfgSettingNameStateMap = map[string]CfgSettingState{
 	"good":         CFG_SETTING_STATE_GOOD,
+	"const":        CFG_SETTING_STATE_CONST,
 	"deprecated":   CFG_SETTING_STATE_DEPRECATED,
 	"defunct":      CFG_SETTING_STATE_DEFUNCT,
 	"experimental": CFG_SETTING_STATE_EXPERIMENTAL,

--- a/newt/syscfg/syscfg.go
+++ b/newt/syscfg/syscfg.go
@@ -242,6 +242,22 @@ func (cfg *Cfg) AddInjectedSettings() {
 	}
 }
 
+func (cfg *Cfg) AddPkgNamesSettings(pkgs []*pkg.LocalPackage) {
+	for _, pkg := range pkgs {
+		entry := CfgEntry{
+			Name:       "PKG_" + pkg.Name(),
+			PackageDef: pkg,
+			State:      CFG_SETTING_STATE_CONST,
+			Value:      "1",
+			History: []CfgPoint{{
+				Value:  "1",
+				Source: pkg,
+			}},
+		}
+		cfg.Settings[entry.Name] = entry
+	}
+}
+
 func (cfg *Cfg) ResolveValueRefs() {
 	for k, entry := range cfg.Settings {
 		refName, val, err := cfg.ExpandRef(strings.TrimSpace(entry.Value))


### PR DESCRIPTION
Now every package included in build will add
syscfg PKG_<pkg.name> and set it to 1.
This config can be used to conditionally include
other configs or packages if some package is included.