### PR TITLE
newt/downoader: Update commits map after a fetch

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -834,6 +834,13 @@ func (gd *GithubDownloader) Fetch(repoDir string) error {
 			cmd = append(cmd, "--depth", strconv.Itoa(util.ShallowCloneDepth))
 		}
 		_, err := gd.authenticatedCommand(repoDir, cmd)
+
+		cmap, err := getCommits(repoDir)
+		if err != nil {
+			return err
+		}
+		gd.commits = cmap
+
 		return err
 	})
 }


### PR DESCRIPTION
Fixes a bug where the first upgrade attempt would sometimes fail due to a outdated commit map (saved before fetch was performed).