### PR TITLE
newt/downloader: Invalidate commit cache after git fetch

### DIFF
--- a/newt/downloader/downloader.go
+++ b/newt/downloader/downloader.go
@@ -697,6 +697,11 @@ func (gd *GenericDownloader) CommitSha(path string, commit string) (string, erro
 	return strings.TrimSpace(string(o)), nil
 }
 
+func (gd *GenericDownloader) invalidateCache() {
+	gd.commits = nil
+	gd.head = ""
+}
+
 // Fetches the downloader's origin remote if it hasn't been fetched yet during
 // this run.
 func (gd *GenericDownloader) cachedFetch(fn func() error) error {
@@ -709,6 +714,7 @@ func (gd *GenericDownloader) cachedFetch(fn func() error) error {
 	}
 
 	gd.fetched = true
+	gd.invalidateCache()
 	return nil
 }
 


### PR DESCRIPTION
newt upgrade fetched new refs but kept using map from before the fetch. Upgrades could be skipped or checkout the wrong commit. Invalidate the downloader cache after fetch so the next lookup rebuilds it from updated repo.